### PR TITLE
chore(stdlib): Clean up extra case in string escape logic

### DIFF
--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -242,7 +242,6 @@ let escape = (ptr, isString) => {
     let byte = WasmI32.load8U(ptr + i, startOffset)
     if (
       byte >= _SEQ_B && byte <= _SEQ_R || /* b, f, n, r, t, v */
-      byte == _SEQ_V ||
       byte == _SEQ_SLASH ||
       byte == _SEQ_QUOTE
     ) {
@@ -261,7 +260,6 @@ let escape = (ptr, isString) => {
     let byte = WasmI32.load8U(ptr + i, startOffset)
     if (
       byte >= _SEQ_B && byte <= _SEQ_R || /* b, f, n, r, t, v */
-      byte == _SEQ_V ||
       byte == _SEQ_SLASH ||
       byte == _SEQ_QUOTE
     ) {


### PR DESCRIPTION
Test for this in `strings.re` continues to pass.