### PR TITLE
fix(stdlib)!: Sys/File reading and writing operate on Bytes

### DIFF
--- a/compiler/test/stdlib/sys.file.test.gr
+++ b/compiler/test/stdlib/sys.file.test.gr
@@ -1,6 +1,7 @@
 module FileTest
 
 include "sys/file" as Fs
+include "bytes"
 include "result"
 
 // fdRead
@@ -20,7 +21,7 @@ let (buf, nread) = Result.unwrap(Fs.fdRead(foo, 40))
 
 Fs.fdClose(foo)
 
-assert buf == "foo, bar, & baz"
+assert buf == Bytes.fromString("foo, bar, & baz")
 assert nread == 15
 
 // fdWrite
@@ -36,7 +37,7 @@ let foo = Result.unwrap(
   )
 )
 
-assert Fs.fdWrite(foo, "this and that") == Ok(13)
+assert Fs.fdWrite(foo, Bytes.fromString("this and that")) == Ok(13)
 
 Fs.fdSeek(foo, 0L, Fs.Set)
 
@@ -46,5 +47,5 @@ Fs.fdSetSize(foo, 0L)
 
 Fs.fdClose(foo)
 
-assert buf == "this and that"
+assert buf == Bytes.fromString("this and that")
 assert nread == 13

--- a/compiler/test/suites/stdlib.re
+++ b/compiler/test/suites/stdlib.re
@@ -64,7 +64,12 @@ describe("stdlib", ({test, testSkip}) => {
   // logging to the stdout file descriptor
   assertRun(
     "stdlib_file_stdout",
-    {|include "sys/file"; ignore(File.fdWrite(File.stdout, "enterthe")); print(void)|},
+    {|
+      include "bytes"
+      include "sys/file"
+      ignore(File.fdWrite(File.stdout, Bytes.fromString("enterthe")))
+      print(void)
+    |},
     "enterthevoid\n",
   );
   assertStdlib("array.test");

--- a/stdlib/sys/file.gr
+++ b/stdlib/sys/file.gr
@@ -32,6 +32,7 @@ include "runtime/dataStructures"
 from DataStructures use {
   tagSimpleNumber,
   allocateArray,
+  allocateBytes,
   allocateString,
   newInt64,
   allocateInt64,
@@ -525,7 +526,7 @@ provide let fdRead = (fd: FileDescriptor, size: Number) => {
   let n = WasmI32.fromGrain(size) >> 1n
 
   let iovs = Memory.malloc(3n * 4n)
-  let strPtr = allocateString(n)
+  let strPtr = allocateBytes(n)
 
   WasmI32.store(iovs, strPtr + 2n * 4n, 0n)
   WasmI32.store(iovs, n, 4n)
@@ -542,7 +543,7 @@ provide let fdRead = (fd: FileDescriptor, size: Number) => {
   nread = WasmI32.load(nread, 0n)
   WasmI32.store(strPtr, nread, 4n)
   Memory.free(iovs)
-  return Ok((WasmI32.toGrain(strPtr): String, tagSimpleNumber(nread)))
+  return Ok((WasmI32.toGrain(strPtr): Bytes, tagSimpleNumber(nread)))
 }
 
 /**
@@ -564,7 +565,7 @@ provide let fdPread = (fd: FileDescriptor, offset: Int64, size: Number) => {
   let n = WasmI32.fromGrain(size) >> 1n
 
   let iovs = Memory.malloc(3n * 4n)
-  let strPtr = allocateString(n)
+  let strPtr = allocateBytes(n)
 
   WasmI32.store(iovs, strPtr + 2n * 4n, 0n)
   WasmI32.store(iovs, n, 4n)
@@ -581,7 +582,7 @@ provide let fdPread = (fd: FileDescriptor, offset: Int64, size: Number) => {
   nread = WasmI32.load(nread, 0n)
   WasmI32.store(strPtr, nread, 4n)
   Memory.free(iovs)
-  return Ok((WasmI32.toGrain(strPtr): String, tagSimpleNumber(nread)))
+  return Ok((WasmI32.toGrain(strPtr): Bytes, tagSimpleNumber(nread)))
 }
 
 /**
@@ -592,7 +593,7 @@ provide let fdPread = (fd: FileDescriptor, offset: Int64, size: Number) => {
  * @returns `Ok(numBytes)` of the number of bytes written if successful or `Err(Exception)` otherwise
  */
 @unsafe
-provide let fdWrite = (fd: FileDescriptor, data: String) => {
+provide let fdWrite = (fd: FileDescriptor, data: Bytes) => {
   let fdArg = fd
   let fd = match (fd) { FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n }
 
@@ -624,7 +625,7 @@ provide let fdWrite = (fd: FileDescriptor, data: String) => {
  * @returns `Ok(numBytes)` of the number of bytes written if successful or `Err(exception)` otherwise
  */
 @unsafe
-provide let fdPwrite = (fd: FileDescriptor, data: String, offset: Int64) => {
+provide let fdPwrite = (fd: FileDescriptor, data: Bytes, offset: Int64) => {
   let fdArg = fd
   let offsetArg = offset
   let fd = match (fd) { FileDescriptor(n) => WasmI32.fromGrain(n) >> 1n }

--- a/stdlib/sys/file.md
+++ b/stdlib/sys/file.md
@@ -238,7 +238,7 @@ Returns:
 ### File.**fdRead**
 
 ```grain
-fdRead : (FileDescriptor, Number) -> Result<(String, Number), Exception>
+fdRead : (FileDescriptor, Number) -> Result<(Bytes, Number), Exception>
 ```
 
 Read from a file descriptor.
@@ -254,13 +254,13 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`Result<(String, Number), Exception>`|`Ok((contents, numBytes))` of bytes read and the number of bytes read if successful or `Err(exception)` otherwise|
+|`Result<(Bytes, Number), Exception>`|`Ok((contents, numBytes))` of bytes read and the number of bytes read if successful or `Err(exception)` otherwise|
 
 ### File.**fdPread**
 
 ```grain
 fdPread :
-  (FileDescriptor, Int64, Number) -> Result<(String, Number), Exception>
+  (FileDescriptor, Int64, Number) -> Result<(Bytes, Number), Exception>
 ```
 
 Read from a file descriptor without updating the file descriptor's offset.
@@ -277,12 +277,12 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`Result<(String, Number), Exception>`|`Ok((contents, numBytes))` of bytes read and the number of bytes read if successful or `Err(exception)` otherwise|
+|`Result<(Bytes, Number), Exception>`|`Ok((contents, numBytes))` of bytes read and the number of bytes read if successful or `Err(exception)` otherwise|
 
 ### File.**fdWrite**
 
 ```grain
-fdWrite : (FileDescriptor, String) -> Result<Number, Exception>
+fdWrite : (FileDescriptor, Bytes) -> Result<Number, Exception>
 ```
 
 Write to a file descriptor.
@@ -292,7 +292,7 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`fd`|`FileDescriptor`|The file descriptor to which data will be written|
-|`data`|`String`|The data to be written|
+|`data`|`Bytes`|The data to be written|
 
 Returns:
 
@@ -303,7 +303,7 @@ Returns:
 ### File.**fdPwrite**
 
 ```grain
-fdPwrite : (FileDescriptor, String, Int64) -> Result<Number, Exception>
+fdPwrite : (FileDescriptor, Bytes, Int64) -> Result<Number, Exception>
 ```
 
 Write to a file descriptor without updating the file descriptor's offset.
@@ -313,7 +313,7 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`fd`|`FileDescriptor`|The file descriptor to which data will be written|
-|`data`|`String`|The data to be written|
+|`data`|`Bytes`|The data to be written|
 |`offset`|`Int64`|The position within the file to begin writing|
 
 Returns:


### PR DESCRIPTION
These utilities previously operated on Strings, but this is not quite correct since files can contain any type of data, not just UTF8 encoded strings.