### PR TITLE
feat(graindoc)!: Replace module attribute with docblock on module header

### DIFF
--- a/compiler/graindoc/docblock.re
+++ b/compiler/graindoc/docblock.re
@@ -98,12 +98,6 @@ let location_for_ident = (~exports, ident) => {
   snd(Ident.find_name(Ident.name(ident), exports));
 };
 
-let module_name_of_location = (loc: Grain_parsing.Location.t) => {
-  Grain_utils.Filepath.String.filename_to_module_name(
-    loc.loc_start.pos_fname,
-  );
-};
-
 let title_for_api = (~module_name, ident: Ident.t) => {
   Format.asprintf("%s.**%a**", module_name, Printtyp.ident, ident);
 };
@@ -151,8 +145,8 @@ let lookup_type_expr = (~idx, type_exprs) => {
 let for_value_description =
     (
       ~comments,
-      ~loc,
-      ~module_name=module_name_of_location(loc),
+      ~loc: Grain_parsing.Location.t,
+      ~module_name,
       ~ident: Ident.t,
       vd: Types.value_description,
     ) => {
@@ -191,8 +185,8 @@ let for_value_description =
 let for_type_declaration =
     (
       ~comments,
-      ~loc,
-      ~module_name=module_name_of_location(loc),
+      ~loc: Grain_parsing.Location.t,
+      ~module_name,
       ~ident: Ident.t,
       td: Types.type_declaration,
     ) => {
@@ -214,19 +208,19 @@ let for_signature_item =
     (
       ~comments,
       ~exports: Ident.tbl(Grain_parsing.Location.t),
-      ~module_name=?,
+      ~module_name,
       sig_item: Types.signature_item,
     ) => {
   switch (sig_item) {
   | TSigValue(ident, vd) =>
     let loc = location_for_ident(~exports, ident);
     let docblock =
-      for_value_description(~comments, ~module_name?, ~ident, ~loc, vd);
+      for_value_description(~comments, ~module_name, ~ident, ~loc, vd);
     Some(docblock);
   | TSigType(ident, td, _rec) =>
     let loc = location_for_ident(~exports, ident);
     let docblock =
-      for_type_declaration(~comments, ~module_name?, ~ident, ~loc, td);
+      for_type_declaration(~comments, ~module_name, ~ident, ~loc, td);
     Some(docblock);
   | _ => None
   };

--- a/compiler/graindoc/docblock.re
+++ b/compiler/graindoc/docblock.re
@@ -81,7 +81,10 @@ let enumerate_exports = stmts => {
             },
             vbinds,
           )
-        | _ => ()
+        | TTopModule(_)
+        | TTopInclude(_)
+        | TTopException(_)
+        | TTopExpr(_) => ()
         };
       };
     });

--- a/compiler/src/typed/typedtree.re
+++ b/compiler/src/typed/typedtree.re
@@ -587,6 +587,7 @@ type comment =
 
 [@deriving sexp]
 type typed_program = {
+  module_name: loc(string),
   statements: list(toplevel_stmt),
   env: [@sexp.opaque] Env.t,
   signature: Cmi_format.cmi_infos,

--- a/compiler/src/typed/typedtree.rei
+++ b/compiler/src/typed/typedtree.rei
@@ -548,6 +548,7 @@ type comment =
 
 [@deriving sexp]
 type typed_program = {
+  module_name: loc(string),
   statements: list(toplevel_stmt),
   env: Env.t,
   signature: Cmi_format.cmi_infos,

--- a/compiler/src/typed/typemod.re
+++ b/compiler/src/typed/typemod.re
@@ -947,7 +947,13 @@ let type_implementation = prog => {
   check_nongen_schemes(finalenv, simple_sg);
   let normalized_sig = normalize_signature(finalenv, simple_sg);
   let signature = Env.build_signature(normalized_sig, module_name, filename);
-  {statements, env: finalenv, signature, comments: prog.comments};
+  {
+    module_name: prog.module_name,
+    statements,
+    env: finalenv,
+    signature,
+    comments: prog.comments,
+  };
 };
 
 /* Error report */

--- a/compiler/src/utils/filepath.re
+++ b/compiler/src/utils/filepath.re
@@ -63,28 +63,6 @@ module String = {
     Printf.sprintf("%s.%s", remove_extension(baseName), newExt);
   };
 
-  // TODO(#216): Turn this into a function that only operates on Fp
-  let filename_to_module_name = fname => {
-    let baseName =
-      Option.bind(from_string(fname), p =>
-        switch (p) {
-        | Absolute(path) => Fp.baseName(path)
-        | Relative(path) => Fp.baseName(path)
-        }
-      );
-    let name =
-      switch (baseName) {
-      | Some(baseName) => remove_extension(baseName)
-      | None =>
-        raise(
-          Invalid_argument(
-            Printf.sprintf("Invalid filepath (fname: '%s')", fname),
-          ),
-        )
-      };
-    String.capitalize_ascii(name);
-  };
-
   let normalize_separators = path =>
     if (Sys.unix) {
       path;

--- a/compiler/test/stdlib/bigint.test.gr
+++ b/compiler/test/stdlib/bigint.test.gr
@@ -3,7 +3,7 @@ module BigintTest
 include "list"
 include "runtime/wasi"
 include "bigint"
-from Bigint use *
+from BigInt use *
 
 assert toString(15t) == "15"
 assert toString(-15t) == "-15"

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -1,5 +1,5 @@
 /**
- * @module Array: Utilities for working with arrays.
+ * Utilities for working with arrays.
  *
  * @example include "array"
  *

--- a/stdlib/bigint.gr
+++ b/stdlib/bigint.gr
@@ -6,7 +6,7 @@
  * @since v0.5.0
  */
 
-module Bigint
+module BigInt
 
 include "runtime/unsafe/wasmi32"
 include "runtime/unsafe/memory"

--- a/stdlib/bigint.gr
+++ b/stdlib/bigint.gr
@@ -1,5 +1,6 @@
 /**
- * @module BigInt: Utilities for working with the BigInt type.
+ * Utilities for working with the BigInt type.
+ *
  * @example include "bigint"
  *
  * @since v0.5.0

--- a/stdlib/buffer.gr
+++ b/stdlib/buffer.gr
@@ -1,5 +1,5 @@
 /**
- * @module Buffer: Utilities for working with buffers.
+ * Utilities for working with buffers.
  *
  * Buffers are data structures that automatically expand as more data is appended. They are useful for storing and operating on an unknown number of bytes. All set or append operations mutate the buffer.
  * @example include "buffer"

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -1,5 +1,5 @@
 /**
- * @module Bytes: Utilities for working with byte sequences.
+ * Utilities for working with byte sequences.
  *
  * @example include "bytes"
  *

--- a/stdlib/char.gr
+++ b/stdlib/char.gr
@@ -1,5 +1,5 @@
 /**
- * @module Char: Utilities for working with the Char type.
+ * Utilities for working with the Char type.
  *
  * The Char type represents a single [Unicode scalar value](https://www.unicode.org/glossary/#unicode_scalar_value).
  *

--- a/stdlib/exception.gr
+++ b/stdlib/exception.gr
@@ -1,5 +1,5 @@
 /**
- * @module Exception: Utilities for working with the Exception type.
+ * Utilities for working with the Exception type.
  *
  * The Exception type represents an error that has occured during computation.
  *

--- a/stdlib/float32.gr
+++ b/stdlib/float32.gr
@@ -1,7 +1,8 @@
 /**
- * @module Float32: Utilities for working with the Float32 type.
+ * Utilities for working with the Float32 type.
+ *
  * @example include "float32"
- * 
+ *
  * @since v0.2.0
  */
 
@@ -24,7 +25,7 @@ from Numbers use {
 
 /**
  * Infinity represented as a Float32 value.
- * 
+ *
  * @since v0.4.0
  */
 @unsafe
@@ -37,7 +38,7 @@ provide let infinity = {
 
 /**
  * NaN (Not a Number) represented as a Float32 value.
- * 
+ *
  * @since v0.4.0
  */
 @unsafe
@@ -50,21 +51,21 @@ provide let nan = {
 
 /**
  * Pi represented as a Float32 value.
- * 
+ *
  * @since v0.5.2
  */
 provide let pi = 3.1415927f
 
 /**
  * Tau represented as a Float32 value.
- * 
+ *
  * @since v0.5.2
  */
 provide let tau = 6.2831853f
 
 /**
  * Euler's number represented as a Float32 value.
- * 
+ *
  * @since v0.5.2
  */
 provide let e = 2.7182817f
@@ -77,7 +78,7 @@ provide let e = 2.7182817f
  *
  * @param number: The value to convert
  * @returns The Number represented as a Float32
- * 
+ *
  * @since v0.2.0
  */
 provide { fromNumber }
@@ -87,7 +88,7 @@ provide { fromNumber }
  *
  * @param float: The value to convert
  * @returns The Float32 represented as a Number
- * 
+ *
  * @since v0.2.0
  */
 provide { toNumber }
@@ -102,7 +103,7 @@ provide { toNumber }
  * @param x: The first operand
  * @param y: The second operand
  * @returns The sum of the two operands
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -119,7 +120,7 @@ provide let add = (x: Float32, y: Float32) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The difference of the two operands
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -136,7 +137,7 @@ provide let sub = (x: Float32, y: Float32) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The product of the two operands
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -153,7 +154,7 @@ provide let mul = (x: Float32, y: Float32) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The quotient of the two operands
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -174,7 +175,7 @@ provide let div = (x: Float32, y: Float32) => {
  * @param x: The first value
  * @param y: The second value
  * @returns `true` if the first value is less than the second value or `false` otherwise
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -190,7 +191,7 @@ provide let lt = (x: Float32, y: Float32) => {
  * @param x: The first value
  * @param y: The second value
  * @returns `true` if the first value is greater than the second value or `false` otherwise
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -206,7 +207,7 @@ provide let gt = (x: Float32, y: Float32) => {
  * @param x: The first value
  * @param y: The second value
  * @returns `true` if the first value is less than or equal to the second value or `false` otherwise
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -222,7 +223,7 @@ provide let lte = (x: Float32, y: Float32) => {
  * @param x: The first value
  * @param y: The second value
  * @returns `true` if the first value is greater than or equal to the second value or `false` otherwise
- * 
+ *
  * @since v0.2.0
  */
 @unsafe

--- a/stdlib/float64.gr
+++ b/stdlib/float64.gr
@@ -1,7 +1,8 @@
 /**
- * @module Float64: Utilities for working with the Float64 type.
+ * Utilities for working with the Float64 type.
+ *
  * @example include "float64"
- * 
+ *
  * @since v0.2.0
  */
 
@@ -24,7 +25,7 @@ from Numbers use {
 
 /**
  * Infinity represented as a Float64 value.
- * 
+ *
  * @since v0.4.0
  */
 @unsafe
@@ -39,7 +40,7 @@ provide let infinity = {
 
 /**
  * NaN (Not a Number) represented as a Float64 value.
- * 
+ *
  * @since v0.4.0
  */
 @unsafe
@@ -54,21 +55,21 @@ provide let nan = {
 
 /**
  * Pi represented as a Float64 value.
- * 
+ *
  * @since v0.5.2
  */
 provide let pi = 3.141592653589793d
 
 /**
  * Tau represented as a Float64 value.
- * 
+ *
  * @since v0.5.2
  */
 provide let tau = 6.283185307179586d
 
 /**
  * Euler's number represented as a Float64 value.
- * 
+ *
  * @since v0.5.2
  */
 provide let e = 2.718281828459045d
@@ -82,7 +83,7 @@ provide let e = 2.718281828459045d
  *
  * @param number: The value to convert
  * @returns The Number represented as a Float64
- * 
+ *
  * @since v0.2.0
  */
 provide { fromNumber }
@@ -92,7 +93,7 @@ provide { fromNumber }
  *
  * @param float: The value to convert
  * @returns The Float64 represented as a Number
- * 
+ *
  * @since v0.2.0
  */
 provide { toNumber }
@@ -107,7 +108,7 @@ provide { toNumber }
  * @param x: The first operand
  * @param y: The second operand
  * @returns The sum of the two operands
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -124,7 +125,7 @@ provide let add = (x: Float64, y: Float64) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The difference of the two operands
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -141,7 +142,7 @@ provide let sub = (x: Float64, y: Float64) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The product of the two operands
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -158,7 +159,7 @@ provide let mul = (x: Float64, y: Float64) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The quotient of the two operands
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -179,7 +180,7 @@ provide let div = (x: Float64, y: Float64) => {
  * @param x: The first value
  * @param y: The second value
  * @returns `true` if the first value is less than the second value or `false` otherwise
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -195,7 +196,7 @@ provide let lt = (x: Float64, y: Float64) => {
  * @param x: The first value
  * @param y: The second value
  * @returns `true` if the first value is greater than the second value or `false` otherwise
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -211,7 +212,7 @@ provide let gt = (x: Float64, y: Float64) => {
  * @param x: The first value
  * @param y: The second value
  * @returns `true` if the first value is less than or equal to the second value or `false` otherwise
- * 
+ *
  * @since v0.2.0
  */
 @unsafe
@@ -227,7 +228,7 @@ provide let lte = (x: Float64, y: Float64) => {
  * @param x: The first value
  * @param y: The second value
  * @returns `true` if the first value is greater than or equal to the second value or `false` otherwise
- * 
+ *
  * @since v0.2.0
  */
 @unsafe

--- a/stdlib/hash.gr
+++ b/stdlib/hash.gr
@@ -1,5 +1,6 @@
 /**
- * @module Hash: Utilities for hashing any value.
+ * Utilities for hashing any value.
+ *
  * @example include "hash"
  *
  * @since v0.1.0

--- a/stdlib/immutablearray.gr
+++ b/stdlib/immutablearray.gr
@@ -1,5 +1,5 @@
 /**
- * @module ImmutableArray: An immutable array implementation, providing fast arbitrary lookups and modifications.
+ * An immutable array implementation, providing fast arbitrary lookups and modifications.
  *
  * @example include "immutablearray"
  *
@@ -92,7 +92,7 @@ record ImmutableArray<a> {
 
 /**
  * An empty array.
- * 
+ *
  * @since v0.6.0
  */
 provide let empty = {
@@ -102,7 +102,7 @@ provide let empty = {
 
 /**
  * Determines if the array contains no elements.
- * 
+ *
  * @param array: The array to check
  * @returns `true` if the array is empty and `false` otherwise
  *
@@ -171,7 +171,7 @@ let log32floor = num => {
  * @param array: The array to access
  * @returns The element from the array
  * @throws IndexOutOfBounds: When the index being accessed is outside the array's bounds
- * 
+ *
  * @example get(1, fromList([1, 2, 3, 4])) == 2
  * @example get(-1, fromList([1, 2, 3, 4])) == 4
  *
@@ -207,7 +207,7 @@ provide let get = (index, array) => {
  * @param array: The array to update
  * @returns A new array containing the new element at the given index
  * @throws IndexOutOfBounds: When the index being updated is outside the array's bounds
- * 
+ *
  * @example set(1, 9, fromList([1, 2, 3, 4, 5])) == fromList([1, 9, 3, 4, 5])
  *
  * @since v0.6.0
@@ -413,7 +413,7 @@ provide let append = (array1, array2) => {
  *
  * @param arrays: A list containing all arrays to combine
  * @returns The new array
- * 
+ *
  * @example concat([fromList([1, 2]), fromList([3, 4]), fromList([5, 6])]) == fromList([1, 2, 3, 4, 5, 6])
  *
  * @since v0.6.0
@@ -593,7 +593,7 @@ provide let reduceRight = (fn, initial, array) => {
  * @param fn: The function to be called on each element, where the value returned will be an array that gets appended to the new array
  * @param array: The array to iterate
  * @returns The new array
- * 
+ *
  * @example flatMap(n => fromList([n, n + 1]), fromList([1, 3, 5])) == fromList([1, 2, 3, 4, 5, 6])
  *
  * @since v0.6.0
@@ -793,7 +793,7 @@ provide let unique = array => {
  *
  * Calling this function with arrays of different sizes will cause the returned
  * array to have the length of the smaller array.
- * 
+ *
  * @param array1: The array to provide values for the first tuple element
  * @param array2: The array to provide values for the second tuple element
  * @returns The new array containing indexed pairs of `(a, b)`
@@ -810,7 +810,7 @@ provide let zip = (array1, array2) => {
  * applying the function to the first elements of each array, the second element
  * will contain the result of applying the function to the second elements of
  * each array, and so on.
- * 
+ *
  * Calling this function with arrays of different sizes will cause the returned
  * array to have the length of the smaller array.
  *
@@ -821,7 +821,7 @@ provide let zip = (array1, array2) => {
  *
  * @example zipWith((a, b) => a + b, fromList([1, 2, 3]), fromList([4, 5, 6])) == fromList([5, 7, 9])
  * @example zipWith((a, b) => a * b, fromList([1, 2, 3]), fromList([4, 5])) == fromList([4, 10])
- * 
+ *
  * @since v0.6.0
  */
 provide let zipWith = (fn, array1, array2) => {
@@ -876,7 +876,7 @@ let clampIndex = (len, index) => {
  * @param end: The index of the array where the slice will end (exclusive)
  * @param array: The array to be sliced
  * @returns The subset of the array that was sliced
- * 
+ *
  * @example slice(0, 2, fromList(['a', 'b', 'c'])) == fromList(['a', 'b'])
  * @example slice(1, -1, fromList(['a', 'b', 'c'])) == fromList(['b'])
  *

--- a/stdlib/immutablemap.gr
+++ b/stdlib/immutablemap.gr
@@ -1,5 +1,6 @@
 /**
- * @module ImmutableMap: An ImmutableMap holds key-value pairs. Any value may be used as a key or value. Operations on an ImmutableMap do not mutate the map's internal state.
+ * An ImmutableMap holds key-value pairs. Any value may be used as a key or value. Operations on an ImmutableMap do not mutate the map's internal state.
+ *
  * @example include "immutablemap"
  *
  * @since v0.5.4

--- a/stdlib/immutablepriorityqueue.gr
+++ b/stdlib/immutablepriorityqueue.gr
@@ -1,5 +1,5 @@
 /**
- * @module ImmutablePriorityQueue: An immutable priority queue. A priority queue is a data structure that maintains elements in a priority order. Elements with higher priority are served before elements with lower priority when extracting from the priority queue.
+ * An immutable priority queue. A priority queue is a data structure that maintains elements in a priority order. Elements with higher priority are served before elements with lower priority when extracting from the priority queue.
  *
  * @example include "immutablepriorityqueue"
  *

--- a/stdlib/immutableset.gr
+++ b/stdlib/immutableset.gr
@@ -1,7 +1,8 @@
 /**
- * @module ImmutableSet: An ImmutableSet is a collection of unique values. Operations on an ImmutableSet do not mutate the set's internal state.
+ * An ImmutableSet is a collection of unique values. Operations on an ImmutableSet do not mutate the set's internal state.
+ *
  * @example include "immutableset"
- * 
+ *
  * @since v0.5.4
  */
 
@@ -38,7 +39,7 @@ let weight = 4
 
 /**
  * An empty set
- * 
+ *
  * @since v0.5.4
  */
 provide let empty = Empty
@@ -57,7 +58,7 @@ let rec min = node => {
  *
  * @param set: The set to inspect
  * @returns The count of elements in the set
- * 
+ *
  * @since v0.5.4
  */
 provide let size = set => {
@@ -72,7 +73,7 @@ provide let size = set => {
  *
  * @param set: The set to inspect
  * @returns `true` if the given set is empty or `false` otherwise
- * 
+ *
  * @since v0.5.4
  */
 provide let isEmpty = set => {
@@ -155,7 +156,7 @@ let balancedNode = (key, left, right) => {
  * @param key: The value to add
  * @param set: The base set
  * @returns A new set containing the new element
- * 
+ *
  * @since v0.5.4
  */
 provide let rec add = (key, set) => {
@@ -177,7 +178,7 @@ provide let rec add = (key, set) => {
  * @param key: The value to search for
  * @param set: The set to search
  * @returns `true` if the set contains the given value or `false` otherwise
- * 
+ *
  * @since v0.5.4
  */
 provide let rec contains = (key, set) => {
@@ -220,7 +221,7 @@ let removeInner = (left, right) => {
  * @param key: The value to exclude
  * @param set: The set to exclude from
  * @returns A new set without the excluded element
- * 
+ *
  * @since v0.5.4
  */
 provide let rec remove = (key, set) => {
@@ -241,7 +242,7 @@ provide let rec remove = (key, set) => {
  *
  * @param fn: The iterator function to call with each element
  * @param set: The set to iterate
- * 
+ *
  * @since v0.5.4
  */
 provide let forEach = (fn, set) => {
@@ -265,7 +266,7 @@ provide let forEach = (fn, set) => {
  * @param init: The initial value to use for the accumulator on the first iteration
  * @param set: The set to iterate
  * @returns The final accumulator returned from `fn`
- * 
+ *
  * @since v0.5.4
  */
 provide let reduce = (fn, init, set) => {
@@ -344,7 +345,7 @@ let concat = (node1, node2) => {
  * @param fn: The predicate function to indicate which elements to exclude from the set, where returning `false` indicates the value should be excluded
  * @param set: The set to iterate
  * @returns A new set excluding the elements not fulfilling the predicate
- * 
+ *
  * @since v0.5.4
  */
 provide let filter = (fn, set) => {
@@ -369,7 +370,7 @@ provide let filter = (fn, set) => {
  * @param fn: The predicate function to indicate which elements to exclude from the set, where returning `true` indicates the value should be excluded
  * @param set: The set to iterate
  * @returns A new set excluding the elements fulfilling the predicate
- * 
+ *
  * @since v0.5.4
  */
 provide let reject = (fn, set) => {
@@ -382,7 +383,7 @@ provide let reject = (fn, set) => {
  * @param set1: The first set to combine
  * @param set2: The second set to combine
  * @returns A set containing all elements of both sets
- * 
+ *
  * @since v0.5.4
  */
 provide let rec union = (set1, set2) => {
@@ -402,7 +403,7 @@ provide let rec union = (set1, set2) => {
  * @param set1: The first set to combine
  * @param set2: The second set to combine
  * @returns A set containing only unshared elements from both sets
- * 
+ *
  * @since v0.5.4
  */
 provide let diff = (set1, set2) => {
@@ -425,7 +426,7 @@ provide let diff = (set1, set2) => {
  * @param set1: The first set to combine
  * @param set2: The second set to combine
  * @returns A set containing only shared elements from both sets
- * 
+ *
  * @since v0.5.4
  */
 provide let rec intersect = (set1, set2) => {
@@ -448,7 +449,7 @@ provide let rec intersect = (set1, set2) => {
  *
  * @param list: The list to convert
  * @returns A set containing all list values
- * 
+ *
  * @since v0.5.4
  */
 provide let fromList = list => {
@@ -460,7 +461,7 @@ provide let fromList = list => {
  *
  * @param set: The set to convert
  * @returns A list containing all set values
- * 
+ *
  * @since v0.5.4
  */
 provide let toList = set => {
@@ -480,7 +481,7 @@ provide let toList = set => {
  *
  * @param array: The array to convert
  * @returns A set containing all array values
- * 
+ *
  * @since v0.5.4
  */
 provide let fromArray = array => {
@@ -492,7 +493,7 @@ provide let fromArray = array => {
  *
  * @param set: The set to convert
  * @returns An array containing all set values
- * 
+ *
  * @since v0.5.4
  */
 provide let toArray = set => {

--- a/stdlib/int32.gr
+++ b/stdlib/int32.gr
@@ -1,5 +1,6 @@
 /**
- * @module Int32: Utilities for working with the Int32 type.
+ * Utilities for working with the Int32 type.
+ *
  * @example include "int32"
  *
  * @since v0.2.0

--- a/stdlib/int64.gr
+++ b/stdlib/int64.gr
@@ -1,5 +1,6 @@
 /**
- * @module Int64: Utilities for working with the Int64 type.
+ * Utilities for working with the Int64 type.
+ *
  * @example include "int64"
  *
  * @since v0.2.0

--- a/stdlib/list.gr
+++ b/stdlib/list.gr
@@ -1,5 +1,5 @@
 /**
- * @module List: Utilities for working with lists.
+ * Utilities for working with lists.
  *
  * @example include "list"
  *

--- a/stdlib/map.gr
+++ b/stdlib/map.gr
@@ -1,5 +1,6 @@
 /**
- * @module Map: A Map holds key-value pairs. Any value may be used as a key or value. Operations on a Map mutate the internal state, so it never needs to be re-assigned.
+ * A Map holds key-value pairs. Any value may be used as a key or value. Operations on a Map mutate the internal state, so it never needs to be re-assigned.
+ *
  * @example include "map"
  *
  * @since v0.2.0

--- a/stdlib/marshal.gr
+++ b/stdlib/marshal.gr
@@ -1,5 +1,5 @@
 /**
- * @module Marshal: Utilities for serializing and deserializing Grain data.
+ * Utilities for serializing and deserializing Grain data.
  *
  * @example include "marshal"
  *

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -1,6 +1,8 @@
 /**
- * @module Number: Utilities for working with numbers.
+ * Utilities for working with numbers.
+ *
  * @example include "number"
+ *
  * @since v0.4.0
  */
 

--- a/stdlib/option.gr
+++ b/stdlib/option.gr
@@ -1,5 +1,5 @@
 /**
- * @module Option: Utilities for working with the Option data type.
+ * Utilities for working with the Option data type.
  *
  * The Option type is an enum that represents the possibility of something being present (with the `Some` variant), or not (with the `None` variant). There’s no standalone `null` or `nil` type in Grain; use an Option where you would normally reach for `null` or `nil`.
  *

--- a/stdlib/path.gr
+++ b/stdlib/path.gr
@@ -1,23 +1,23 @@
 /**
- * @module Path: Utilities for working with system paths.
- * 
+ * Utilities for working with system paths.
+ *
  * This module treats paths purely as a data representation and does not
  * provide functionality for interacting with the file system.
- * 
+ *
  * This module explicitly encodes whether a path is absolute or relative, and
  * whether it refers to a file or a directory, as part of the `Path` type.
  *
  * Paths in this module abide by a special POSIX-like representation/grammar
  * rather than one defined by a specific operating system. The rules are as
  * follows:
- * 
+ *
  * - Path separators are denoted by `/` for POSIX-like paths
  * - Absolute paths may be rooted either at the POSIX-like root `/` or at Windows-like drive roots like `C:/`
  * - Paths referencing files must not include trailing forward slashes, but paths referencing directories may
  * - The path segment `.` indicates the relative "current" directory of a path, and `..` indicates the parent directory of a path
- * 
+ *
  * @example include "path"
- * 
+ *
  * @since v0.5.5
  */
 
@@ -377,14 +377,14 @@ let fromStringHelper = (pathStr, platform) => {
 /**
  * Parses a path string into a `Path`. Paths will be parsed as file paths
  * rather than directory paths if there is ambiguity.
- * 
+ *
  * @param pathStr: The string to parse as a path
  * @returns The path wrapped with details encoded within the type
- * 
+ *
  * @example fromString("/bin/") // an absolute Path referencing the directory /bin/
  * @example fromString("file.txt") // a relative Path referencing the file ./file.txt
  * @example fromString(".") // a relative Path referencing the current directory
- * 
+ *
  * @since v0.5.5
  */
 provide let fromString = pathStr => {
@@ -396,14 +396,14 @@ provide let fromString = pathStr => {
  * the given platform (`/` for `Posix` and either `/` or `\` for `Windows`).
  * Paths will be parsed as file paths rather than directory paths if there is
  * ambiguity.
- * 
+ *
  * @param pathStr: The string to parse as a path
  * @param platform: The platform whose path separators should be used for parsing
  * @returns The path wrapped with details encoded within the type
- * 
+ *
  * @example fromPlatformString("/bin/", Posix) // an absolute Path referencing the directory /bin/
  * @example fromPlatformString("C:\\file.txt", Windows) // a relative Path referencing the file C:\file.txt
- * 
+ *
  * @since v0.5.5
  */
 provide let fromPlatformString = (pathStr, platform) => {
@@ -440,13 +440,13 @@ let toStringHelper = (path, platform) => {
 /**
  * Converts the given `Path` into a string, using the `/` path separator.
  * A trailing slash is added to directory paths.
- * 
+ *
  * @param path: The path to convert to a string
  * @returns A string representing the given path
- * 
+ *
  * @example toString(fromString("/file.txt")) == "/file.txt"
  * @example toString(fromString("dir/")) == "./dir/"
- * 
+ *
  * @since v0.5.5
  */
 provide let toString = path => {
@@ -457,14 +457,14 @@ provide let toString = path => {
  * Converts the given `Path` into a string, using the canonical path separator
  * appropriate to the given platform (`/` for `Posix` and `\` for `Windows`).
  * A trailing slash is added to directory paths.
- * 
+ *
  * @param path: The path to convert to a string
  * @param platform: The `Platform` to use to represent the path as a string
  * @returns A string representing the given path
- * 
+ *
  * @example toPlatformString(fromString("dir/"), Posix) == "./dir/"
  * @example toPlatformString(fromString("C:/file.txt"), Windows) == "C:\\file.txt"
- * 
+ *
  * @since v0.5.5
  */
 provide let toPlatformString = (path, platform) => {
@@ -473,13 +473,13 @@ provide let toPlatformString = (path, platform) => {
 
 /**
  * Determines whether the path is a directory path.
- * 
+ *
  * @param path: The path to inspect
  * @returns `true` if the path is a directory path or `false` otherwise
- * 
+ *
  * @example isDirectory(fromString("file.txt")) == false
  * @example isDirectory(fromString("/bin/")) == true
- * 
+ *
  * @since v0.5.5
  */
 provide let isDirectory = path => {
@@ -489,10 +489,10 @@ provide let isDirectory = path => {
 
 /**
  * Determines whether the path is an absolute path.
- * 
+ *
  * @param path: The path to inspect
  * @returns `true` if the path is absolute or `false` otherwise
- * 
+ *
  * @example isAbsolute(fromString("/Users/me")) == true
  * @example isAbsolute(fromString("./file.txt")) == false
  */
@@ -521,15 +521,15 @@ let rec appendHelper = (path: PathInfo, toAppend: PathInfo) =>
 
 /**
  * Creates a new path by appending a relative path segment to a directory path.
- * 
+ *
  * @param path: The base path
  * @param toAppend: The relative path to append
  * @returns `Ok(path)` combining the base and appended paths or `Err(err)` if the paths are incompatible
- * 
+ *
  * @example append(fromString("./dir/"), fromString("file.txt")) == Ok(fromString("./dir/file.txt"))
  * @example append(fromString("a.txt"), fromString("b.sh")) == Err(AppendToFile) // cannot append to file path
  * @example append(fromString("./dir/"), fromString("/dir2")) == Err(AppendAbsolute) // cannot append an absolute path
- * 
+ *
  * @since v0.5.5
  */
 provide let append = (path: Path, toAppend: Path) => {
@@ -579,24 +579,24 @@ let relativeToHelper = (source: PathInfo, dest: PathInfo) => {
 /**
  * Attempts to construct a new relative path which will lead to the destination
  * path from the source path.
- * 
+ *
  * If the source and destination are incompatible in their bases, the result
  * will be `Err(IncompatibilityError)`.
  *
  * If the route to the destination cannot be concretely determined from the
  * source, the result will be `Err(ImpossibleRelativization)`.
- * 
+ *
  * @param source: The source path
  * @param dest: The destination path to resolve
  * @returns `Ok(path)` containing the relative path if successfully resolved or `Err(err)` otherwise
- * 
+ *
  * @example relativeTo(fromString("/usr"), fromString("/usr/bin")) == Ok(fromString("./bin"))
  * @example relativeTo(fromString("/home/me"), fromString("/home/me")) == Ok(fromString("."))
  * @example relativeTo(fromString("/file.txt"), fromString("/etc/")) == Ok(fromString("../etc/"))
  * @example relativeTo(fromString(".."), fromString("../../thing")) Ok(fromString("../thing"))
  * @example relativeTo(fromString("/usr/bin"), fromString("C:/Users")) == Err(Incompatible(DifferentRoots))
  * @example relativeTo(fromString("../here"), fromString("./there")) == Err(ImpossibleRelativization)
- * 
+ *
  * @since v0.5.5
  */
 provide let relativeTo = (source, dest) => {
@@ -631,16 +631,16 @@ let ancestryHelper = (base: PathInfo, path: PathInfo) => {
 
 /**
  * Determines the relative ancestry betwen two paths.
- * 
+ *
  * @param base: The first path to consider
  * @param path: The second path to consider
  * @returns `Ok(ancestryStatus)` with the relative ancestry between the paths if they are compatible or `Err(err)` if they are incompatible
- * 
+ *
  * @example ancestry(fromString("/usr"), fromString("/usr/bin/bash")) == Ok(Ancestor)
  * @example ancestry(fromString("/Users/me"), fromString("/Users")) == Ok(Descendant)
  * @example ancestry(fromString("/usr"), fromString("/etc")) == Ok(Neither)
  * @example ancestry(fromString("C:/dir1"), fromString("/dir2")) == Err(DifferentRoots)
- * 
+ *
  * @since v0.5.5
  */
 provide let ancestry = (path1: Path, path2: Path) => {
@@ -663,13 +663,13 @@ let parentHelper = (path: PathInfo) =>
 
 /**
  * Retrieves the path corresponding to the parent directory of the given path.
- * 
+ *
  * @param path: The path to inspect
  * @returns A path corresponding to the parent directory of the given path
- * 
+ *
  * @example parent(fromString("./dir/inner")) == fromString("./dir/")
  * @example parent(fromString("/")) == fromString("/")
- * 
+ *
  * @since v0.5.5
  */
 provide let parent = (path: Path) => {
@@ -684,13 +684,13 @@ let basenameHelper = (path: PathInfo) =>
 
 /**
  * Retrieves the basename (named final segment) of a path.
- * 
+ *
  * @param path: The path to inspect
  * @returns `Some(path)` containing the basename of the path or `None` if the path does not have one
- * 
+ *
  * @example basename(fromString("./dir/file.txt")) == Some("file.txt")
  * @example basename(fromString(".."))) == None
- * 
+ *
  * @since v0.5.5
  */
 provide let basename = (path: Path) => {
@@ -717,15 +717,15 @@ let stemExtHelper = (path: PathInfo) =>
 
 /**
  * Retrieves the basename of a file path without the extension.
- * 
+ *
  * @param path: The path to inspect
  * @returns `Ok(path)` containing the stem of the file path or `Err(err)` if the path is a directory path
- * 
+ *
  * @example stem(fromString("file.txt")) == Ok("file")
  * @example stem(fromString(".gitignore")) == Ok(".gitignore")
  * @example stem(fromString(".a.tar.gz")) == Ok(".a")
  * @example stem(fromString("/dir/")) == Err(IncompatiblePathType) // can only take stem of a file path
- * 
+ *
  * @since v0.5.5
  */
 provide let stem = (path: Path) => {
@@ -740,15 +740,15 @@ provide let stem = (path: Path) => {
 
 /**
  * Retrieves the extension on the basename of a file path.
- * 
+ *
  * @param path: The path to inspect
  * @returns `Ok(path)` containing the extension of the file path or `Err(err)` if the path is a directory path
- * 
+ *
  * @example extension(fromString("file.txt")) == Ok(".txt")
  * @example extension(fromString(".gitignore")) == Ok("")
  * @example extension(fromString(".a.tar.gz")) == Ok(".tar.gz")
  * @example extension(fromString("/dir/")) == Err(IncompatiblePathType) // can only take extension of a file path
- * 
+ *
  * @since v0.5.5
  */
 provide let extension = (path: Path) => {
@@ -770,14 +770,14 @@ let rootHelper = (path: PathInfo) =>
 
 /**
  * Retrieves the root of the absolute path.
- * 
+ *
  * @param path: The path to inspect
  * @returns `Ok(root)` containing the root of the path or `Err(err)` if the path is a relative path
- * 
+ *
  * @example root(fromString("C:/Users/me/")) == Ok(Drive('C'))
  * @example root(fromString("/home/me/")) == Ok(Root)
  * @example root(fromString("./file.txt")) == Err(IncompatiblePathType)
- * 
+ *
  * @since v0.5.5
  */
 provide let root = (path: Path) => {

--- a/stdlib/pervasives.gr
+++ b/stdlib/pervasives.gr
@@ -1,7 +1,7 @@
 /* grainc-flags --no-pervasives */
 
 /**
- * @module Pervasives: This module is automatically imported into every Grain program. You can think of it as the global environment. Although it is automatically imported, it can still be imported manually.
+ * This module is automatically imported into every Grain program. You can think of it as the global environment. Although it is automatically imported, it can still be imported manually.
  *
  * @example include "pervasives"
  *

--- a/stdlib/priorityqueue.gr
+++ b/stdlib/priorityqueue.gr
@@ -1,5 +1,5 @@
 /**
- * @module PriorityQueue: A mutable priority queue implementation. A priority queue is a data structure that maintains elements in a priority order. Elements with higher priority are served before elements with lower priority when extracting from the priority queue.
+ * A mutable priority queue implementation. A priority queue is a data structure that maintains elements in a priority order. Elements with higher priority are served before elements with lower priority when extracting from the priority queue.
  *
  * @example include "priorityqueue"
  *
@@ -80,10 +80,10 @@ let rec siftUp = (i, pq) => {
  * comparator function takes two elements and must return 0 if both share
  * priority, a positive number if the first has greater priority, and a
  * negative number if the first has less priority.
- * 
+ *
  * Generally, you won't need to care about the storage size of your priority
  * queue and can use `PriorityQueue.make()` instead.
- * 
+ *
  * @param size: The initial storage size of the priority queue
  * @param comp: The comparator function used to indicate priority order
  * @returns An empty priority queue
@@ -99,10 +99,10 @@ provide let makeSized = (size, comp) => {
  * determine priority of elements. The comparator function takes two elements
  * and must return 0 if both share priority, a positive number if the first
  * has greater priority, and a negative number if the first has less priority.
- * 
+ *
  * @param comp: The comparator function used to indicate priority order
  * @returns An empty priority queue
- * 
+ *
  * @example PriorityQueue.make(compare) // creates a min priority queue of numbers using the compare pervasive
  * @example PriorityQueue.make((a, b) => String.length(b) - String.length(a)) // creates a priority queue by string length (longest to shortest)
  *
@@ -114,7 +114,7 @@ provide let make = comp => {
 
 /**
  * Gets the number of elements in a priority queue.
- * 
+ *
  * @param pq: The priority queue to inspect
  * @returns The number of elements in the priority queue
  *
@@ -126,7 +126,7 @@ provide let size = pq => {
 
 /**
  * Determines if the priority queue contains no elements.
- * 
+ *
  * @param pq: The priority queue to check
  * @returns `true` if the priority queue is empty and `false` otherwise
  *
@@ -138,7 +138,7 @@ provide let isEmpty = pq => {
 
 /**
  * Adds a new element to the priority queue.
- * 
+ *
  * @param val: The value to add into the priority queue
  * @param pq: The priority queue to update
  *
@@ -164,7 +164,7 @@ provide let push = (val, pq) => {
 /**
  * Retrieves the highest priority element in the priority queue. It is not
  * removed from the queue.
- * 
+ *
  * @param pq: The priority queue to inspect
  * @returns `Some(value)` containing the highest priority element or `None` if the priority queue is empty
  *
@@ -180,7 +180,7 @@ provide let peek = pq => {
 
 /**
  * Removes and retrieves the highest priority element in the priority queue.
- * 
+ *
  * @param pq: The priority queue to inspect
  * @returns `Some(value)` containing the highest priority element or `None` if the priority queue is empty
  *
@@ -202,7 +202,7 @@ provide let pop = pq => {
 /**
  * Clears the priority queue and produces a list of all of the elements in the priority
  * queue in priority order.
- * 
+ *
  * @param pq: The priority queue to drain
  * @returns A list of all elements in the priority in priority order
  *
@@ -224,7 +224,7 @@ provide let drain = pq => {
  * elements. The comparator function takes two elements and must return 0 if
  * both share priority, a positive number if the first has greater priority,
  * and a negative number if the first has less priority.
- * 
+ *
  * @param array: An array of values used to initialize the priority queue
  * @param comp: A comparator function used to assign priority to elements
  * @returns A priority queue containing the elements from the array
@@ -247,7 +247,7 @@ provide let fromArray = (array, comp) => {
  * elements. The comparator function takes two elements and must return 0 if
  * both share priority, a positive number if the first has greater priority,
  * and a negative number if the first has less priority.
- * 
+ *
  * @param list: A list of values used to initialize the priority queue
  * @param comp: A comparator function used to assign priority to elements
  * @returns A priority queue containing the elements from the list

--- a/stdlib/queue.gr
+++ b/stdlib/queue.gr
@@ -1,6 +1,8 @@
 /**
- * @module Queue: An immutable queue implementation. A queue is a FIFO (first-in-first-out) data structure where new values are added to the end and retrieved or removed from the beginning.
+ * An immutable queue implementation. A queue is a FIFO (first-in-first-out) data structure where new values are added to the end and retrieved or removed from the beginning.
+ *
  * @example include "queue"
+ *
  * @since v0.2.0
  *
  * @deprecated This module will be renamed to ImmutableQueue in the v0.6.0 release of Grain.

--- a/stdlib/random.gr
+++ b/stdlib/random.gr
@@ -1,6 +1,8 @@
 /**
- * @module Random: Pseudo-random number generation.
+ * Pseudo-random number generation.
+ *
  * @example include "random"
+ *
  * @since v0.5.0
  */
 

--- a/stdlib/range.gr
+++ b/stdlib/range.gr
@@ -1,6 +1,8 @@
 /**
- * @module Range: Utilities for working with ranges. A range represents an interval—a set of values with a beginning and an end.
+ * Utilities for working with ranges. A range represents an interval—a set of values with a beginning and an end.
+ *
  * @example include "range"
+ *
  * @since v0.3.0
  */
 

--- a/stdlib/regex.gr
+++ b/stdlib/regex.gr
@@ -1,5 +1,6 @@
 /**
- * @module Regex: Regular Expressions.
+ * Regular Expressions.
+ *
  * @example include "regex"
  *
  * @since 0.4.3

--- a/stdlib/result.gr
+++ b/stdlib/result.gr
@@ -1,11 +1,10 @@
 /**
- * @module Result: Utilities for working with the Result data type.
+ * Utilities for working with the Result data type.
  *
  * The Result type is an enum that represents the possibility of a success case (with the `Ok` variant),
  * or an error case (with the `Err` variant). Use a Result as the return type of a function that may return an error.
  *
  * @example include "result"
- *
  *
  * @example let success = Ok((x) => 1 + x) // Creates a successful Result containing (x) => 1 + x
  * @example let failure = Err("Something bad happened") // Creates an unsuccessful Result containing "Something bad happened"

--- a/stdlib/runtime/atof/common.md
+++ b/stdlib/runtime/atof/common.md
@@ -1,3 +1,7 @@
+---
+title: Common
+---
+
 ### Common.**BiasedFp**
 
 ```grain

--- a/stdlib/runtime/atof/decimal.md
+++ b/stdlib/runtime/atof/decimal.md
@@ -1,3 +1,7 @@
+---
+title: Decimal
+---
+
 ### Decimal.**Decimal**
 
 ```grain

--- a/stdlib/runtime/atof/lemire.md
+++ b/stdlib/runtime/atof/lemire.md
@@ -1,3 +1,7 @@
+---
+title: Lemire
+---
+
 ### Lemire.**computeFloat**
 
 ```grain

--- a/stdlib/runtime/atof/parse.md
+++ b/stdlib/runtime/atof/parse.md
@@ -1,3 +1,7 @@
+---
+title: Parse
+---
+
 ### Parse.**isFastPath**
 
 ```grain

--- a/stdlib/runtime/atof/slow.md
+++ b/stdlib/runtime/atof/slow.md
@@ -1,3 +1,7 @@
+---
+title: Slow
+---
+
 ### Slow.**parseLongMantissa**
 
 ```grain

--- a/stdlib/runtime/atof/table.md
+++ b/stdlib/runtime/atof/table.md
@@ -1,3 +1,7 @@
+---
+title: Table
+---
+
 ### Table.**get_F64_POWERS10_FAST_PATH**
 
 ```grain

--- a/stdlib/runtime/atoi/parse.md
+++ b/stdlib/runtime/atoi/parse.md
@@ -1,3 +1,7 @@
+---
+title: Parse
+---
+
 ### Parse.**parseInt**
 
 ```grain

--- a/stdlib/runtime/bigint.md
+++ b/stdlib/runtime/bigint.md
@@ -1,3 +1,7 @@
+---
+title: Bigint
+---
+
 ### Bigint.**List**
 
 ```grain

--- a/stdlib/runtime/compare.md
+++ b/stdlib/runtime/compare.md
@@ -1,3 +1,7 @@
+---
+title: Compare
+---
+
 ### Compare.**compare**
 
 ```grain

--- a/stdlib/runtime/dataStructures.md
+++ b/stdlib/runtime/dataStructures.md
@@ -1,3 +1,7 @@
+---
+title: DataStructures
+---
+
 ### DataStructures.**allocateArray**
 
 ```grain

--- a/stdlib/runtime/debug.md
+++ b/stdlib/runtime/debug.md
@@ -1,3 +1,7 @@
+---
+title: Debug
+---
+
 ### Debug.**debug**
 
 ```grain

--- a/stdlib/runtime/debugPrint.md
+++ b/stdlib/runtime/debugPrint.md
@@ -1,3 +1,7 @@
+---
+title: DebugPrint
+---
+
 ### DebugPrint.**print**
 
 ```grain

--- a/stdlib/runtime/equal.md
+++ b/stdlib/runtime/equal.md
@@ -1,3 +1,7 @@
+---
+title: Equal
+---
+
 ### Equal.**equal**
 
 ```grain

--- a/stdlib/runtime/exception.md
+++ b/stdlib/runtime/exception.md
@@ -1,3 +1,7 @@
+---
+title: Exception
+---
+
 ### Exception.**printers**
 
 ```grain

--- a/stdlib/runtime/gc.md
+++ b/stdlib/runtime/gc.md
@@ -1,34 +1,38 @@
-### Gc.**decimalCount32**
+---
+title: GC
+---
+
+### GC.**decimalCount32**
 
 ```grain
 decimalCount32 : Box<WasmI32 -> WasmI32>
 ```
 
-### Gc.**utoa32Buffered**
+### GC.**utoa32Buffered**
 
 ```grain
 utoa32Buffered : Box<(WasmI32, WasmI32, WasmI32) -> Void>
 ```
 
-### Gc.**malloc**
+### GC.**malloc**
 
 ```grain
 malloc : WasmI32 -> WasmI32
 ```
 
-### Gc.**free**
+### GC.**free**
 
 ```grain
 free : WasmI32 -> Void
 ```
 
-### Gc.**incRef**
+### GC.**incRef**
 
 ```grain
 incRef : WasmI32 -> WasmI32
 ```
 
-### Gc.**decRef**
+### GC.**decRef**
 
 ```grain
 decRef : WasmI32 -> WasmI32

--- a/stdlib/runtime/malloc.md
+++ b/stdlib/runtime/malloc.md
@@ -1,3 +1,7 @@
+---
+title: Malloc
+---
+
 ### Malloc.**_RESERVED_RUNTIME_SPACE**
 
 ```grain

--- a/stdlib/runtime/numberUtils.md
+++ b/stdlib/runtime/numberUtils.md
@@ -1,3 +1,7 @@
+---
+title: NumberUtils
+---
+
 ### NumberUtils.**_MAX_DOUBLE_LENGTH**
 
 ```grain

--- a/stdlib/runtime/numbers.md
+++ b/stdlib/runtime/numbers.md
@@ -1,3 +1,7 @@
+---
+title: Numbers
+---
+
 ### Numbers.**isBoxedNumber**
 
 ```grain

--- a/stdlib/runtime/string.md
+++ b/stdlib/runtime/string.md
@@ -1,3 +1,7 @@
+---
+title: String
+---
+
 ### String.**StringList**
 
 ```grain

--- a/stdlib/runtime/unsafe/constants.md
+++ b/stdlib/runtime/unsafe/constants.md
@@ -1,3 +1,7 @@
+---
+title: Constants
+---
+
 ### Constants.**_SMIN_I32**
 
 ```grain

--- a/stdlib/runtime/unsafe/conv.md
+++ b/stdlib/runtime/unsafe/conv.md
@@ -1,3 +1,7 @@
+---
+title: Conv
+---
+
 ### Conv.**toInt32**
 
 ```grain

--- a/stdlib/runtime/unsafe/errors.md
+++ b/stdlib/runtime/unsafe/errors.md
@@ -1,3 +1,7 @@
+---
+title: Errors
+---
+
 ### Errors.**_GRAIN_ERR_NOT_NUMBER_COMP**
 
 ```grain

--- a/stdlib/runtime/unsafe/memory.md
+++ b/stdlib/runtime/unsafe/memory.md
@@ -1,3 +1,7 @@
+---
+title: Memory
+---
+
 ### Memory.**malloc**
 
 ```grain

--- a/stdlib/runtime/unsafe/tags.md
+++ b/stdlib/runtime/unsafe/tags.md
@@ -1,3 +1,7 @@
+---
+title: Tags
+---
+
 ### Tags.**_GRAIN_NUMBER_TAG_TYPE**
 
 ```grain

--- a/stdlib/runtime/unsafe/wasmf32.md
+++ b/stdlib/runtime/unsafe/wasmf32.md
@@ -1,166 +1,170 @@
-### Wasmf32.**load**
+---
+title: WasmF32
+---
+
+### WasmF32.**load**
 
 ```grain
 load : (WasmI32, WasmI32) -> WasmF32
 ```
 
-### Wasmf32.**store**
+### WasmF32.**store**
 
 ```grain
 store : (WasmI32, WasmF32, WasmI32) -> Void
 ```
 
-### Wasmf32.**neg**
+### WasmF32.**neg**
 
 ```grain
 neg : WasmF32 -> WasmF32
 ```
 
-### Wasmf32.**abs**
+### WasmF32.**abs**
 
 ```grain
 abs : WasmF32 -> WasmF32
 ```
 
-### Wasmf32.**ceil**
+### WasmF32.**ceil**
 
 ```grain
 ceil : WasmF32 -> WasmF32
 ```
 
-### Wasmf32.**floor**
+### WasmF32.**floor**
 
 ```grain
 floor : WasmF32 -> WasmF32
 ```
 
-### Wasmf32.**trunc**
+### WasmF32.**trunc**
 
 ```grain
 trunc : WasmF32 -> WasmF32
 ```
 
-### Wasmf32.**nearest**
+### WasmF32.**nearest**
 
 ```grain
 nearest : WasmF32 -> WasmF32
 ```
 
-### Wasmf32.**sqrt**
+### WasmF32.**sqrt**
 
 ```grain
 sqrt : WasmF32 -> WasmF32
 ```
 
-### Wasmf32.**add**
+### WasmF32.**add**
 
 ```grain
 add : (WasmF32, WasmF32) -> WasmF32
 ```
 
-### Wasmf32.**sub**
+### WasmF32.**sub**
 
 ```grain
 sub : (WasmF32, WasmF32) -> WasmF32
 ```
 
-### Wasmf32.**mul**
+### WasmF32.**mul**
 
 ```grain
 mul : (WasmF32, WasmF32) -> WasmF32
 ```
 
-### Wasmf32.**div**
+### WasmF32.**div**
 
 ```grain
 div : (WasmF32, WasmF32) -> WasmF32
 ```
 
-### Wasmf32.**copySign**
+### WasmF32.**copySign**
 
 ```grain
 copySign : (WasmF32, WasmF32) -> WasmF32
 ```
 
-### Wasmf32.**min**
+### WasmF32.**min**
 
 ```grain
 min : (WasmF32, WasmF32) -> WasmF32
 ```
 
-### Wasmf32.**max**
+### WasmF32.**max**
 
 ```grain
 max : (WasmF32, WasmF32) -> WasmF32
 ```
 
-### Wasmf32.**eq**
+### WasmF32.**eq**
 
 ```grain
 eq : (WasmF32, WasmF32) -> Bool
 ```
 
-### Wasmf32.**ne**
+### WasmF32.**ne**
 
 ```grain
 ne : (WasmF32, WasmF32) -> Bool
 ```
 
-### Wasmf32.**lt**
+### WasmF32.**lt**
 
 ```grain
 lt : (WasmF32, WasmF32) -> Bool
 ```
 
-### Wasmf32.**le**
+### WasmF32.**le**
 
 ```grain
 le : (WasmF32, WasmF32) -> Bool
 ```
 
-### Wasmf32.**gt**
+### WasmF32.**gt**
 
 ```grain
 gt : (WasmF32, WasmF32) -> Bool
 ```
 
-### Wasmf32.**ge**
+### WasmF32.**ge**
 
 ```grain
 ge : (WasmF32, WasmF32) -> Bool
 ```
 
-### Wasmf32.**reinterpretI32**
+### WasmF32.**reinterpretI32**
 
 ```grain
 reinterpretI32 : WasmI32 -> WasmF32
 ```
 
-### Wasmf32.**convertI32S**
+### WasmF32.**convertI32S**
 
 ```grain
 convertI32S : WasmI32 -> WasmF32
 ```
 
-### Wasmf32.**convertI32U**
+### WasmF32.**convertI32U**
 
 ```grain
 convertI32U : WasmI32 -> WasmF32
 ```
 
-### Wasmf32.**convertI64S**
+### WasmF32.**convertI64S**
 
 ```grain
 convertI64S : WasmI64 -> WasmF32
 ```
 
-### Wasmf32.**convertI64U**
+### WasmF32.**convertI64U**
 
 ```grain
 convertI64U : WasmI64 -> WasmF32
 ```
 
-### Wasmf32.**demoteF64**
+### WasmF32.**demoteF64**
 
 ```grain
 demoteF64 : WasmF64 -> WasmF32

--- a/stdlib/runtime/unsafe/wasmf64.md
+++ b/stdlib/runtime/unsafe/wasmf64.md
@@ -1,166 +1,170 @@
-### Wasmf64.**load**
+---
+title: WasmF64
+---
+
+### WasmF64.**load**
 
 ```grain
 load : (WasmI32, WasmI32) -> WasmF64
 ```
 
-### Wasmf64.**store**
+### WasmF64.**store**
 
 ```grain
 store : (WasmI32, WasmF64, WasmI32) -> Void
 ```
 
-### Wasmf64.**neg**
+### WasmF64.**neg**
 
 ```grain
 neg : WasmF64 -> WasmF64
 ```
 
-### Wasmf64.**abs**
+### WasmF64.**abs**
 
 ```grain
 abs : WasmF64 -> WasmF64
 ```
 
-### Wasmf64.**ceil**
+### WasmF64.**ceil**
 
 ```grain
 ceil : WasmF64 -> WasmF64
 ```
 
-### Wasmf64.**floor**
+### WasmF64.**floor**
 
 ```grain
 floor : WasmF64 -> WasmF64
 ```
 
-### Wasmf64.**trunc**
+### WasmF64.**trunc**
 
 ```grain
 trunc : WasmF64 -> WasmF64
 ```
 
-### Wasmf64.**nearest**
+### WasmF64.**nearest**
 
 ```grain
 nearest : WasmF64 -> WasmF64
 ```
 
-### Wasmf64.**sqrt**
+### WasmF64.**sqrt**
 
 ```grain
 sqrt : WasmF64 -> WasmF64
 ```
 
-### Wasmf64.**add**
+### WasmF64.**add**
 
 ```grain
 add : (WasmF64, WasmF64) -> WasmF64
 ```
 
-### Wasmf64.**sub**
+### WasmF64.**sub**
 
 ```grain
 sub : (WasmF64, WasmF64) -> WasmF64
 ```
 
-### Wasmf64.**mul**
+### WasmF64.**mul**
 
 ```grain
 mul : (WasmF64, WasmF64) -> WasmF64
 ```
 
-### Wasmf64.**div**
+### WasmF64.**div**
 
 ```grain
 div : (WasmF64, WasmF64) -> WasmF64
 ```
 
-### Wasmf64.**copySign**
+### WasmF64.**copySign**
 
 ```grain
 copySign : (WasmF64, WasmF64) -> WasmF64
 ```
 
-### Wasmf64.**min**
+### WasmF64.**min**
 
 ```grain
 min : (WasmF64, WasmF64) -> WasmF64
 ```
 
-### Wasmf64.**max**
+### WasmF64.**max**
 
 ```grain
 max : (WasmF64, WasmF64) -> WasmF64
 ```
 
-### Wasmf64.**eq**
+### WasmF64.**eq**
 
 ```grain
 eq : (WasmF64, WasmF64) -> Bool
 ```
 
-### Wasmf64.**ne**
+### WasmF64.**ne**
 
 ```grain
 ne : (WasmF64, WasmF64) -> Bool
 ```
 
-### Wasmf64.**lt**
+### WasmF64.**lt**
 
 ```grain
 lt : (WasmF64, WasmF64) -> Bool
 ```
 
-### Wasmf64.**le**
+### WasmF64.**le**
 
 ```grain
 le : (WasmF64, WasmF64) -> Bool
 ```
 
-### Wasmf64.**gt**
+### WasmF64.**gt**
 
 ```grain
 gt : (WasmF64, WasmF64) -> Bool
 ```
 
-### Wasmf64.**ge**
+### WasmF64.**ge**
 
 ```grain
 ge : (WasmF64, WasmF64) -> Bool
 ```
 
-### Wasmf64.**reinterpretI64**
+### WasmF64.**reinterpretI64**
 
 ```grain
 reinterpretI64 : WasmI64 -> WasmF64
 ```
 
-### Wasmf64.**convertI32S**
+### WasmF64.**convertI32S**
 
 ```grain
 convertI32S : WasmI32 -> WasmF64
 ```
 
-### Wasmf64.**convertI32U**
+### WasmF64.**convertI32U**
 
 ```grain
 convertI32U : WasmI32 -> WasmF64
 ```
 
-### Wasmf64.**convertI64S**
+### WasmF64.**convertI64S**
 
 ```grain
 convertI64S : WasmI64 -> WasmF64
 ```
 
-### Wasmf64.**convertI64U**
+### WasmF64.**convertI64U**
 
 ```grain
 convertI64U : WasmI64 -> WasmF64
 ```
 
-### Wasmf64.**promoteF32**
+### WasmF64.**promoteF32**
 
 ```grain
 promoteF32 : WasmF32 -> WasmF64

--- a/stdlib/runtime/unsafe/wasmi32.md
+++ b/stdlib/runtime/unsafe/wasmi32.md
@@ -1,280 +1,284 @@
-### Wasmi32.**load**
+---
+title: WasmI32
+---
+
+### WasmI32.**load**
 
 ```grain
 load : (WasmI32, WasmI32) -> WasmI32
 ```
 
-### Wasmi32.**load8S**
+### WasmI32.**load8S**
 
 ```grain
 load8S : (WasmI32, WasmI32) -> WasmI32
 ```
 
-### Wasmi32.**load8U**
+### WasmI32.**load8U**
 
 ```grain
 load8U : (WasmI32, WasmI32) -> WasmI32
 ```
 
-### Wasmi32.**load16S**
+### WasmI32.**load16S**
 
 ```grain
 load16S : (WasmI32, WasmI32) -> WasmI32
 ```
 
-### Wasmi32.**load16U**
+### WasmI32.**load16U**
 
 ```grain
 load16U : (WasmI32, WasmI32) -> WasmI32
 ```
 
-### Wasmi32.**store**
+### WasmI32.**store**
 
 ```grain
 store : (WasmI32, WasmI32, WasmI32) -> Void
 ```
 
-### Wasmi32.**store8**
+### WasmI32.**store8**
 
 ```grain
 store8 : (WasmI32, WasmI32, WasmI32) -> Void
 ```
 
-### Wasmi32.**store16**
+### WasmI32.**store16**
 
 ```grain
 store16 : (WasmI32, WasmI32, WasmI32) -> Void
 ```
 
-### Wasmi32.**clz**
+### WasmI32.**clz**
 
 ```grain
 clz : WasmI32 -> WasmI32
 ```
 
-### Wasmi32.**ctz**
+### WasmI32.**ctz**
 
 ```grain
 ctz : WasmI32 -> WasmI32
 ```
 
-### Wasmi32.**popcnt**
+### WasmI32.**popcnt**
 
 ```grain
 popcnt : WasmI32 -> WasmI32
 ```
 
-### Wasmi32.**eqz**
+### WasmI32.**eqz**
 
 ```grain
 eqz : WasmI32 -> Bool
 ```
 
-### Wasmi32.**add**
+### WasmI32.**add**
 
 ```grain
 add : (WasmI32, WasmI32) -> WasmI32
 ```
 
-### Wasmi32.**sub**
+### WasmI32.**sub**
 
 ```grain
 sub : (WasmI32, WasmI32) -> WasmI32
 ```
 
-### Wasmi32.**mul**
+### WasmI32.**mul**
 
 ```grain
 mul : (WasmI32, WasmI32) -> WasmI32
 ```
 
-### Wasmi32.**divS**
+### WasmI32.**divS**
 
 ```grain
 divS : (WasmI32, WasmI32) -> WasmI32
 ```
 
-### Wasmi32.**divU**
+### WasmI32.**divU**
 
 ```grain
 divU : (WasmI32, WasmI32) -> WasmI32
 ```
 
-### Wasmi32.**remS**
+### WasmI32.**remS**
 
 ```grain
 remS : (WasmI32, WasmI32) -> WasmI32
 ```
 
-### Wasmi32.**remU**
+### WasmI32.**remU**
 
 ```grain
 remU : (WasmI32, WasmI32) -> WasmI32
 ```
 
-### Wasmi32.**and**
+### WasmI32.**and**
 
 ```grain
 and : (WasmI32, WasmI32) -> WasmI32
 ```
 
-### Wasmi32.**or**
+### WasmI32.**or**
 
 ```grain
 or : (WasmI32, WasmI32) -> WasmI32
 ```
 
-### Wasmi32.**xor**
+### WasmI32.**xor**
 
 ```grain
 xor : (WasmI32, WasmI32) -> WasmI32
 ```
 
-### Wasmi32.**shl**
+### WasmI32.**shl**
 
 ```grain
 shl : (WasmI32, WasmI32) -> WasmI32
 ```
 
-### Wasmi32.**shrS**
+### WasmI32.**shrS**
 
 ```grain
 shrS : (WasmI32, WasmI32) -> WasmI32
 ```
 
-### Wasmi32.**shrU**
+### WasmI32.**shrU**
 
 ```grain
 shrU : (WasmI32, WasmI32) -> WasmI32
 ```
 
-### Wasmi32.**rotl**
+### WasmI32.**rotl**
 
 ```grain
 rotl : (WasmI32, WasmI32) -> WasmI32
 ```
 
-### Wasmi32.**rotr**
+### WasmI32.**rotr**
 
 ```grain
 rotr : (WasmI32, WasmI32) -> WasmI32
 ```
 
-### Wasmi32.**eq**
+### WasmI32.**eq**
 
 ```grain
 eq : (WasmI32, WasmI32) -> Bool
 ```
 
-### Wasmi32.**ne**
+### WasmI32.**ne**
 
 ```grain
 ne : (WasmI32, WasmI32) -> Bool
 ```
 
-### Wasmi32.**ltS**
+### WasmI32.**ltS**
 
 ```grain
 ltS : (WasmI32, WasmI32) -> Bool
 ```
 
-### Wasmi32.**ltU**
+### WasmI32.**ltU**
 
 ```grain
 ltU : (WasmI32, WasmI32) -> Bool
 ```
 
-### Wasmi32.**leS**
+### WasmI32.**leS**
 
 ```grain
 leS : (WasmI32, WasmI32) -> Bool
 ```
 
-### Wasmi32.**leU**
+### WasmI32.**leU**
 
 ```grain
 leU : (WasmI32, WasmI32) -> Bool
 ```
 
-### Wasmi32.**gtS**
+### WasmI32.**gtS**
 
 ```grain
 gtS : (WasmI32, WasmI32) -> Bool
 ```
 
-### Wasmi32.**gtU**
+### WasmI32.**gtU**
 
 ```grain
 gtU : (WasmI32, WasmI32) -> Bool
 ```
 
-### Wasmi32.**geS**
+### WasmI32.**geS**
 
 ```grain
 geS : (WasmI32, WasmI32) -> Bool
 ```
 
-### Wasmi32.**geU**
+### WasmI32.**geU**
 
 ```grain
 geU : (WasmI32, WasmI32) -> Bool
 ```
 
-### Wasmi32.**wrapI64**
+### WasmI32.**wrapI64**
 
 ```grain
 wrapI64 : WasmI64 -> WasmI32
 ```
 
-### Wasmi32.**truncF32S**
+### WasmI32.**truncF32S**
 
 ```grain
 truncF32S : WasmF32 -> WasmI32
 ```
 
-### Wasmi32.**truncF32U**
+### WasmI32.**truncF32U**
 
 ```grain
 truncF32U : WasmF32 -> WasmI32
 ```
 
-### Wasmi32.**truncF64S**
+### WasmI32.**truncF64S**
 
 ```grain
 truncF64S : WasmF64 -> WasmI32
 ```
 
-### Wasmi32.**truncF64U**
+### WasmI32.**truncF64U**
 
 ```grain
 truncF64U : WasmF64 -> WasmI32
 ```
 
-### Wasmi32.**reinterpretF32**
+### WasmI32.**reinterpretF32**
 
 ```grain
 reinterpretF32 : WasmF32 -> WasmI32
 ```
 
-### Wasmi32.**extendS8**
+### WasmI32.**extendS8**
 
 ```grain
 extendS8 : WasmI32 -> WasmI32
 ```
 
-### Wasmi32.**extendS16**
+### WasmI32.**extendS16**
 
 ```grain
 extendS16 : WasmI32 -> WasmI32
 ```
 
-### Wasmi32.**fromGrain**
+### WasmI32.**fromGrain**
 
 ```grain
 fromGrain : a -> WasmI32
 ```
 
-### Wasmi32.**toGrain**
+### WasmI32.**toGrain**
 
 ```grain
 toGrain : WasmI32 -> a

--- a/stdlib/runtime/unsafe/wasmi64.md
+++ b/stdlib/runtime/unsafe/wasmi64.md
@@ -1,298 +1,302 @@
-### Wasmi64.**load**
+---
+title: WasmI64
+---
+
+### WasmI64.**load**
 
 ```grain
 load : (WasmI32, WasmI32) -> WasmI64
 ```
 
-### Wasmi64.**load8S**
+### WasmI64.**load8S**
 
 ```grain
 load8S : (WasmI32, WasmI32) -> WasmI64
 ```
 
-### Wasmi64.**load8U**
+### WasmI64.**load8U**
 
 ```grain
 load8U : (WasmI32, WasmI32) -> WasmI64
 ```
 
-### Wasmi64.**load16S**
+### WasmI64.**load16S**
 
 ```grain
 load16S : (WasmI32, WasmI32) -> WasmI64
 ```
 
-### Wasmi64.**load16U**
+### WasmI64.**load16U**
 
 ```grain
 load16U : (WasmI32, WasmI32) -> WasmI64
 ```
 
-### Wasmi64.**load32S**
+### WasmI64.**load32S**
 
 ```grain
 load32S : (WasmI32, WasmI32) -> WasmI64
 ```
 
-### Wasmi64.**load32U**
+### WasmI64.**load32U**
 
 ```grain
 load32U : (WasmI32, WasmI32) -> WasmI64
 ```
 
-### Wasmi64.**store**
+### WasmI64.**store**
 
 ```grain
 store : (WasmI32, WasmI64, WasmI32) -> Void
 ```
 
-### Wasmi64.**store8**
+### WasmI64.**store8**
 
 ```grain
 store8 : (WasmI32, WasmI64, WasmI32) -> Void
 ```
 
-### Wasmi64.**store16**
+### WasmI64.**store16**
 
 ```grain
 store16 : (WasmI32, WasmI64, WasmI32) -> Void
 ```
 
-### Wasmi64.**store32**
+### WasmI64.**store32**
 
 ```grain
 store32 : (WasmI32, WasmI64, WasmI32) -> Void
 ```
 
-### Wasmi64.**clz**
+### WasmI64.**clz**
 
 ```grain
 clz : WasmI64 -> WasmI64
 ```
 
-### Wasmi64.**ctz**
+### WasmI64.**ctz**
 
 ```grain
 ctz : WasmI64 -> WasmI64
 ```
 
-### Wasmi64.**popcnt**
+### WasmI64.**popcnt**
 
 ```grain
 popcnt : WasmI64 -> WasmI64
 ```
 
-### Wasmi64.**eqz**
+### WasmI64.**eqz**
 
 ```grain
 eqz : WasmI64 -> Bool
 ```
 
-### Wasmi64.**add**
+### WasmI64.**add**
 
 ```grain
 add : (WasmI64, WasmI64) -> WasmI64
 ```
 
-### Wasmi64.**sub**
+### WasmI64.**sub**
 
 ```grain
 sub : (WasmI64, WasmI64) -> WasmI64
 ```
 
-### Wasmi64.**mul**
+### WasmI64.**mul**
 
 ```grain
 mul : (WasmI64, WasmI64) -> WasmI64
 ```
 
-### Wasmi64.**divS**
+### WasmI64.**divS**
 
 ```grain
 divS : (WasmI64, WasmI64) -> WasmI64
 ```
 
-### Wasmi64.**divU**
+### WasmI64.**divU**
 
 ```grain
 divU : (WasmI64, WasmI64) -> WasmI64
 ```
 
-### Wasmi64.**remS**
+### WasmI64.**remS**
 
 ```grain
 remS : (WasmI64, WasmI64) -> WasmI64
 ```
 
-### Wasmi64.**remU**
+### WasmI64.**remU**
 
 ```grain
 remU : (WasmI64, WasmI64) -> WasmI64
 ```
 
-### Wasmi64.**and**
+### WasmI64.**and**
 
 ```grain
 and : (WasmI64, WasmI64) -> WasmI64
 ```
 
-### Wasmi64.**or**
+### WasmI64.**or**
 
 ```grain
 or : (WasmI64, WasmI64) -> WasmI64
 ```
 
-### Wasmi64.**xor**
+### WasmI64.**xor**
 
 ```grain
 xor : (WasmI64, WasmI64) -> WasmI64
 ```
 
-### Wasmi64.**shl**
+### WasmI64.**shl**
 
 ```grain
 shl : (WasmI64, WasmI64) -> WasmI64
 ```
 
-### Wasmi64.**shrU**
+### WasmI64.**shrU**
 
 ```grain
 shrU : (WasmI64, WasmI64) -> WasmI64
 ```
 
-### Wasmi64.**shrS**
+### WasmI64.**shrS**
 
 ```grain
 shrS : (WasmI64, WasmI64) -> WasmI64
 ```
 
-### Wasmi64.**rotl**
+### WasmI64.**rotl**
 
 ```grain
 rotl : (WasmI64, WasmI64) -> WasmI64
 ```
 
-### Wasmi64.**rotr**
+### WasmI64.**rotr**
 
 ```grain
 rotr : (WasmI64, WasmI64) -> WasmI64
 ```
 
-### Wasmi64.**eq**
+### WasmI64.**eq**
 
 ```grain
 eq : (WasmI64, WasmI64) -> Bool
 ```
 
-### Wasmi64.**ne**
+### WasmI64.**ne**
 
 ```grain
 ne : (WasmI64, WasmI64) -> Bool
 ```
 
-### Wasmi64.**ltS**
+### WasmI64.**ltS**
 
 ```grain
 ltS : (WasmI64, WasmI64) -> Bool
 ```
 
-### Wasmi64.**ltU**
+### WasmI64.**ltU**
 
 ```grain
 ltU : (WasmI64, WasmI64) -> Bool
 ```
 
-### Wasmi64.**leS**
+### WasmI64.**leS**
 
 ```grain
 leS : (WasmI64, WasmI64) -> Bool
 ```
 
-### Wasmi64.**leU**
+### WasmI64.**leU**
 
 ```grain
 leU : (WasmI64, WasmI64) -> Bool
 ```
 
-### Wasmi64.**gtS**
+### WasmI64.**gtS**
 
 ```grain
 gtS : (WasmI64, WasmI64) -> Bool
 ```
 
-### Wasmi64.**gtU**
+### WasmI64.**gtU**
 
 ```grain
 gtU : (WasmI64, WasmI64) -> Bool
 ```
 
-### Wasmi64.**geS**
+### WasmI64.**geS**
 
 ```grain
 geS : (WasmI64, WasmI64) -> Bool
 ```
 
-### Wasmi64.**geU**
+### WasmI64.**geU**
 
 ```grain
 geU : (WasmI64, WasmI64) -> Bool
 ```
 
-### Wasmi64.**extendI32S**
+### WasmI64.**extendI32S**
 
 ```grain
 extendI32S : WasmI32 -> WasmI64
 ```
 
-### Wasmi64.**extendI32U**
+### WasmI64.**extendI32U**
 
 ```grain
 extendI32U : WasmI32 -> WasmI64
 ```
 
-### Wasmi64.**truncF32S**
+### WasmI64.**truncF32S**
 
 ```grain
 truncF32S : WasmF32 -> WasmI64
 ```
 
-### Wasmi64.**truncF32U**
+### WasmI64.**truncF32U**
 
 ```grain
 truncF32U : WasmF32 -> WasmI64
 ```
 
-### Wasmi64.**truncF64S**
+### WasmI64.**truncF64S**
 
 ```grain
 truncF64S : WasmF64 -> WasmI64
 ```
 
-### Wasmi64.**truncF64U**
+### WasmI64.**truncF64U**
 
 ```grain
 truncF64U : WasmF64 -> WasmI64
 ```
 
-### Wasmi64.**reinterpretF64**
+### WasmI64.**reinterpretF64**
 
 ```grain
 reinterpretF64 : WasmF64 -> WasmI64
 ```
 
-### Wasmi64.**extendS8**
+### WasmI64.**extendS8**
 
 ```grain
 extendS8 : WasmI64 -> WasmI64
 ```
 
-### Wasmi64.**extendS16**
+### WasmI64.**extendS16**
 
 ```grain
 extendS16 : WasmI64 -> WasmI64
 ```
 
-### Wasmi64.**extendS32**
+### WasmI64.**extendS32**
 
 ```grain
 extendS32 : WasmI64 -> WasmI64

--- a/stdlib/runtime/utils/printing.md
+++ b/stdlib/runtime/utils/printing.md
@@ -1,3 +1,7 @@
+---
+title: Printing
+---
+
 ### Printing.**numberToString**
 
 ```grain

--- a/stdlib/runtime/wasi.md
+++ b/stdlib/runtime/wasi.md
@@ -1,3 +1,7 @@
+---
+title: Wasi
+---
+
 ### Wasi.**args_get**
 
 ```grain

--- a/stdlib/set.gr
+++ b/stdlib/set.gr
@@ -1,7 +1,8 @@
 /**
- * @module Set: A Set is an unordered collection of unique values. Operations on a Set mutate the internal state, so it never needs to be re-assigned.
+ * A Set is an unordered collection of unique values. Operations on a Set mutate the internal state, so it never needs to be re-assigned.
+ *
  * @example include "set"
- * 
+ *
  * @since v0.3.0
  */
 
@@ -36,7 +37,7 @@ record Set<k> {
  *
  * @param size: The initial storage size of the set
  * @returns An empty set with the given initial storage size
- * 
+ *
  * @since v0.3.0
  */
 provide let makeSized = size => {
@@ -47,7 +48,7 @@ provide let makeSized = size => {
  * Creates a new, empty set.
  *
  * @returns An empty set
- * 
+ *
  * @since v0.3.0
  */
 provide let make = () => {
@@ -124,7 +125,7 @@ let rec nodeInBucket = (key, node) => {
  *
  * @param key: The value to add
  * @param set: The set to update
- * 
+ *
  * @since v0.3.0
  */
 provide let add = (key, set) => {
@@ -157,7 +158,7 @@ provide let add = (key, set) => {
  * @param key: The value to search for
  * @param set: The set to search
  * @returns `true` if the set contains the given value or `false` otherwise
- * 
+ *
  * @since v0.3.0
  */
 provide let contains = (key, set) => {
@@ -189,7 +190,7 @@ let rec removeInBucket = (key, node) => {
  *
  * @param key: The value to remove
  * @param set: The set to update
- * 
+ *
  * @since v0.3.0
  */
 provide let remove = (key, set) => {
@@ -217,7 +218,7 @@ provide let remove = (key, set) => {
  *
  * @param set: The set to inspect
  * @returns The count of elements in the set
- * 
+ *
  * @since v0.3.0
  */
 provide let size = set => {
@@ -229,7 +230,7 @@ provide let size = set => {
  *
  * @param set: The set to inspect
  * @returns `true` if the given set is empty or `false` otherwise
- * 
+ *
  * @since v0.3.0
  */
 provide let isEmpty = set => {
@@ -240,7 +241,7 @@ provide let isEmpty = set => {
  * Resets the set by removing all values.
  *
  * @param set: The set to reset
- * 
+ *
  * @since v0.3.0
  */
 provide let clear = set => {
@@ -266,7 +267,7 @@ let rec forEachBucket = (fn, node) => {
  *
  * @param fn: The iterator function to call with each element
  * @param set: The set to iterate
- * 
+ *
  * @since v0.3.0
  * @history v0.5.0: Ensured the iterator function return type is always `Void`
  */
@@ -291,7 +292,7 @@ let rec reduceEachBucket = (fn, node, acc) => {
  * @param init: The initial value to use for the accumulator on the first iteration
  * @param set: The set to iterate
  * @returns The final accumulator returned from `fn`
- * 
+ *
  * @since v0.3.0
  */
 provide let reduce = (fn, init, set) => {
@@ -308,7 +309,7 @@ provide let reduce = (fn, init, set) => {
  *
  * @param fn: The predicate function to indicate which elements to remove from the set, where returning `false` indicates the value should be removed
  * @param set: The set to iterate
- * 
+ *
  * @since v0.3.0
  */
 provide let filter = (fn, set) => {
@@ -327,7 +328,7 @@ provide let filter = (fn, set) => {
  *
  * @param fn: The predicate function to indicate which elements to remove from the set, where returning `true` indicates the value should be removed
  * @param set: The set to iterate
- * 
+ *
  * @since v0.3.0
  */
 provide let reject = (fn, set) => {
@@ -339,7 +340,7 @@ provide let reject = (fn, set) => {
  *
  * @param set: The set to convert
  * @returns A list containing all set values
- * 
+ *
  * @since v0.3.0
  */
 provide let toList = set => {
@@ -351,7 +352,7 @@ provide let toList = set => {
  *
  * @param list: The list to convert
  * @returns A set containing all list values
- * 
+ *
  * @since v0.3.0
  */
 provide let fromList = list => {
@@ -367,7 +368,7 @@ provide let fromList = list => {
  *
  * @param set: The set to convert
  * @returns An array containing all set values
- * 
+ *
  * @since v0.3.0
  */
 provide let toArray = set => {
@@ -379,7 +380,7 @@ provide let toArray = set => {
  *
  * @param array: The array to convert
  * @returns A set containing all array values
- * 
+ *
  * @since v0.3.0
  */
 provide let fromArray = array => {
@@ -396,7 +397,7 @@ provide let fromArray = array => {
  * @param set1: The first set to combine
  * @param set2: The second set to combine
  * @returns A set containing all elements of both sets
- * 
+ *
  * @since v0.3.0
  */
 provide let union = (set1, set2) => {
@@ -416,7 +417,7 @@ provide let union = (set1, set2) => {
  * @param set1: The first set to combine
  * @param set2: The second set to combine
  * @returns A set containing only unshared elements from both sets
- * 
+ *
  * @since v0.3.0
  */
 provide let diff = (set1, set2) => {
@@ -440,7 +441,7 @@ provide let diff = (set1, set2) => {
  * @param set1: The first set to combine
  * @param set2: The second set to combine
  * @returns A set containing only shared elements from both sets
- * 
+ *
  * @since v0.3.0
  */
 provide let intersect = (set1, set2) => {
@@ -464,7 +465,7 @@ provide let intersect = (set1, set2) => {
  *
  * @param set: The set to inspect
  * @returns The internal state of the set
- * 
+ *
  * @since v0.3.0
  */
 provide let getInternalStats = set => {

--- a/stdlib/stack.gr
+++ b/stdlib/stack.gr
@@ -1,8 +1,10 @@
 /**
- * @module Stack: An immutable stack implementation. A stack is a LIFO (last-in-first-out) data structure where new values are added, retrieved, and removed from the end.
+ * An immutable stack implementation. A stack is a LIFO (last-in-first-out) data structure where new values are added, retrieved, and removed from the end.
+ *
  * @example include "stack"
  *
  * @since v0.3.0
+ *
  * @deprecated This module will be renamed to ImmutableStack in the v0.6.0 release of Grain.
  */
 

--- a/stdlib/string.gr
+++ b/stdlib/string.gr
@@ -1,5 +1,6 @@
 /**
- * @module String: Utilities for working with strings.
+ * Utilities for working with strings.
+ *
  * @example include "string"
  *
  * @since v0.2.0

--- a/stdlib/sys/file.gr
+++ b/stdlib/sys/file.gr
@@ -1,5 +1,5 @@
 /**
- * @module File: Utilities for accessing the filesystem & working with files.
+ * Utilities for accessing the filesystem & working with files.
  *
  * Many of the functions in this module are not intended to be used directly, but rather for other libraries to be built on top of them.
  *

--- a/stdlib/sys/process.gr
+++ b/stdlib/sys/process.gr
@@ -1,5 +1,5 @@
 /**
- * @module Process: Utilities for accessing functionality and information about the Grain program's process.
+ * Utilities for accessing functionality and information about the Grain program's process.
  *
  * This includes things like accessing environment variables and sending signals.
  *

--- a/stdlib/sys/random.gr
+++ b/stdlib/sys/random.gr
@@ -1,5 +1,5 @@
 /**
- * @module Random: System access to random values.
+ * System access to random values.
  *
  * @example include "sys/random"
  */

--- a/stdlib/sys/time.gr
+++ b/stdlib/sys/time.gr
@@ -1,5 +1,5 @@
 /**
- * @module Time: Access to system clocks.
+ * Access to system clocks.
  *
  * @example include "sys/time"
  */


### PR DESCRIPTION
This removes our custom `@module` attribute in a docblock and instead relies on a docblock attached to the module header (hooray module anchor points!).

Also, I updated the stdlib to avoid using `@module`, which caught one problem with the `Bigint` module header which generally should be `BigInt` and the docs were different.

One benefit you'll noticed from the regenerated docs is that the docs produced for runtime are more accurate because we have accurate module naming in the files.

Ref #1621 (still plenty to do before it is done).