### PR TITLE
feat(compiler): Allow importing a memory

### DIFF
--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -118,6 +118,7 @@ class GrainCommand extends commander.Command {
       "maximum number of WebAssembly memory pages",
       num
     );
+    cmd.forwardOption("--import-memory", "import the memory from `env.memory`");
     cmd.forwardOption(
       "--compilation-mode <mode>",
       "compilation mode (advanced use only)"

--- a/compiler/src/linking/link.re
+++ b/compiler/src/linking/link.re
@@ -530,6 +530,10 @@ let link_all = (linked_mod, dependencies, signature) => {
     -1,
     Type.funcref,
   );
+
+  if (Config.import_memory^) {
+    Import.add_memory_import(linked_mod, "memory", "env", "memory", false);
+  };
   let (initial_memory, maximum_memory) =
     switch (Config.initial_memory_pages^, Config.maximum_memory_pages^) {
     | (initial_memory, Some(maximum_memory)) => (

--- a/compiler/src/utils/config.re
+++ b/compiler/src/utils/config.re
@@ -445,6 +445,13 @@ let maximum_memory_pages =
     None,
   );
 
+let import_memory =
+  toggle_flag(
+    ~names=["import-memory"],
+    ~doc="Import the memory from `env.memory`",
+    false,
+  );
+
 let compilation_mode =
   opt(
     ~names=["compilation-mode"],

--- a/compiler/src/utils/config.rei
+++ b/compiler/src/utils/config.rei
@@ -78,6 +78,10 @@ let initial_memory_pages: ref(int);
 
 let maximum_memory_pages: ref(option(int));
 
+/** Import the memory from `env.memory` */
+
+let import_memory: ref(bool);
+
 /** Compilation mode to use when compiling */
 
 let compilation_mode: ref(option(string));

--- a/compiler/test/suites/linking.re
+++ b/compiler/test/suites/linking.re
@@ -49,6 +49,8 @@ describe("linking", ({test, testSkip}) => {
   );
 
   let tuple_equal = ((a1, a2), (b1, b2)) => a1 == b1 && a2 == b2;
+  let triple_equal = ((a1, a2, a3), (b1, b2, b3)) =>
+    a1 == b1 && a2 == b2 && a3 == b3;
   test("no_start_section", ({expect}) => {
     let name = "no_start_section";
     let outfile = wasmfile(name);
@@ -117,6 +119,33 @@ describe("linking", ({test, testSkip}) => {
     expect.list(Option.get(export_sections)).not.toContainEqual(
       ~equals=tuple_equal,
       (WasmFunction, "_start"),
+    );
+  });
+
+  test("import_memory", ({expect}) => {
+    let name = "import_memory";
+    let outfile = wasmfile(name);
+    ignore @@
+    compile(
+      ~config_fn=() => {Grain_utils.Config.import_memory := true},
+      name,
+      {|module Test; print("Hello, world!")|},
+    );
+    let ic = open_in_bin(outfile);
+    let sections = Grain_utils.Wasm_utils.get_wasm_sections(ic);
+    close_in(ic);
+    let imports =
+      List.find_map(
+        (sec: Grain_utils.Wasm_utils.wasm_bin_section) =>
+          switch (sec) {
+          | {sec_type: Import(imports)} => Some(imports)
+          | _ => None
+          },
+        sections,
+      );
+    expect.list(Option.get(imports)).toContainEqual(
+      ~equals=triple_equal,
+      (WasmMemory, "env", "memory"),
     );
   });
 });


### PR DESCRIPTION
Works towards #1029 

For compilers that support this functionality, they just support importing from `env.memory`. We could make this a bit more complicated and allow passing the module name and memory name, but for now I don't think this is necessary.

We don't currently have the ability to add a test for this because the memory import happens after linking.