### PR TITLE
feat(compiler)!: Allocate closures only when necessary

### DIFF
--- a/compiler/src/codegen/comp_utils.re
+++ b/compiler/src/codegen/comp_utils.re
@@ -180,7 +180,7 @@ let write_universal_exports =
               );
             let function_call =
               switch (direct) {
-              | Direct(name) =>
+              | Direct({name}) =>
                 Expression.Call.make(
                   wasm_mod,
                   Hashtbl.find(exported_names, name),

--- a/compiler/src/codegen/compcore.re
+++ b/compiler/src/codegen/compcore.re
@@ -3821,6 +3821,7 @@ let compile_main = (wasm_mod, env, prog) => {
       name: Some(grain_main),
       args: [],
       return_type: [Types.Unmanaged(WasmI32)],
+      has_closure: false,
       body: prog.main_body,
       stack_size: prog.main_body_stack_size,
       attrs: [],

--- a/compiler/src/codegen/mashtree.re
+++ b/compiler/src/codegen/mashtree.re
@@ -499,6 +499,7 @@ type mash_function = {
   name: option(string),
   args: list(Types.allocation_type),
   return_type: list(Types.allocation_type),
+  has_closure: bool,
   body: block,
   stack_size,
   attrs: attributes,

--- a/compiler/src/middle_end/analyze_free_vars.re
+++ b/compiler/src/middle_end/analyze_free_vars.re
@@ -43,7 +43,7 @@ module FreeVarsArg: Anf_iterator.IterArgument = {
     push_free_vars(analyses) @@
     (
       switch (desc) {
-      | CLambda(_, args, (body, _)) =>
+      | CLambda(_, args, (body, _), _) =>
         Ident.Set.diff(
           anf_free_vars(body),
           Ident.Set.of_list(List.map(((arg, _)) => arg, args)),

--- a/compiler/src/middle_end/analyze_globals.re
+++ b/compiler/src/middle_end/analyze_globals.re
@@ -1,0 +1,37 @@
+open Anftree;
+open Anf_iterator;
+open Grain_typed;
+
+let global_vars = ref(Ident.Set.empty);
+
+let get_globals = () => global_vars^;
+
+module AnalyzeGlobalsArg: Anf_iterator.IterArgument = {
+  include Anf_iterator.DefaultIterArgument;
+
+  let leave_anf_expression = ({anf_desc: desc}) =>
+    switch (desc) {
+    | AELet(Global, _, _, binds, _) =>
+      List.iter(
+        ((id, _)) => {global_vars := Ident.Set.add(id, global_vars^)},
+        binds,
+      )
+    | _ => ()
+    };
+
+  let leave_anf_program = ({imports}) => {
+    List.iter(
+      ({imp_use_id}) => {
+        global_vars := Ident.Set.add(imp_use_id, global_vars^)
+      },
+      imports.specs,
+    );
+  };
+};
+
+module AnalyzeGlobalsIterator = Anf_iterator.MakeIter(AnalyzeGlobalsArg);
+
+let analyze = anfprog => {
+  global_vars := Ident.Set.empty;
+  AnalyzeGlobalsIterator.iter_anf_program(anfprog);
+};

--- a/compiler/src/middle_end/analyze_globals.rei
+++ b/compiler/src/middle_end/analyze_globals.rei
@@ -1,0 +1,3 @@
+let analyze: Analysis_pass.t;
+
+let get_globals: unit => Grain_typed.Ident.Set.t;

--- a/compiler/src/middle_end/analyze_tail_calls.re
+++ b/compiler/src/middle_end/analyze_tail_calls.re
@@ -39,7 +39,7 @@ let rec analyze_comp_expression =
     /* While this loop itself is not in tail position, we still want to analyze the body. */
     ignore @@ analyze_anf_expression(false, body);
     false;
-  | CLambda(_, args, (body, _)) =>
+  | CLambda(_, args, (body, _), _) =>
     /* While this lambda itself is not in tail position, we still want to analyze the body. */
     ignore @@ analyze_anf_expression(true, body);
     false;
@@ -107,7 +107,7 @@ and analyze_anf_expression =
     List.iter(
       ((_, {comp_desc, comp_analyses} as bind)) =>
         switch (comp_desc) {
-        | CLambda(_, args, (body, _)) =>
+        | CLambda(_, args, (body, _), _) =>
           if (analyze_anf_expression(true, body)) {
             push_tail_recursive(comp_analyses);
           }

--- a/compiler/src/middle_end/anf_helper.re
+++ b/compiler/src/middle_end/anf_helper.re
@@ -223,7 +223,7 @@ module Comp = {
       ~attributes?,
       ~allocation_type=Managed,
       ~env?,
-      CLambda(name, args, body),
+      CLambda(name, args, body, Uncomputed),
     );
   let bytes = (~loc=?, ~attributes=?, ~env=?, b) =>
     mk(~loc?, ~attributes?, ~allocation_type=Managed, ~env?, CBytes(b));

--- a/compiler/src/middle_end/anf_iterator.re
+++ b/compiler/src/middle_end/anf_iterator.re
@@ -99,7 +99,7 @@ module MakeIter = (Iter: IterArgument) => {
       iter_imm_expression(f);
       List.iter(iter_imm_expression, args);
     | CAppBuiltin(_, _, args) => List.iter(iter_imm_expression, args)
-    | CLambda(_, idents, (expr, _)) => iter_anf_expression(expr)
+    | CLambda(_, idents, (expr, _), _) => iter_anf_expression(expr)
     | CBytes(s) => ()
     | CString(s) => ()
     | CChar(c) => ()

--- a/compiler/src/middle_end/anf_mapper.re
+++ b/compiler/src/middle_end/anf_mapper.re
@@ -238,12 +238,16 @@ module MakeMap = (Iter: MapArgument) => {
       leave_with(
         CAppBuiltin(mod_, f, List.map(process_imm_expression, args)),
       )
-    | CLambda(name, idents, (expr, alloc_ty)) =>
+    | CLambda(name, idents, (expr, alloc_ty), closure_status) =>
       push_input(
         CompMarker(
           Lambda(
             expr =>
-              {...c, comp_desc: CLambda(name, idents, (expr, alloc_ty))},
+              {
+                ...c,
+                comp_desc:
+                  CLambda(name, idents, (expr, alloc_ty), closure_status),
+              },
           ),
         ),
       );

--- a/compiler/src/middle_end/anftree.re
+++ b/compiler/src/middle_end/anftree.re
@@ -320,6 +320,12 @@ type comp_expression = {
 }
 
 [@deriving sexp]
+and closure_status =
+  | Uncomputed
+  | Precomputed(list(Ident.t))
+  | Unnecessary
+
+[@deriving sexp]
 and comp_expression_desc =
   | CImmExpr(imm_expression)
   | CPrim0(prim0)
@@ -357,6 +363,7 @@ and comp_expression_desc =
       option(string),
       list((Ident.t, allocation_type)),
       (anf_expression, allocation_type),
+      closure_status,
     )
   | CBytes(bytes)
   | CString(string)
@@ -396,7 +403,11 @@ and anf_expression_desc =
 
 [@deriving sexp]
 type import_shape =
-  | FunctionShape(list(allocation_type), list(allocation_type))
+  | FunctionShape({
+      args: list(allocation_type),
+      returns: list(allocation_type),
+      has_closure: bool,
+    })
   | GlobalShape(allocation_type);
 
 [@deriving sexp]

--- a/compiler/src/middle_end/anftree.rei
+++ b/compiler/src/middle_end/anftree.rei
@@ -300,6 +300,12 @@ type comp_expression = {
 }
 
 [@deriving sexp]
+and closure_status =
+  | Uncomputed
+  | Precomputed(list(Ident.t))
+  | Unnecessary
+
+[@deriving sexp]
 and comp_expression_desc =
   | CImmExpr(imm_expression)
   | CPrim0(prim0)
@@ -337,6 +343,7 @@ and comp_expression_desc =
       option(string),
       list((Ident.t, allocation_type)),
       (anf_expression, allocation_type),
+      closure_status,
     )
   | CBytes(bytes)
   | CString(string)
@@ -375,7 +382,11 @@ and anf_expression_desc =
 
 [@deriving sexp]
 type import_shape =
-  | FunctionShape(list(allocation_type), list(allocation_type))
+  | FunctionShape({
+      args: list(allocation_type),
+      returns: list(allocation_type),
+      has_closure: bool,
+    })
   | GlobalShape(allocation_type);
 
 [@deriving sexp]

--- a/compiler/src/middle_end/linearize.re
+++ b/compiler/src/middle_end/linearize.re
@@ -70,19 +70,19 @@ let lookup_symbol = (~env, ~allocation_type, ~repr, path) => {
         Path_tbl.add(include_map, path, fresh);
         let shape =
           switch (repr) {
-          | ReprFunction(args, rets, Direct(_)) =>
+          | ReprFunction(args, rets, Direct({closure: has_closure})) =>
             // Add closure argument
             let args = [
               Managed,
               ...List.map(allocation_type_of_wasm_repr, args),
             ];
             // Add return type for functions that return void
-            let rets =
+            let returns =
               switch (rets) {
               | [] => [Unmanaged(WasmI32)]
               | _ => List.map(allocation_type_of_wasm_repr, rets)
               };
-            FunctionShape(args, rets);
+            FunctionShape({args, returns, has_closure});
           | _ => GlobalShape(allocation_type)
           };
         value_imports :=
@@ -1506,7 +1506,7 @@ let rec transl_anf_statement =
             desc.tvd_id,
             desc.tvd_mod.txt,
             external_name.txt,
-            FunctionShape(argsty, retty),
+            FunctionShape({args: argsty, returns: retty, has_closure: true}),
           ),
         ],
       );

--- a/compiler/src/middle_end/optimize.re
+++ b/compiler/src/middle_end/optimize.re
@@ -1,6 +1,8 @@
 open Anftree;
 
 let analysis_passes = [
+  Analyze_globals.analyze,
+  Analyze_function_calls.analyze,
   Analyze_manual_memory_management.analyze,
   Analyze_purity.analyze,
   Analyze_tail_calls.analyze,

--- a/compiler/src/middle_end/optimize_closures.re
+++ b/compiler/src/middle_end/optimize_closures.re
@@ -1,0 +1,74 @@
+open Anftree;
+open Grain_typed;
+
+module ClosuresArg: Anf_mapper.MapArgument = {
+  include Anf_mapper.DefaultMapArgument;
+
+  let leave_anf_expression = ({anf_desc: desc} as a) =>
+    switch (desc) {
+    | AELet(_, _, Mutable, _, _)
+    | AESeq(_)
+    | AEComp(_) => a
+    | AELet(g, r, m, binds, b) =>
+      let binds =
+        List.map(
+          ((id, value)) => {
+            switch (value.comp_desc) {
+            | CLambda(name, args, (body, body_ty), Uncomputed) =>
+              if (!Analyze_function_calls.has_indirect_call(id)) {
+                let used_var_set =
+                  Ident.Set.remove(
+                    id,
+                    Analyze_free_vars.anf_free_vars(body),
+                  );
+                let arg_vars = List.map(((arg, _)) => arg, args);
+                let accessible_var_set =
+                  Ident.Set.union(
+                    Analyze_globals.get_globals(),
+                    Ident.Set.of_list(arg_vars),
+                  );
+                let free_var_set =
+                  Ident.Set.diff(used_var_set, accessible_var_set);
+                if (Ident.Set.is_empty(free_var_set)) {
+                  (
+                    id,
+                    {
+                      ...value,
+                      comp_desc:
+                        CLambda(name, args, (body, body_ty), Unnecessary),
+                    },
+                  );
+                } else {
+                  (
+                    id,
+                    {
+                      ...value,
+                      comp_desc:
+                        CLambda(
+                          name,
+                          args,
+                          (body, body_ty),
+                          Precomputed(
+                            List.of_seq(Ident.Set.to_seq(free_var_set)),
+                          ),
+                        ),
+                    },
+                  );
+                };
+              } else {
+                (id, value);
+              }
+            | _ => (id, value)
+            }
+          },
+          binds,
+        );
+      {...a, anf_desc: AELet(g, r, m, binds, b)};
+    };
+};
+
+module ClosuresMapper = Anf_mapper.MakeMap(ClosuresArg);
+
+let optimize = anfprog => {
+  ClosuresMapper.map_anf_program(anfprog);
+};

--- a/compiler/src/typed/env.re
+++ b/compiler/src/typed/env.re
@@ -1684,7 +1684,7 @@ and components_of_module_maker = ((env, sub, path, mty)) =>
                   ReprFunction(
                     List.map(_ => WasmI32, args),
                     [WasmI32],
-                    Direct(Ident.unique_name(id)),
+                    Direct({name: Ident.unique_name(id), closure: false}),
                   )
                 };
               let get_path = name =>
@@ -1747,7 +1747,7 @@ and components_of_module_maker = ((env, sub, path, mty)) =>
               ReprFunction(
                 List.map(_ => WasmI32, args),
                 [WasmI32],
-                Direct(Ident.unique_name(id)),
+                Direct({name: Ident.unique_name(id), closure: false}),
               )
             };
           let get_path = name =>

--- a/compiler/src/typed/types.re
+++ b/compiler/src/typed/types.re
@@ -90,7 +90,10 @@ type val_repr =
 
 [@deriving (sexp, yojson)]
 and func_direct =
-  | Direct(string)
+  | Direct({
+      name: string,
+      closure: bool,
+    })
   | Indirect
   | Unknown;
 

--- a/compiler/test/__snapshots__/basic_functionality.52ca8e0e.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.52ca8e0e.0.snapshot
@@ -140,37 +140,14 @@ basic functionality › func_shadow
   (local $6 i32)
   (local $7 i32)
   (return
-   (block $cleanup_locals.18 (result i32)
+   (block $cleanup_locals.16 (result i32)
     (local.set $0
-     (block $compile_block.17 (result i32)
-      (block $compile_store.9
+     (block $compile_block.15 (result i32)
+      (block $compile_store.8
        (global.set $foo_1113
         (tuple.extract 0
          (tuple.make
-          (block $allocate_closure.7 (result i32)
-           (i32.store
-            (local.tee $0
-             (call $malloc_0
-              (global.get $GRAIN$EXPORT$malloc_0)
-              (i32.const 16)
-             )
-            )
-            (i32.const 6)
-           )
-           (i32.store offset=4
-            (local.get $0)
-            (i32.const 1)
-           )
-           (i32.store offset=8
-            (local.get $0)
-            (i32.const -1)
-           )
-           (i32.store offset=12
-            (local.get $0)
-            (i32.const 0)
-           )
-           (local.get $0)
-          )
+          (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (global.get $foo_1113)
@@ -178,13 +155,10 @@ basic functionality › func_shadow
          )
         )
        )
-       (block $do_backpatches.8
-        (local.set $0
-         (global.get $foo_1113)
-        )
+       (block $do_backpatches.7
        )
       )
-      (block $compile_store.11
+      (block $compile_store.10
        (local.set $6
         (tuple.extract 0
          (tuple.make
@@ -201,7 +175,7 @@ basic functionality › func_shadow
          )
         )
        )
-       (block $do_backpatches.10
+       (block $do_backpatches.9
        )
       )
       (drop
@@ -216,34 +190,11 @@ basic functionality › func_shadow
         )
        )
       )
-      (block $compile_store.14
+      (block $compile_store.12
        (global.set $foo_1115
         (tuple.extract 0
          (tuple.make
-          (block $allocate_closure.12 (result i32)
-           (i32.store
-            (local.tee $0
-             (call $malloc_0
-              (global.get $GRAIN$EXPORT$malloc_0)
-              (i32.const 16)
-             )
-            )
-            (i32.const 6)
-           )
-           (i32.store offset=4
-            (local.get $0)
-            (i32.const 1)
-           )
-           (i32.store offset=8
-            (local.get $0)
-            (i32.const -1)
-           )
-           (i32.store offset=12
-            (local.get $0)
-            (i32.const 0)
-           )
-           (local.get $0)
-          )
+          (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (global.get $foo_1115)
@@ -251,13 +202,10 @@ basic functionality › func_shadow
          )
         )
        )
-       (block $do_backpatches.13
-        (local.set $0
-         (global.get $foo_1115)
-        )
+       (block $do_backpatches.11
        )
       )
-      (block $compile_store.16
+      (block $compile_store.14
        (local.set $7
         (tuple.extract 0
          (tuple.make
@@ -274,7 +222,7 @@ basic functionality › func_shadow
          )
         )
        )
-       (block $do_backpatches.15
+       (block $do_backpatches.13
        )
       )
       (call $print_1118

--- a/compiler/test/__snapshots__/basic_functionality.61c58118.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.61c58118.0.snapshot
@@ -1,17 +1,15 @@
 basic functionality › block_no_expression
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
  (import \"_genv\" \"mem\" (memory $0 0))
  (import \"_genv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_genv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_genv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
  (global $f_1113 (mut i32) (i32.const 0))
@@ -63,37 +61,14 @@ basic functionality › block_no_expression
   (local $4 f32)
   (local $5 f64)
   (return
-   (block $cleanup_locals.7 (result i32)
+   (block $cleanup_locals.6 (result i32)
     (local.set $0
-     (block $compile_block.6 (result i32)
-      (block $compile_store.5
+     (block $compile_block.5 (result i32)
+      (block $compile_store.4
        (global.set $f_1113
         (tuple.extract 0
          (tuple.make
-          (block $allocate_closure.3 (result i32)
-           (i32.store
-            (local.tee $0
-             (call $malloc_0
-              (global.get $GRAIN$EXPORT$malloc_0)
-              (i32.const 16)
-             )
-            )
-            (i32.const 6)
-           )
-           (i32.store offset=4
-            (local.get $0)
-            (i32.const 1)
-           )
-           (i32.store offset=8
-            (local.get $0)
-            (i32.const -1)
-           )
-           (i32.store offset=12
-            (local.get $0)
-            (i32.const 0)
-           )
-           (local.get $0)
-          )
+          (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (global.get $f_1113)
@@ -101,10 +76,7 @@ basic functionality › block_no_expression
          )
         )
        )
-       (block $do_backpatches.4
-        (local.set $0
-         (global.get $f_1113)
-        )
+       (block $do_backpatches.3
        )
       )
       (call $f_1113

--- a/compiler/test/__snapshots__/basic_functionality.711a4824.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.711a4824.0.snapshot
@@ -33,37 +33,14 @@ basic functionality › pattern_match_unsafe_wasm
   (local $6 f64)
   (local $7 i32)
   (return
-   (block $cleanup_locals.5 (result i32)
+   (block $cleanup_locals.4 (result i32)
     (local.set $1
-     (block $compile_block.4 (result i32)
-      (block $compile_store.3
+     (block $compile_block.3 (result i32)
+      (block $compile_store.2
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (block $allocate_closure.1 (result i32)
-           (i32.store
-            (local.tee $1
-             (call $malloc_0
-              (global.get $GRAIN$EXPORT$malloc_0)
-              (i32.const 16)
-             )
-            )
-            (i32.const 6)
-           )
-           (i32.store offset=4
-            (local.get $1)
-            (i32.const 2)
-           )
-           (i32.store offset=8
-            (local.get $1)
-            (i32.const -1)
-           )
-           (i32.store offset=12
-            (local.get $1)
-            (i32.const 0)
-           )
-           (local.get $1)
-          )
+          (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (local.get $7)
@@ -71,10 +48,7 @@ basic functionality › pattern_match_unsafe_wasm
          )
         )
        )
-       (block $do_backpatches.2
-        (local.set $1
-         (local.get $7)
-        )
+       (block $do_backpatches.1
        )
       )
       (drop
@@ -153,10 +127,10 @@ basic functionality › pattern_match_unsafe_wasm
   (local $13 i32)
   (local $14 i32)
   (return
-   (block $cleanup_locals.45 (result i32)
+   (block $cleanup_locals.44 (result i32)
     (local.set $2
-     (block $compile_block.44 (result i32)
-      (block $compile_store.7
+     (block $compile_block.43 (result i32)
+      (block $compile_store.6
        (local.set $9
         (i32.or
          (i32.shl
@@ -169,21 +143,21 @@ basic functionality › pattern_match_unsafe_wasm
          (i32.const 2147483646)
         )
        )
-       (block $do_backpatches.6
+       (block $do_backpatches.5
        )
       )
-      (block $compile_store.31
+      (block $compile_store.30
        (local.set $10
         (if (result i32)
          (i32.shr_u
           (local.get $9)
           (i32.const 31)
          )
-         (block $compile_block.8 (result i32)
+         (block $compile_block.7 (result i32)
           (i32.const 1)
          )
-         (block $compile_block.29 (result i32)
-          (block $compile_store.10
+         (block $compile_block.28 (result i32)
+          (block $compile_store.9
            (local.set $10
             (i32.or
              (i32.shl
@@ -196,7 +170,7 @@ basic functionality › pattern_match_unsafe_wasm
              (i32.const 2147483646)
             )
            )
-           (block $do_backpatches.9
+           (block $do_backpatches.8
            )
           )
           (if (result i32)
@@ -204,11 +178,11 @@ basic functionality › pattern_match_unsafe_wasm
             (local.get $10)
             (i32.const 31)
            )
-           (block $compile_block.11 (result i32)
+           (block $compile_block.10 (result i32)
             (i32.const 3)
            )
-           (block $compile_block.28 (result i32)
-            (block $compile_store.13
+           (block $compile_block.27 (result i32)
+            (block $compile_store.12
              (local.set $11
               (i32.or
                (i32.shl
@@ -221,7 +195,7 @@ basic functionality › pattern_match_unsafe_wasm
                (i32.const 2147483646)
               )
              )
-             (block $do_backpatches.12
+             (block $do_backpatches.11
              )
             )
             (if (result i32)
@@ -229,11 +203,11 @@ basic functionality › pattern_match_unsafe_wasm
               (local.get $11)
               (i32.const 31)
              )
-             (block $compile_block.14 (result i32)
+             (block $compile_block.13 (result i32)
               (i32.const 5)
              )
-             (block $compile_block.27 (result i32)
-              (block $compile_store.16
+             (block $compile_block.26 (result i32)
+              (block $compile_store.15
                (local.set $12
                 (i32.or
                  (i32.shl
@@ -246,7 +220,7 @@ basic functionality › pattern_match_unsafe_wasm
                  (i32.const 2147483646)
                 )
                )
-               (block $do_backpatches.15
+               (block $do_backpatches.14
                )
               )
               (if (result i32)
@@ -254,11 +228,11 @@ basic functionality › pattern_match_unsafe_wasm
                 (local.get $12)
                 (i32.const 31)
                )
-               (block $compile_block.17 (result i32)
+               (block $compile_block.16 (result i32)
                 (i32.const 7)
                )
-               (block $compile_block.26 (result i32)
-                (block $compile_store.19
+               (block $compile_block.25 (result i32)
+                (block $compile_store.18
                  (local.set $13
                   (i32.or
                    (i32.shl
@@ -271,7 +245,7 @@ basic functionality › pattern_match_unsafe_wasm
                    (i32.const 2147483646)
                   )
                  )
-                 (block $do_backpatches.18
+                 (block $do_backpatches.17
                  )
                 )
                 (if (result i32)
@@ -279,11 +253,11 @@ basic functionality › pattern_match_unsafe_wasm
                   (local.get $13)
                   (i32.const 31)
                  )
-                 (block $compile_block.20 (result i32)
+                 (block $compile_block.19 (result i32)
                   (i32.const 9)
                  )
-                 (block $compile_block.25 (result i32)
-                  (block $compile_store.22
+                 (block $compile_block.24 (result i32)
+                  (block $compile_store.21
                    (local.set $14
                     (i32.or
                      (i32.shl
@@ -296,7 +270,7 @@ basic functionality › pattern_match_unsafe_wasm
                      (i32.const 2147483646)
                     )
                    )
-                   (block $do_backpatches.21
+                   (block $do_backpatches.20
                    )
                   )
                   (if (result i32)
@@ -304,10 +278,10 @@ basic functionality › pattern_match_unsafe_wasm
                     (local.get $14)
                     (i32.const 31)
                    )
-                   (block $compile_block.23 (result i32)
+                   (block $compile_block.22 (result i32)
                     (i32.const 11)
                    )
-                   (block $compile_block.24 (result i32)
+                   (block $compile_block.23 (result i32)
                     (i32.const 13)
                    )
                   )
@@ -322,28 +296,28 @@ basic functionality › pattern_match_unsafe_wasm
          )
         )
        )
-       (block $do_backpatches.30
+       (block $do_backpatches.29
        )
       )
-      (block $switch.32_outer (result i32)
-       (block $switch.32_branch_0 (result i32)
+      (block $switch.31_outer (result i32)
+       (block $switch.31_branch_0 (result i32)
         (drop
-         (block $switch.32_branch_1 (result i32)
+         (block $switch.31_branch_1 (result i32)
           (drop
-           (block $switch.32_branch_2 (result i32)
+           (block $switch.31_branch_2 (result i32)
             (drop
-             (block $switch.32_branch_3 (result i32)
+             (block $switch.31_branch_3 (result i32)
               (drop
-               (block $switch.32_branch_4 (result i32)
+               (block $switch.31_branch_4 (result i32)
                 (drop
-                 (block $switch.32_branch_5 (result i32)
+                 (block $switch.31_branch_5 (result i32)
                   (drop
-                   (block $switch.32_branch_6 (result i32)
+                   (block $switch.31_branch_6 (result i32)
                     (drop
-                     (block $switch.32_branch_7 (result i32)
+                     (block $switch.31_branch_7 (result i32)
                       (drop
-                       (block $switch.32_default (result i32)
-                        (br_table $switch.32_branch_1 $switch.32_branch_2 $switch.32_branch_3 $switch.32_branch_4 $switch.32_branch_5 $switch.32_branch_6 $switch.32_branch_7 $switch.32_default $switch.32_default
+                       (block $switch.31_default (result i32)
+                        (br_table $switch.31_branch_1 $switch.31_branch_2 $switch.31_branch_3 $switch.31_branch_4 $switch.31_branch_5 $switch.31_branch_6 $switch.31_branch_7 $switch.31_default $switch.31_default
                          (i32.const 0)
                          (i32.shr_s
                           (local.get $10)
@@ -352,20 +326,20 @@ basic functionality › pattern_match_unsafe_wasm
                         )
                        )
                       )
-                      (br $switch.32_outer
-                       (block $compile_block.43 (result i32)
+                      (br $switch.31_outer
+                       (block $compile_block.42 (result i32)
                         (unreachable)
                        )
                       )
                      )
                     )
-                    (br $switch.32_outer
-                     (block $compile_block.42 (result i32)
-                      (block $compile_store.41
+                    (br $switch.31_outer
+                     (block $compile_block.41 (result i32)
+                      (block $compile_store.40
                        (local.set $8
                         (tuple.extract 0
                          (tuple.make
-                          (block $allocate_string.39 (result i32)
+                          (block $allocate_string.38 (result i32)
                            (i32.store
                             (local.tee $2
                              (call $malloc_0
@@ -392,7 +366,7 @@ basic functionality › pattern_match_unsafe_wasm
                          )
                         )
                        )
-                       (block $do_backpatches.40
+                       (block $do_backpatches.39
                        )
                       )
                       (call $print_1125
@@ -409,8 +383,8 @@ basic functionality › pattern_match_unsafe_wasm
                     )
                    )
                   )
-                  (br $switch.32_outer
-                   (block $compile_block.38 (result i32)
+                  (br $switch.31_outer
+                   (block $compile_block.37 (result i32)
                     (call $print_1125
                      (call $incRef_0
                       (global.get $GRAIN$EXPORT$incRef_0)
@@ -422,8 +396,8 @@ basic functionality › pattern_match_unsafe_wasm
                   )
                  )
                 )
-                (br $switch.32_outer
-                 (block $compile_block.37 (result i32)
+                (br $switch.31_outer
+                 (block $compile_block.36 (result i32)
                   (call $print_1125
                    (call $incRef_0
                     (global.get $GRAIN$EXPORT$incRef_0)
@@ -435,8 +409,8 @@ basic functionality › pattern_match_unsafe_wasm
                 )
                )
               )
-              (br $switch.32_outer
-               (block $compile_block.36 (result i32)
+              (br $switch.31_outer
+               (block $compile_block.35 (result i32)
                 (call $print_1125
                  (call $incRef_0
                   (global.get $GRAIN$EXPORT$incRef_0)
@@ -448,8 +422,8 @@ basic functionality › pattern_match_unsafe_wasm
               )
              )
             )
-            (br $switch.32_outer
-             (block $compile_block.35 (result i32)
+            (br $switch.31_outer
+             (block $compile_block.34 (result i32)
               (call $print_1125
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
@@ -461,8 +435,8 @@ basic functionality › pattern_match_unsafe_wasm
             )
            )
           )
-          (br $switch.32_outer
-           (block $compile_block.34 (result i32)
+          (br $switch.31_outer
+           (block $compile_block.33 (result i32)
             (call $print_1125
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
@@ -474,8 +448,8 @@ basic functionality › pattern_match_unsafe_wasm
           )
          )
         )
-        (br $switch.32_outer
-         (block $compile_block.33 (result i32)
+        (br $switch.31_outer
+         (block $compile_block.32 (result i32)
           (call $print_1125
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
@@ -522,37 +496,14 @@ basic functionality › pattern_match_unsafe_wasm
   (local $4 f32)
   (local $5 f64)
   (return
-   (block $cleanup_locals.50 (result i32)
+   (block $cleanup_locals.48 (result i32)
     (local.set $0
-     (block $compile_block.49 (result i32)
-      (block $compile_store.48
+     (block $compile_block.47 (result i32)
+      (block $compile_store.46
        (global.set $test_1113
         (tuple.extract 0
          (tuple.make
-          (block $allocate_closure.46 (result i32)
-           (i32.store
-            (local.tee $0
-             (call $malloc_0
-              (global.get $GRAIN$EXPORT$malloc_0)
-              (i32.const 16)
-             )
-            )
-            (i32.const 6)
-           )
-           (i32.store offset=4
-            (local.get $0)
-            (i32.const 1)
-           )
-           (i32.store offset=8
-            (local.get $0)
-            (i32.const -1)
-           )
-           (i32.store offset=12
-            (local.get $0)
-            (i32.const 0)
-           )
-           (local.get $0)
-          )
+          (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (global.get $test_1113)
@@ -560,10 +511,7 @@ basic functionality › pattern_match_unsafe_wasm
          )
         )
        )
-       (block $do_backpatches.47
-        (local.set $0
-         (global.get $test_1113)
-        )
+       (block $do_backpatches.45
        )
       )
       (call $test_1113

--- a/compiler/test/__snapshots__/basic_functionality.fe88cb04.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.fe88cb04.0.snapshot
@@ -246,37 +246,14 @@ basic functionality › func_shadow_and_indirect_call
   (local $7 i32)
   (local $8 i32)
   (return
-   (block $cleanup_locals.32 (result i32)
+   (block $cleanup_locals.29 (result i32)
     (local.set $0
-     (block $compile_block.31 (result i32)
-      (block $compile_store.15
+     (block $compile_block.28 (result i32)
+      (block $compile_store.14
        (global.set $foo_1113
         (tuple.extract 0
          (tuple.make
-          (block $allocate_closure.13 (result i32)
-           (i32.store
-            (local.tee $0
-             (call $malloc_0
-              (global.get $GRAIN$EXPORT$malloc_0)
-              (i32.const 16)
-             )
-            )
-            (i32.const 6)
-           )
-           (i32.store offset=4
-            (local.get $0)
-            (i32.const 1)
-           )
-           (i32.store offset=8
-            (local.get $0)
-            (i32.const -1)
-           )
-           (i32.store offset=12
-            (local.get $0)
-            (i32.const 0)
-           )
-           (local.get $0)
-          )
+          (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (global.get $foo_1113)
@@ -284,13 +261,10 @@ basic functionality › func_shadow_and_indirect_call
          )
         )
        )
-       (block $do_backpatches.14
-        (local.set $0
-         (global.get $foo_1113)
-        )
+       (block $do_backpatches.13
        )
       )
-      (block $compile_store.17
+      (block $compile_store.16
        (local.set $6
         (tuple.extract 0
          (tuple.make
@@ -307,7 +281,7 @@ basic functionality › func_shadow_and_indirect_call
          )
         )
        )
-       (block $do_backpatches.16
+       (block $do_backpatches.15
        )
       )
       (drop
@@ -322,34 +296,11 @@ basic functionality › func_shadow_and_indirect_call
         )
        )
       )
-      (block $compile_store.20
+      (block $compile_store.18
        (global.set $foo_1115
         (tuple.extract 0
          (tuple.make
-          (block $allocate_closure.18 (result i32)
-           (i32.store
-            (local.tee $0
-             (call $malloc_0
-              (global.get $GRAIN$EXPORT$malloc_0)
-              (i32.const 16)
-             )
-            )
-            (i32.const 6)
-           )
-           (i32.store offset=4
-            (local.get $0)
-            (i32.const 1)
-           )
-           (i32.store offset=8
-            (local.get $0)
-            (i32.const -1)
-           )
-           (i32.store offset=12
-            (local.get $0)
-            (i32.const 0)
-           )
-           (local.get $0)
-          )
+          (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (global.get $foo_1115)
@@ -357,13 +308,10 @@ basic functionality › func_shadow_and_indirect_call
          )
         )
        )
-       (block $do_backpatches.19
-        (local.set $0
-         (global.get $foo_1115)
-        )
+       (block $do_backpatches.17
        )
       )
-      (block $compile_store.22
+      (block $compile_store.20
        (local.set $7
         (tuple.extract 0
          (tuple.make
@@ -380,7 +328,7 @@ basic functionality › func_shadow_and_indirect_call
          )
         )
        )
-       (block $do_backpatches.21
+       (block $do_backpatches.19
        )
       )
       (drop
@@ -395,34 +343,11 @@ basic functionality › func_shadow_and_indirect_call
         )
        )
       )
-      (block $compile_store.25
+      (block $compile_store.22
        (global.set $foo_1117
         (tuple.extract 0
          (tuple.make
-          (block $allocate_closure.23 (result i32)
-           (i32.store
-            (local.tee $0
-             (call $malloc_0
-              (global.get $GRAIN$EXPORT$malloc_0)
-              (i32.const 16)
-             )
-            )
-            (i32.const 6)
-           )
-           (i32.store offset=4
-            (local.get $0)
-            (i32.const 1)
-           )
-           (i32.store offset=8
-            (local.get $0)
-            (i32.const -1)
-           )
-           (i32.store offset=12
-            (local.get $0)
-            (i32.const 0)
-           )
-           (local.get $0)
-          )
+          (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (global.get $foo_1117)
@@ -430,13 +355,10 @@ basic functionality › func_shadow_and_indirect_call
          )
         )
        )
-       (block $do_backpatches.24
-        (local.set $0
-         (global.get $foo_1117)
-        )
+       (block $do_backpatches.21
        )
       )
-      (block $compile_store.27
+      (block $compile_store.24
        (global.set $foo_1119
         (tuple.extract 0
          (tuple.make
@@ -453,14 +375,14 @@ basic functionality › func_shadow_and_indirect_call
          )
         )
        )
-       (block $do_backpatches.26
+       (block $do_backpatches.23
        )
       )
-      (block $compile_store.30
+      (block $compile_store.27
        (local.set $8
         (tuple.extract 0
          (tuple.make
-          (block $call_lambda.28 (result i32)
+          (block $call_lambda.25 (result i32)
            (local.set $0
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)
@@ -481,7 +403,7 @@ basic functionality › func_shadow_and_indirect_call
          )
         )
        )
-       (block $do_backpatches.29
+       (block $do_backpatches.26
        )
       )
       (call $print_1121

--- a/compiler/test/__snapshots__/early_return.1183a893.0.snapshot
+++ b/compiler/test/__snapshots__/early_return.1183a893.0.snapshot
@@ -1,7 +1,7 @@
 early return › early_return3
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
@@ -9,11 +9,9 @@ early return › early_return3
  (import \"_genv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_genv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_genv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1118 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1118 (param i32 i32 i32) (result i32)))
@@ -129,37 +127,14 @@ early return › early_return3
   (local $4 f32)
   (local $5 f64)
   (return
-   (block $cleanup_locals.13 (result i32)
+   (block $cleanup_locals.12 (result i32)
     (local.set $0
-     (block $compile_block.12 (result i32)
-      (block $compile_store.11
+     (block $compile_block.11 (result i32)
+      (block $compile_store.10
        (global.set $foo_1113
         (tuple.extract 0
          (tuple.make
-          (block $allocate_closure.9 (result i32)
-           (i32.store
-            (local.tee $0
-             (call $malloc_0
-              (global.get $GRAIN$EXPORT$malloc_0)
-              (i32.const 16)
-             )
-            )
-            (i32.const 6)
-           )
-           (i32.store offset=4
-            (local.get $0)
-            (i32.const 1)
-           )
-           (i32.store offset=8
-            (local.get $0)
-            (i32.const -1)
-           )
-           (i32.store offset=12
-            (local.get $0)
-            (i32.const 0)
-           )
-           (local.get $0)
-          )
+          (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (global.get $foo_1113)
@@ -167,10 +142,7 @@ early return › early_return3
          )
         )
        )
-       (block $do_backpatches.10
-        (local.set $0
-         (global.get $foo_1113)
-        )
+       (block $do_backpatches.9
        )
       )
       (i32.const 1879048190)
@@ -185,5 +157,5 @@ early return › early_return3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 843
+ ;; custom section \"cmi\", size 868
 )

--- a/compiler/test/__snapshots__/functions.06134c8a.0.snapshot
+++ b/compiler/test/__snapshots__/functions.06134c8a.0.snapshot
@@ -1,17 +1,15 @@
 functions › dup_func
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
  (import \"_genv\" \"mem\" (memory $0 0))
  (import \"_genv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_genv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_genv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
  (global $foo_1117 (mut i32) (i32.const 0))
@@ -68,37 +66,14 @@ functions › dup_func
   (local $4 f32)
   (local $5 f64)
   (return
-   (block $cleanup_locals.7 (result i32)
+   (block $cleanup_locals.6 (result i32)
     (local.set $0
-     (block $compile_block.6 (result i32)
-      (block $compile_store.5
+     (block $compile_block.5 (result i32)
+      (block $compile_store.4
        (global.set $foo_1117
         (tuple.extract 0
          (tuple.make
-          (block $allocate_closure.3 (result i32)
-           (i32.store
-            (local.tee $0
-             (call $malloc_0
-              (global.get $GRAIN$EXPORT$malloc_0)
-              (i32.const 16)
-             )
-            )
-            (i32.const 6)
-           )
-           (i32.store offset=4
-            (local.get $0)
-            (i32.const 1)
-           )
-           (i32.store offset=8
-            (local.get $0)
-            (i32.const -1)
-           )
-           (i32.store offset=12
-            (local.get $0)
-            (i32.const 0)
-           )
-           (local.get $0)
-          )
+          (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (global.get $foo_1117)
@@ -106,10 +81,7 @@ functions › dup_func
          )
         )
        )
-       (block $do_backpatches.4
-        (local.set $0
-         (global.get $foo_1117)
-        )
+       (block $do_backpatches.3
        )
       )
       (call $foo_1117

--- a/compiler/test/__snapshots__/functions.14922a92.0.snapshot
+++ b/compiler/test/__snapshots__/functions.14922a92.0.snapshot
@@ -8,11 +8,9 @@ functions › shorthand_4
  (import \"_genv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_genv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_genv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1115 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1115 (param i32 i32 i32) (result i32)))
@@ -86,37 +84,14 @@ functions › shorthand_4
   (local $4 f32)
   (local $5 f64)
   (return
-   (block $cleanup_locals.7 (result i32)
+   (block $cleanup_locals.6 (result i32)
     (local.set $0
-     (block $compile_block.6 (result i32)
-      (block $compile_store.5
+     (block $compile_block.5 (result i32)
+      (block $compile_store.4
        (global.set $foo_1113
         (tuple.extract 0
          (tuple.make
-          (block $allocate_closure.3 (result i32)
-           (i32.store
-            (local.tee $0
-             (call $malloc_0
-              (global.get $GRAIN$EXPORT$malloc_0)
-              (i32.const 16)
-             )
-            )
-            (i32.const 6)
-           )
-           (i32.store offset=4
-            (local.get $0)
-            (i32.const 2)
-           )
-           (i32.store offset=8
-            (local.get $0)
-            (i32.const -1)
-           )
-           (i32.store offset=12
-            (local.get $0)
-            (i32.const 0)
-           )
-           (local.get $0)
-          )
+          (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (global.get $foo_1113)
@@ -124,10 +99,7 @@ functions › shorthand_4
          )
         )
        )
-       (block $do_backpatches.4
-        (local.set $0
-         (global.get $foo_1113)
-        )
+       (block $do_backpatches.3
        )
       )
       (call $foo_1113

--- a/compiler/test/__snapshots__/functions.1be5ecd5.0.snapshot
+++ b/compiler/test/__snapshots__/functions.1be5ecd5.0.snapshot
@@ -7,10 +7,8 @@ functions › shorthand_1
  (import \"_genv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_genv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_genv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
  (global $foo_1113 (mut i32) (i32.const 0))
@@ -76,37 +74,14 @@ functions › shorthand_1
   (local $4 f32)
   (local $5 f64)
   (return
-   (block $cleanup_locals.7 (result i32)
+   (block $cleanup_locals.6 (result i32)
     (local.set $0
-     (block $compile_block.6 (result i32)
-      (block $compile_store.5
+     (block $compile_block.5 (result i32)
+      (block $compile_store.4
        (global.set $foo_1113
         (tuple.extract 0
          (tuple.make
-          (block $allocate_closure.3 (result i32)
-           (i32.store
-            (local.tee $0
-             (call $malloc_0
-              (global.get $GRAIN$EXPORT$malloc_0)
-              (i32.const 16)
-             )
-            )
-            (i32.const 6)
-           )
-           (i32.store offset=4
-            (local.get $0)
-            (i32.const 2)
-           )
-           (i32.store offset=8
-            (local.get $0)
-            (i32.const -1)
-           )
-           (i32.store offset=12
-            (local.get $0)
-            (i32.const 0)
-           )
-           (local.get $0)
-          )
+          (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (global.get $foo_1113)
@@ -114,10 +89,7 @@ functions › shorthand_1
          )
         )
        )
-       (block $do_backpatches.4
-        (local.set $0
-         (global.get $foo_1113)
-        )
+       (block $do_backpatches.3
        )
       )
       (call $foo_1113

--- a/compiler/test/__snapshots__/functions.23afd9c9.0.snapshot
+++ b/compiler/test/__snapshots__/functions.23afd9c9.0.snapshot
@@ -557,37 +557,14 @@ functions › lam_destructure_5
   (local $7 i32)
   (local $8 i32)
   (return
-   (block $cleanup_locals.44 (result i32)
+   (block $cleanup_locals.43 (result i32)
     (local.set $0
-     (block $compile_block.43 (result i32)
-      (block $compile_store.36
+     (block $compile_block.42 (result i32)
+      (block $compile_store.35
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (block $allocate_closure.34 (result i32)
-           (i32.store
-            (local.tee $0
-             (call $malloc_0
-              (global.get $GRAIN$EXPORT$malloc_0)
-              (i32.const 16)
-             )
-            )
-            (i32.const 6)
-           )
-           (i32.store offset=4
-            (local.get $0)
-            (i32.const 3)
-           )
-           (i32.store offset=8
-            (local.get $0)
-            (i32.const -1)
-           )
-           (i32.store offset=12
-            (local.get $0)
-            (i32.const 0)
-           )
-           (local.get $0)
-          )
+          (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (local.get $6)
@@ -595,17 +572,14 @@ functions › lam_destructure_5
          )
         )
        )
-       (block $do_backpatches.35
-        (local.set $0
-         (local.get $6)
-        )
+       (block $do_backpatches.34
        )
       )
-      (block $compile_store.39
+      (block $compile_store.38
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (block $allocate_tuple.37 (result i32)
+          (block $allocate_tuple.36 (result i32)
            (i32.store
             (local.tee $0
              (call $malloc_0
@@ -640,14 +614,14 @@ functions › lam_destructure_5
          )
         )
        )
-       (block $do_backpatches.38
+       (block $do_backpatches.37
        )
       )
-      (block $compile_store.42
+      (block $compile_store.41
        (local.set $8
         (tuple.extract 0
          (tuple.make
-          (block $allocate_tuple.40 (result i32)
+          (block $allocate_tuple.39 (result i32)
            (i32.store
             (local.tee $0
              (call $malloc_0
@@ -678,7 +652,7 @@ functions › lam_destructure_5
          )
         )
        )
-       (block $do_backpatches.41
+       (block $do_backpatches.40
        )
       )
       (call $lam_lambda_1118

--- a/compiler/test/__snapshots__/functions.28e0f2b3.0.snapshot
+++ b/compiler/test/__snapshots__/functions.28e0f2b3.0.snapshot
@@ -74,37 +74,14 @@ functions › lambda_pat_any
   (local $5 f64)
   (local $6 i32)
   (return
-   (block $cleanup_locals.10 (result i32)
+   (block $cleanup_locals.9 (result i32)
     (local.set $0
-     (block $compile_block.9 (result i32)
-      (block $compile_store.5
+     (block $compile_block.8 (result i32)
+      (block $compile_store.4
        (global.set $x_1113
         (tuple.extract 0
          (tuple.make
-          (block $allocate_closure.3 (result i32)
-           (i32.store
-            (local.tee $0
-             (call $malloc_0
-              (global.get $GRAIN$EXPORT$malloc_0)
-              (i32.const 16)
-             )
-            )
-            (i32.const 6)
-           )
-           (i32.store offset=4
-            (local.get $0)
-            (i32.const 2)
-           )
-           (i32.store offset=8
-            (local.get $0)
-            (i32.const -1)
-           )
-           (i32.store offset=12
-            (local.get $0)
-            (i32.const 0)
-           )
-           (local.get $0)
-          )
+          (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (global.get $x_1113)
@@ -112,17 +89,14 @@ functions › lambda_pat_any
          )
         )
        )
-       (block $do_backpatches.4
-        (local.set $0
-         (global.get $x_1113)
-        )
+       (block $do_backpatches.3
        )
       )
-      (block $compile_store.8
+      (block $compile_store.7
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (block $allocate_string.6 (result i32)
+          (block $allocate_string.5 (result i32)
            (i32.store
             (local.tee $0
              (call $malloc_0
@@ -149,7 +123,7 @@ functions › lambda_pat_any
          )
         )
        )
-       (block $do_backpatches.7
+       (block $do_backpatches.6
        )
       )
       (call $x_1113

--- a/compiler/test/__snapshots__/functions.49ccab54.0.snapshot
+++ b/compiler/test/__snapshots__/functions.49ccab54.0.snapshot
@@ -160,37 +160,14 @@ functions › curried_func
   (local $5 f64)
   (local $6 i32)
   (return
-   (block $cleanup_locals.13 (result i32)
+   (block $cleanup_locals.12 (result i32)
     (local.set $0
-     (block $compile_block.12 (result i32)
-      (block $compile_store.8
+     (block $compile_block.11 (result i32)
+      (block $compile_store.7
        (global.set $add_1113
         (tuple.extract 0
          (tuple.make
-          (block $allocate_closure.6 (result i32)
-           (i32.store
-            (local.tee $0
-             (call $malloc_0
-              (global.get $GRAIN$EXPORT$malloc_0)
-              (i32.const 16)
-             )
-            )
-            (i32.const 6)
-           )
-           (i32.store offset=4
-            (local.get $0)
-            (i32.const 2)
-           )
-           (i32.store offset=8
-            (local.get $0)
-            (i32.const -1)
-           )
-           (i32.store offset=12
-            (local.get $0)
-            (i32.const 0)
-           )
-           (local.get $0)
-          )
+          (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (global.get $add_1113)
@@ -198,13 +175,10 @@ functions › curried_func
          )
         )
        )
-       (block $do_backpatches.7
-        (local.set $0
-         (global.get $add_1113)
-        )
+       (block $do_backpatches.6
        )
       )
-      (block $compile_store.10
+      (block $compile_store.9
        (local.set $6
         (tuple.extract 0
          (tuple.make
@@ -222,10 +196,10 @@ functions › curried_func
          )
         )
        )
-       (block $do_backpatches.9
+       (block $do_backpatches.8
        )
       )
-      (block $call_lambda.11 (result i32)
+      (block $call_lambda.10 (result i32)
        (local.set $0
         (call $incRef_0
          (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/functions.6eacded0.0.snapshot
+++ b/compiler/test/__snapshots__/functions.6eacded0.0.snapshot
@@ -109,39 +109,16 @@ functions › func_recursive_closure
   (local $6 f64)
   (local $7 i32)
   (return
-   (block $cleanup_locals.8 (result i32)
+   (block $cleanup_locals.7 (result i32)
     (local.set $1
      (tuple.extract 0
       (tuple.make
-       (block $compile_block.7 (result i32)
-        (block $compile_store.6
+       (block $compile_block.6 (result i32)
+        (block $compile_store.5
          (local.set $7
           (tuple.extract 0
            (tuple.make
-            (block $allocate_closure.4 (result i32)
-             (i32.store
-              (local.tee $1
-               (call $malloc_0
-                (global.get $GRAIN$EXPORT$malloc_0)
-                (i32.const 16)
-               )
-              )
-              (i32.const 6)
-             )
-             (i32.store offset=4
-              (local.get $1)
-              (i32.const 2)
-             )
-             (i32.store offset=8
-              (local.get $1)
-              (i32.const -1)
-             )
-             (i32.store offset=12
-              (local.get $1)
-              (i32.const 0)
-             )
-             (local.get $1)
-            )
+            (i32.const 0)
             (call $decRef_0
              (global.get $GRAIN$EXPORT$decRef_0)
              (local.get $7)
@@ -149,10 +126,7 @@ functions › func_recursive_closure
            )
           )
          )
-         (block $do_backpatches.5
-          (local.set $1
-           (local.get $7)
-          )
+         (block $do_backpatches.4
          )
         )
         (call $foo_1117
@@ -191,11 +165,11 @@ functions › func_recursive_closure
   (local $6 f32)
   (local $7 f64)
   (return
-   (block $cleanup_locals.10 (result i32)
+   (block $cleanup_locals.9 (result i32)
     (local.set $2
      (tuple.extract 0
       (tuple.make
-       (block $compile_block.9 (result i32)
+       (block $compile_block.8 (result i32)
         (call $+_1124
          (call $incRef_0
           (global.get $GRAIN$EXPORT$incRef_0)
@@ -246,12 +220,12 @@ functions › func_recursive_closure
   (local $11 i32)
   (local $12 i32)
   (return
-   (block $cleanup_locals.27 (result i32)
+   (block $cleanup_locals.26 (result i32)
     (local.set $2
      (tuple.extract 0
       (tuple.make
-       (block $compile_block.26 (result i32)
-        (block $compile_store.12
+       (block $compile_block.25 (result i32)
+        (block $compile_store.11
          (local.set $8
           (tuple.extract 0
            (tuple.make
@@ -269,14 +243,14 @@ functions › func_recursive_closure
            )
           )
          )
-         (block $do_backpatches.11
+         (block $do_backpatches.10
          )
         )
-        (block $compile_store.15
+        (block $compile_store.14
          (local.set $9
           (tuple.extract 0
            (tuple.make
-            (block $allocate_closure.13 (result i32)
+            (block $allocate_closure.12 (result i32)
              (i32.store
               (local.tee $2
                (call $malloc_0
@@ -307,7 +281,7 @@ functions › func_recursive_closure
            )
           )
          )
-         (block $do_backpatches.14
+         (block $do_backpatches.13
           (local.set $2
            (local.get $9)
           )
@@ -327,7 +301,7 @@ functions › func_recursive_closure
           )
          )
         )
-        (block $compile_store.17
+        (block $compile_store.16
          (local.set $11
           (call $==_1134
            (call $incRef_0
@@ -341,7 +315,7 @@ functions › func_recursive_closure
            (i32.const 1)
           )
          )
-         (block $do_backpatches.16
+         (block $do_backpatches.15
          )
         )
         (if (result i32)
@@ -349,11 +323,11 @@ functions › func_recursive_closure
           (local.get $11)
           (i32.const 31)
          )
-         (block $compile_block.18 (result i32)
+         (block $compile_block.17 (result i32)
           (i32.const 1)
          )
-         (block $compile_block.25 (result i32)
-          (block $compile_store.20
+         (block $compile_block.24 (result i32)
+          (block $compile_store.19
            (local.set $12
             (call $==_1134
              (call $incRef_0
@@ -367,7 +341,7 @@ functions › func_recursive_closure
              (i32.const 3)
             )
            )
-           (block $do_backpatches.19
+           (block $do_backpatches.18
            )
           )
           (if (result i32)
@@ -375,7 +349,7 @@ functions › func_recursive_closure
             (local.get $12)
             (i32.const 31)
            )
-           (block $compile_block.21 (result i32)
+           (block $compile_block.20 (result i32)
             (call $bar_1120
              (call $incRef_0
               (global.get $GRAIN$EXPORT$incRef_0)
@@ -384,8 +358,8 @@ functions › func_recursive_closure
              (i32.const 3)
             )
            )
-           (block $compile_block.24 (result i32)
-            (block $compile_store.23
+           (block $compile_block.23 (result i32)
+            (block $compile_store.22
              (local.set $10
               (tuple.extract 0
                (tuple.make
@@ -407,7 +381,7 @@ functions › func_recursive_closure
                )
               )
              )
-             (block $do_backpatches.22
+             (block $do_backpatches.21
              )
             )
             (call $foo_1117
@@ -473,12 +447,12 @@ functions › func_recursive_closure
   (local $8 i32)
   (local $9 i32)
   (return
-   (block $cleanup_locals.34 (result i32)
+   (block $cleanup_locals.33 (result i32)
     (local.set $2
      (tuple.extract 0
       (tuple.make
-       (block $compile_block.33 (result i32)
-        (block $compile_store.29
+       (block $compile_block.32 (result i32)
+        (block $compile_store.28
          (local.set $8
           (tuple.extract 0
            (tuple.make
@@ -498,14 +472,14 @@ functions › func_recursive_closure
            )
           )
          )
-         (block $do_backpatches.28
+         (block $do_backpatches.27
          )
         )
-        (block $compile_store.32
+        (block $compile_store.31
          (local.set $9
           (tuple.extract 0
            (tuple.make
-            (block $call_lambda.30 (result i32)
+            (block $call_lambda.29 (result i32)
              (local.set $2
               (call $incRef_0
                (global.get $GRAIN$EXPORT$incRef_0)
@@ -529,7 +503,7 @@ functions › func_recursive_closure
            )
           )
          )
-         (block $do_backpatches.31
+         (block $do_backpatches.30
          )
         )
         (call $+_1124
@@ -596,37 +570,14 @@ functions › func_recursive_closure
   (local $4 f32)
   (local $5 f64)
   (return
-   (block $cleanup_locals.42 (result i32)
+   (block $cleanup_locals.39 (result i32)
     (local.set $0
-     (block $compile_block.41 (result i32)
-      (block $compile_store.37
+     (block $compile_block.38 (result i32)
+      (block $compile_store.35
        (global.set $makeAdder_1113
         (tuple.extract 0
          (tuple.make
-          (block $allocate_closure.35 (result i32)
-           (i32.store
-            (local.tee $0
-             (call $malloc_0
-              (global.get $GRAIN$EXPORT$malloc_0)
-              (i32.const 16)
-             )
-            )
-            (i32.const 6)
-           )
-           (i32.store offset=4
-            (local.get $0)
-            (i32.const 2)
-           )
-           (i32.store offset=8
-            (local.get $0)
-            (i32.const -1)
-           )
-           (i32.store offset=12
-            (local.get $0)
-            (i32.const 0)
-           )
-           (local.get $0)
-          )
+          (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (global.get $makeAdder_1113)
@@ -634,40 +585,14 @@ functions › func_recursive_closure
          )
         )
        )
-       (block $do_backpatches.36
-        (local.set $0
-         (global.get $makeAdder_1113)
-        )
+       (block $do_backpatches.34
        )
       )
-      (block $compile_store.40
+      (block $compile_store.37
        (global.set $truc_1116
         (tuple.extract 0
          (tuple.make
-          (block $allocate_closure.38 (result i32)
-           (i32.store
-            (local.tee $0
-             (call $malloc_0
-              (global.get $GRAIN$EXPORT$malloc_0)
-              (i32.const 16)
-             )
-            )
-            (i32.const 6)
-           )
-           (i32.store offset=4
-            (local.get $0)
-            (i32.const 1)
-           )
-           (i32.store offset=8
-            (local.get $0)
-            (i32.const -1)
-           )
-           (i32.store offset=12
-            (local.get $0)
-            (i32.const 0)
-           )
-           (local.get $0)
-          )
+          (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (global.get $truc_1116)
@@ -675,10 +600,7 @@ functions › func_recursive_closure
          )
         )
        )
-       (block $do_backpatches.39
-        (local.set $0
-         (global.get $truc_1116)
-        )
+       (block $do_backpatches.36
        )
       )
       (call $truc_1116
@@ -698,5 +620,5 @@ functions › func_recursive_closure
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 868
+ ;; custom section \"cmi\", size 893
 )

--- a/compiler/test/__snapshots__/functions.7a8986a5.0.snapshot
+++ b/compiler/test/__snapshots__/functions.7a8986a5.0.snapshot
@@ -7,10 +7,8 @@ functions › app_1
  (import \"_genv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_genv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_genv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
@@ -76,37 +74,14 @@ functions › app_1
   (local $5 f64)
   (local $6 i32)
   (return
-   (block $cleanup_locals.7 (result i32)
+   (block $cleanup_locals.6 (result i32)
     (local.set $0
-     (block $compile_block.6 (result i32)
-      (block $compile_store.5
+     (block $compile_block.5 (result i32)
+      (block $compile_store.4
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (block $allocate_closure.3 (result i32)
-           (i32.store
-            (local.tee $0
-             (call $malloc_0
-              (global.get $GRAIN$EXPORT$malloc_0)
-              (i32.const 16)
-             )
-            )
-            (i32.const 6)
-           )
-           (i32.store offset=4
-            (local.get $0)
-            (i32.const 2)
-           )
-           (i32.store offset=8
-            (local.get $0)
-            (i32.const -1)
-           )
-           (i32.store offset=12
-            (local.get $0)
-            (i32.const 0)
-           )
-           (local.get $0)
-          )
+          (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (local.get $6)
@@ -114,10 +89,7 @@ functions › app_1
          )
         )
        )
-       (block $do_backpatches.4
-        (local.set $0
-         (local.get $6)
-        )
+       (block $do_backpatches.3
        )
       )
       (call $lam_lambda_1114

--- a/compiler/test/__snapshots__/functions.84b6e84b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.84b6e84b.0.snapshot
@@ -7,10 +7,8 @@ functions › shorthand_3
  (import \"_genv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_genv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_genv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
  (global $foo_1113 (mut i32) (i32.const 0))
@@ -76,37 +74,14 @@ functions › shorthand_3
   (local $4 f32)
   (local $5 f64)
   (return
-   (block $cleanup_locals.7 (result i32)
+   (block $cleanup_locals.6 (result i32)
     (local.set $0
-     (block $compile_block.6 (result i32)
-      (block $compile_store.5
+     (block $compile_block.5 (result i32)
+      (block $compile_store.4
        (global.set $foo_1113
         (tuple.extract 0
          (tuple.make
-          (block $allocate_closure.3 (result i32)
-           (i32.store
-            (local.tee $0
-             (call $malloc_0
-              (global.get $GRAIN$EXPORT$malloc_0)
-              (i32.const 16)
-             )
-            )
-            (i32.const 6)
-           )
-           (i32.store offset=4
-            (local.get $0)
-            (i32.const 2)
-           )
-           (i32.store offset=8
-            (local.get $0)
-            (i32.const -1)
-           )
-           (i32.store offset=12
-            (local.get $0)
-            (i32.const 0)
-           )
-           (local.get $0)
-          )
+          (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (global.get $foo_1113)
@@ -114,10 +89,7 @@ functions › shorthand_3
          )
         )
        )
-       (block $do_backpatches.4
-        (local.set $0
-         (global.get $foo_1113)
-        )
+       (block $do_backpatches.3
        )
       )
       (call $foo_1113

--- a/compiler/test/__snapshots__/functions.8baf471f.0.snapshot
+++ b/compiler/test/__snapshots__/functions.8baf471f.0.snapshot
@@ -338,37 +338,14 @@ functions › lam_destructure_3
   (local $6 i32)
   (local $7 i32)
   (return
-   (block $cleanup_locals.27 (result i32)
+   (block $cleanup_locals.26 (result i32)
     (local.set $0
-     (block $compile_block.26 (result i32)
-      (block $compile_store.22
+     (block $compile_block.25 (result i32)
+      (block $compile_store.21
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (block $allocate_closure.20 (result i32)
-           (i32.store
-            (local.tee $0
-             (call $malloc_0
-              (global.get $GRAIN$EXPORT$malloc_0)
-              (i32.const 16)
-             )
-            )
-            (i32.const 6)
-           )
-           (i32.store offset=4
-            (local.get $0)
-            (i32.const 2)
-           )
-           (i32.store offset=8
-            (local.get $0)
-            (i32.const -1)
-           )
-           (i32.store offset=12
-            (local.get $0)
-            (i32.const 0)
-           )
-           (local.get $0)
-          )
+          (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (local.get $6)
@@ -376,17 +353,14 @@ functions › lam_destructure_3
          )
         )
        )
-       (block $do_backpatches.21
-        (local.set $0
-         (local.get $6)
-        )
+       (block $do_backpatches.20
        )
       )
-      (block $compile_store.25
+      (block $compile_store.24
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (block $allocate_tuple.23 (result i32)
+          (block $allocate_tuple.22 (result i32)
            (i32.store
             (local.tee $0
              (call $malloc_0
@@ -421,7 +395,7 @@ functions › lam_destructure_3
          )
         )
        )
-       (block $do_backpatches.24
+       (block $do_backpatches.23
        )
       )
       (call $lam_lambda_1116

--- a/compiler/test/__snapshots__/functions.9223245d.0.snapshot
+++ b/compiler/test/__snapshots__/functions.9223245d.0.snapshot
@@ -472,37 +472,14 @@ functions › lam_destructure_7
   (local $7 i32)
   (local $8 i32)
   (return
-   (block $cleanup_locals.39 (result i32)
+   (block $cleanup_locals.38 (result i32)
     (local.set $0
-     (block $compile_block.38 (result i32)
-      (block $compile_store.31
+     (block $compile_block.37 (result i32)
+      (block $compile_store.30
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (block $allocate_closure.29 (result i32)
-           (i32.store
-            (local.tee $0
-             (call $malloc_0
-              (global.get $GRAIN$EXPORT$malloc_0)
-              (i32.const 16)
-             )
-            )
-            (i32.const 6)
-           )
-           (i32.store offset=4
-            (local.get $0)
-            (i32.const 2)
-           )
-           (i32.store offset=8
-            (local.get $0)
-            (i32.const -1)
-           )
-           (i32.store offset=12
-            (local.get $0)
-            (i32.const 0)
-           )
-           (local.get $0)
-          )
+          (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (local.get $6)
@@ -510,17 +487,14 @@ functions › lam_destructure_7
          )
         )
        )
-       (block $do_backpatches.30
-        (local.set $0
-         (local.get $6)
-        )
+       (block $do_backpatches.29
        )
       )
-      (block $compile_store.34
+      (block $compile_store.33
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (block $allocate_tuple.32 (result i32)
+          (block $allocate_tuple.31 (result i32)
            (i32.store
             (local.tee $0
              (call $malloc_0
@@ -551,14 +525,14 @@ functions › lam_destructure_7
          )
         )
        )
-       (block $do_backpatches.33
+       (block $do_backpatches.32
        )
       )
-      (block $compile_store.37
+      (block $compile_store.36
        (local.set $8
         (tuple.extract 0
          (tuple.make
-          (block $allocate_tuple.35 (result i32)
+          (block $allocate_tuple.34 (result i32)
            (i32.store
             (local.tee $0
              (call $malloc_0
@@ -596,7 +570,7 @@ functions › lam_destructure_7
          )
         )
        )
-       (block $do_backpatches.36
+       (block $do_backpatches.35
        )
       )
       (call $lam_lambda_1117

--- a/compiler/test/__snapshots__/functions.9fd69835.0.snapshot
+++ b/compiler/test/__snapshots__/functions.9fd69835.0.snapshot
@@ -8,11 +8,9 @@ functions › shorthand_2
  (import \"_genv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_genv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_genv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1115 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1115 (param i32 i32 i32) (result i32)))
@@ -86,37 +84,14 @@ functions › shorthand_2
   (local $4 f32)
   (local $5 f64)
   (return
-   (block $cleanup_locals.7 (result i32)
+   (block $cleanup_locals.6 (result i32)
     (local.set $0
-     (block $compile_block.6 (result i32)
-      (block $compile_store.5
+     (block $compile_block.5 (result i32)
+      (block $compile_store.4
        (global.set $foo_1113
         (tuple.extract 0
          (tuple.make
-          (block $allocate_closure.3 (result i32)
-           (i32.store
-            (local.tee $0
-             (call $malloc_0
-              (global.get $GRAIN$EXPORT$malloc_0)
-              (i32.const 16)
-             )
-            )
-            (i32.const 6)
-           )
-           (i32.store offset=4
-            (local.get $0)
-            (i32.const 2)
-           )
-           (i32.store offset=8
-            (local.get $0)
-            (i32.const -1)
-           )
-           (i32.store offset=12
-            (local.get $0)
-            (i32.const 0)
-           )
-           (local.get $0)
-          )
+          (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (global.get $foo_1113)
@@ -124,10 +99,7 @@ functions › shorthand_2
          )
         )
        )
-       (block $do_backpatches.4
-        (local.set $0
-         (global.get $foo_1113)
-        )
+       (block $do_backpatches.3
        )
       )
       (call $foo_1113

--- a/compiler/test/__snapshots__/functions.b37949b2.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b37949b2.0.snapshot
@@ -338,37 +338,14 @@ functions › lam_destructure_4
   (local $5 f64)
   (local $6 i32)
   (return
-   (block $cleanup_locals.27 (result i32)
+   (block $cleanup_locals.26 (result i32)
     (local.set $0
-     (block $compile_block.26 (result i32)
-      (block $compile_store.22
+     (block $compile_block.25 (result i32)
+      (block $compile_store.21
        (global.set $foo_1113
         (tuple.extract 0
          (tuple.make
-          (block $allocate_closure.20 (result i32)
-           (i32.store
-            (local.tee $0
-             (call $malloc_0
-              (global.get $GRAIN$EXPORT$malloc_0)
-              (i32.const 16)
-             )
-            )
-            (i32.const 6)
-           )
-           (i32.store offset=4
-            (local.get $0)
-            (i32.const 2)
-           )
-           (i32.store offset=8
-            (local.get $0)
-            (i32.const -1)
-           )
-           (i32.store offset=12
-            (local.get $0)
-            (i32.const 0)
-           )
-           (local.get $0)
-          )
+          (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (global.get $foo_1113)
@@ -376,17 +353,14 @@ functions › lam_destructure_4
          )
         )
        )
-       (block $do_backpatches.21
-        (local.set $0
-         (global.get $foo_1113)
-        )
+       (block $do_backpatches.20
        )
       )
-      (block $compile_store.25
+      (block $compile_store.24
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (block $allocate_tuple.23 (result i32)
+          (block $allocate_tuple.22 (result i32)
            (i32.store
             (local.tee $0
              (call $malloc_0
@@ -421,7 +395,7 @@ functions › lam_destructure_4
          )
         )
        )
-       (block $do_backpatches.24
+       (block $do_backpatches.23
        )
       )
       (call $foo_1113

--- a/compiler/test/__snapshots__/functions.b3a8d88b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b3a8d88b.0.snapshot
@@ -472,37 +472,14 @@ functions › lam_destructure_8
   (local $6 i32)
   (local $7 i32)
   (return
-   (block $cleanup_locals.39 (result i32)
+   (block $cleanup_locals.38 (result i32)
     (local.set $0
-     (block $compile_block.38 (result i32)
-      (block $compile_store.31
+     (block $compile_block.37 (result i32)
+      (block $compile_store.30
        (global.set $foo_1113
         (tuple.extract 0
          (tuple.make
-          (block $allocate_closure.29 (result i32)
-           (i32.store
-            (local.tee $0
-             (call $malloc_0
-              (global.get $GRAIN$EXPORT$malloc_0)
-              (i32.const 16)
-             )
-            )
-            (i32.const 6)
-           )
-           (i32.store offset=4
-            (local.get $0)
-            (i32.const 2)
-           )
-           (i32.store offset=8
-            (local.get $0)
-            (i32.const -1)
-           )
-           (i32.store offset=12
-            (local.get $0)
-            (i32.const 0)
-           )
-           (local.get $0)
-          )
+          (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (global.get $foo_1113)
@@ -510,17 +487,14 @@ functions › lam_destructure_8
          )
         )
        )
-       (block $do_backpatches.30
-        (local.set $0
-         (global.get $foo_1113)
-        )
+       (block $do_backpatches.29
        )
       )
-      (block $compile_store.34
+      (block $compile_store.33
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (block $allocate_tuple.32 (result i32)
+          (block $allocate_tuple.31 (result i32)
            (i32.store
             (local.tee $0
              (call $malloc_0
@@ -551,14 +525,14 @@ functions › lam_destructure_8
          )
         )
        )
-       (block $do_backpatches.33
+       (block $do_backpatches.32
        )
       )
-      (block $compile_store.37
+      (block $compile_store.36
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (block $allocate_tuple.35 (result i32)
+          (block $allocate_tuple.34 (result i32)
            (i32.store
             (local.tee $0
              (call $malloc_0
@@ -596,7 +570,7 @@ functions › lam_destructure_8
          )
         )
        )
-       (block $do_backpatches.36
+       (block $do_backpatches.35
        )
       )
       (call $foo_1113

--- a/compiler/test/__snapshots__/functions.b632a2ab.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b632a2ab.0.snapshot
@@ -74,37 +74,14 @@ functions › lam_destructure_1
   (local $6 i32)
   (local $7 i32)
   (return
-   (block $cleanup_locals.10 (result i32)
+   (block $cleanup_locals.9 (result i32)
     (local.set $0
-     (block $compile_block.9 (result i32)
-      (block $compile_store.5
+     (block $compile_block.8 (result i32)
+      (block $compile_store.4
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (block $allocate_closure.3 (result i32)
-           (i32.store
-            (local.tee $0
-             (call $malloc_0
-              (global.get $GRAIN$EXPORT$malloc_0)
-              (i32.const 16)
-             )
-            )
-            (i32.const 6)
-           )
-           (i32.store offset=4
-            (local.get $0)
-            (i32.const 2)
-           )
-           (i32.store offset=8
-            (local.get $0)
-            (i32.const -1)
-           )
-           (i32.store offset=12
-            (local.get $0)
-            (i32.const 0)
-           )
-           (local.get $0)
-          )
+          (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (local.get $6)
@@ -112,17 +89,14 @@ functions › lam_destructure_1
          )
         )
        )
-       (block $do_backpatches.4
-        (local.set $0
-         (local.get $6)
-        )
+       (block $do_backpatches.3
        )
       )
-      (block $compile_store.8
+      (block $compile_store.7
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (block $allocate_string.6 (result i32)
+          (block $allocate_string.5 (result i32)
            (i32.store
             (local.tee $0
              (call $malloc_0
@@ -149,7 +123,7 @@ functions › lam_destructure_1
          )
         )
        )
-       (block $do_backpatches.7
+       (block $do_backpatches.6
        )
       )
       (call $lam_lambda_1113

--- a/compiler/test/__snapshots__/functions.c6e8a9aa.0.snapshot
+++ b/compiler/test/__snapshots__/functions.c6e8a9aa.0.snapshot
@@ -74,37 +74,14 @@ functions › lam_destructure_2
   (local $5 f64)
   (local $6 i32)
   (return
-   (block $cleanup_locals.10 (result i32)
+   (block $cleanup_locals.9 (result i32)
     (local.set $0
-     (block $compile_block.9 (result i32)
-      (block $compile_store.5
+     (block $compile_block.8 (result i32)
+      (block $compile_store.4
        (global.set $foo_1113
         (tuple.extract 0
          (tuple.make
-          (block $allocate_closure.3 (result i32)
-           (i32.store
-            (local.tee $0
-             (call $malloc_0
-              (global.get $GRAIN$EXPORT$malloc_0)
-              (i32.const 16)
-             )
-            )
-            (i32.const 6)
-           )
-           (i32.store offset=4
-            (local.get $0)
-            (i32.const 2)
-           )
-           (i32.store offset=8
-            (local.get $0)
-            (i32.const -1)
-           )
-           (i32.store offset=12
-            (local.get $0)
-            (i32.const 0)
-           )
-           (local.get $0)
-          )
+          (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (global.get $foo_1113)
@@ -112,17 +89,14 @@ functions › lam_destructure_2
          )
         )
        )
-       (block $do_backpatches.4
-        (local.set $0
-         (global.get $foo_1113)
-        )
+       (block $do_backpatches.3
        )
       )
-      (block $compile_store.8
+      (block $compile_store.7
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (block $allocate_string.6 (result i32)
+          (block $allocate_string.5 (result i32)
            (i32.store
             (local.tee $0
              (call $malloc_0
@@ -149,7 +123,7 @@ functions › lam_destructure_2
          )
         )
        )
-       (block $do_backpatches.7
+       (block $do_backpatches.6
        )
       )
       (call $foo_1113

--- a/compiler/test/__snapshots__/functions.e6c6212b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.e6c6212b.0.snapshot
@@ -1,18 +1,16 @@
 functions › fn_trailing_comma
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $none_=>_none (func))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
  (import \"_genv\" \"mem\" (memory $0 0))
  (import \"_genv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_genv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_genv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1116 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1116 (param i32 i32 i32) (result i32)))
@@ -95,37 +93,14 @@ functions › fn_trailing_comma
   (local $4 f32)
   (local $5 f64)
   (return
-   (block $cleanup_locals.7 (result i32)
+   (block $cleanup_locals.6 (result i32)
     (local.set $0
-     (block $compile_block.6 (result i32)
-      (block $compile_store.5
+     (block $compile_block.5 (result i32)
+      (block $compile_store.4
        (global.set $testFn_1113
         (tuple.extract 0
          (tuple.make
-          (block $allocate_closure.3 (result i32)
-           (i32.store
-            (local.tee $0
-             (call $malloc_0
-              (global.get $GRAIN$EXPORT$malloc_0)
-              (i32.const 16)
-             )
-            )
-            (i32.const 6)
-           )
-           (i32.store offset=4
-            (local.get $0)
-            (i32.const 3)
-           )
-           (i32.store offset=8
-            (local.get $0)
-            (i32.const -1)
-           )
-           (i32.store offset=12
-            (local.get $0)
-            (i32.const 0)
-           )
-           (local.get $0)
-          )
+          (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (global.get $testFn_1113)
@@ -133,10 +108,7 @@ functions › fn_trailing_comma
          )
         )
        )
-       (block $do_backpatches.4
-        (local.set $0
-         (global.get $testFn_1113)
-        )
+       (block $do_backpatches.3
        )
       )
       (call $testFn_1113

--- a/compiler/test/__snapshots__/functions.f400bb7b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.f400bb7b.0.snapshot
@@ -557,37 +557,14 @@ functions › lam_destructure_6
   (local $6 i32)
   (local $7 i32)
   (return
-   (block $cleanup_locals.44 (result i32)
+   (block $cleanup_locals.43 (result i32)
     (local.set $0
-     (block $compile_block.43 (result i32)
-      (block $compile_store.36
+     (block $compile_block.42 (result i32)
+      (block $compile_store.35
        (global.set $foo_1113
         (tuple.extract 0
          (tuple.make
-          (block $allocate_closure.34 (result i32)
-           (i32.store
-            (local.tee $0
-             (call $malloc_0
-              (global.get $GRAIN$EXPORT$malloc_0)
-              (i32.const 16)
-             )
-            )
-            (i32.const 6)
-           )
-           (i32.store offset=4
-            (local.get $0)
-            (i32.const 3)
-           )
-           (i32.store offset=8
-            (local.get $0)
-            (i32.const -1)
-           )
-           (i32.store offset=12
-            (local.get $0)
-            (i32.const 0)
-           )
-           (local.get $0)
-          )
+          (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (global.get $foo_1113)
@@ -595,17 +572,14 @@ functions › lam_destructure_6
          )
         )
        )
-       (block $do_backpatches.35
-        (local.set $0
-         (global.get $foo_1113)
-        )
+       (block $do_backpatches.34
        )
       )
-      (block $compile_store.39
+      (block $compile_store.38
        (local.set $6
         (tuple.extract 0
          (tuple.make
-          (block $allocate_tuple.37 (result i32)
+          (block $allocate_tuple.36 (result i32)
            (i32.store
             (local.tee $0
              (call $malloc_0
@@ -640,14 +614,14 @@ functions › lam_destructure_6
          )
         )
        )
-       (block $do_backpatches.38
+       (block $do_backpatches.37
        )
       )
-      (block $compile_store.42
+      (block $compile_store.41
        (local.set $7
         (tuple.extract 0
          (tuple.make
-          (block $allocate_tuple.40 (result i32)
+          (block $allocate_tuple.39 (result i32)
            (i32.store
             (local.tee $0
              (call $malloc_0
@@ -678,7 +652,7 @@ functions › lam_destructure_6
          )
         )
        )
-       (block $do_backpatches.41
+       (block $do_backpatches.40
        )
       )
       (call $foo_1113

--- a/compiler/test/__snapshots__/optimizations.d72b00c6.0.snapshot
+++ b/compiler/test/__snapshots__/optimizations.d72b00c6.0.snapshot
@@ -1,17 +1,15 @@
 optimizations › trs1
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
  (import \"_genv\" \"mem\" (memory $0 0))
  (import \"_genv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_genv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_genv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
  (global $f1_1113 (mut i32) (i32.const 0))
@@ -83,37 +81,14 @@ optimizations › trs1
   (local $4 f32)
   (local $5 f64)
   (return
-   (block $cleanup_locals.7 (result i32)
+   (block $cleanup_locals.6 (result i32)
     (local.set $0
-     (block $compile_block.6 (result i32)
-      (block $compile_store.5
+     (block $compile_block.5 (result i32)
+      (block $compile_store.4
        (global.set $f1_1113
         (tuple.extract 0
          (tuple.make
-          (block $allocate_closure.3 (result i32)
-           (i32.store
-            (local.tee $0
-             (call $malloc_0
-              (global.get $GRAIN$EXPORT$malloc_0)
-              (i32.const 16)
-             )
-            )
-            (i32.const 6)
-           )
-           (i32.store offset=4
-            (local.get $0)
-            (i32.const 3)
-           )
-           (i32.store offset=8
-            (local.get $0)
-            (i32.const -1)
-           )
-           (i32.store offset=12
-            (local.get $0)
-            (i32.const 0)
-           )
-           (local.get $0)
-          )
+          (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (global.get $f1_1113)
@@ -121,10 +96,7 @@ optimizations › trs1
          )
         )
        )
-       (block $do_backpatches.4
-        (local.set $0
-         (global.get $f1_1113)
-        )
+       (block $do_backpatches.3
        )
       )
       (call $f1_1113

--- a/compiler/test/__snapshots__/provides.30cbc409.0.snapshot
+++ b/compiler/test/__snapshots__/provides.30cbc409.0.snapshot
@@ -121,9 +121,9 @@ provides › provide_start_function
   (local $5 f64)
   (local $6 i32)
   (return
-   (block $cleanup_locals.13 (result i32)
+   (block $cleanup_locals.12 (result i32)
     (local.set $0
-     (block $compile_block.12 (result i32)
+     (block $compile_block.11 (result i32)
       (block $compile_store.8
        (local.set $6
         (tuple.extract 0
@@ -170,34 +170,11 @@ provides › provide_start_function
         )
        )
       )
-      (block $compile_store.11
+      (block $compile_store.10
        (global.set $_start_1113
         (tuple.extract 0
          (tuple.make
-          (block $allocate_closure.9 (result i32)
-           (i32.store
-            (local.tee $0
-             (call $malloc_0
-              (global.get $GRAIN$EXPORT$malloc_0)
-              (i32.const 16)
-             )
-            )
-            (i32.const 6)
-           )
-           (i32.store offset=4
-            (local.get $0)
-            (i32.const 1)
-           )
-           (i32.store offset=8
-            (local.get $0)
-            (i32.const -1)
-           )
-           (i32.store offset=12
-            (local.get $0)
-            (i32.const 0)
-           )
-           (local.get $0)
-          )
+          (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (global.get $_start_1113)
@@ -205,10 +182,7 @@ provides › provide_start_function
          )
         )
        )
-       (block $do_backpatches.10
-        (local.set $0
-         (global.get $_start_1113)
-        )
+       (block $do_backpatches.9
        )
       )
       (i32.const 1879048190)
@@ -224,5 +198,5 @@ provides › provide_start_function
    )
   )
  )
- ;; custom section \"cmi\", size 864
+ ;; custom section \"cmi\", size 889
 )

--- a/compiler/test/__snapshots__/provides.c6bf4567.0.snapshot
+++ b/compiler/test/__snapshots__/provides.c6bf4567.0.snapshot
@@ -1,16 +1,14 @@
 provides › let_rec_provide
 (module
  (type $none_=>_none (func))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import \"_genv\" \"mem\" (memory $0 0))
  (import \"_genv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_genv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_genv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
- (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
  (global $foo_1113 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
@@ -68,37 +66,14 @@ provides › let_rec_provide
   (local $4 f32)
   (local $5 f64)
   (return
-   (block $cleanup_locals.7 (result i32)
+   (block $cleanup_locals.6 (result i32)
     (local.set $0
-     (block $compile_block.6 (result i32)
-      (block $compile_store.5
+     (block $compile_block.5 (result i32)
+      (block $compile_store.4
        (global.set $foo_1113
         (tuple.extract 0
          (tuple.make
-          (block $allocate_closure.3 (result i32)
-           (i32.store
-            (local.tee $0
-             (call $malloc_0
-              (global.get $GRAIN$EXPORT$malloc_0)
-              (i32.const 16)
-             )
-            )
-            (i32.const 6)
-           )
-           (i32.store offset=4
-            (local.get $0)
-            (i32.const 1)
-           )
-           (i32.store offset=8
-            (local.get $0)
-            (i32.const -1)
-           )
-           (i32.store offset=12
-            (local.get $0)
-            (i32.const 0)
-           )
-           (local.get $0)
-          )
+          (i32.const 0)
           (call $decRef_0
            (global.get $GRAIN$EXPORT$decRef_0)
            (global.get $foo_1113)
@@ -106,10 +81,7 @@ provides › let_rec_provide
          )
         )
        )
-       (block $do_backpatches.4
-        (local.set $0
-         (global.get $foo_1113)
-        )
+       (block $do_backpatches.3
        )
       )
       (i32.const 1879048190)
@@ -124,5 +96,5 @@ provides › let_rec_provide
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 848
+ ;; custom section \"cmi\", size 873
 )

--- a/compiler/test/stdlib/immutablepriorityqueue.test.gr
+++ b/compiler/test/stdlib/immutablepriorityqueue.test.gr
@@ -4,8 +4,6 @@ include "immutablepriorityqueue"
 include "list"
 include "array"
 
-assert ImmutablePriorityQueue.make(compare) == ImmutablePriorityQueue.empty
-
 // formatter-ignore
 let lotsOfVals = [>
   3, 2, 1, 5, 3, 2, 2, 10, 6, 5,

--- a/compiler/test/suites/gc.re
+++ b/compiler/test/suites/gc.re
@@ -81,7 +81,7 @@ describe("garbage collection", ({test, testSkip}) => {
   );
   assertRunGCError(
     "fib_gc_err",
-    1024,
+    512,
     {|
     let fib = x => {
       let rec fib_help = (n, acc) => {
@@ -100,7 +100,7 @@ describe("garbage collection", ({test, testSkip}) => {
   );
   assertRunGC(
     "fib_gc",
-    2048,
+    1024,
     {|
     let fib = x => {
       let rec fib_help = (n, acc) => {


### PR DESCRIPTION
Closes #1410 
Works towards #1029 

This PR only allocates closures when absolutely necessary—when a function actually closes over values or the function may be used in a first-class way. 

This results in a 40% module size reduction for hello world programs, and similar 20-40% module size reductions for most Grain programs. It also improves program performance and module startup time.

This is breaking at the CMI level because consuming modules may need to allocate a closure for an imported function if it plans to use it in a first-class way.