### PR TITLE
feat(compiler)!: Explicit abstract types

### DIFF
--- a/compiler/src/formatting/format.re
+++ b/compiler/src/formatting/format.re
@@ -4013,6 +4013,7 @@ and print_value_bind =
     switch (provide_flag) {
     | NotProvided => Doc.nil
     | Provided => Doc.text("provide ")
+    | Abstract => Doc.text("abstract ")
     };
   let recursive =
     switch (rec_flag) {
@@ -4627,6 +4628,7 @@ let data_print =
           switch ((expt: Asttypes.provide_flag)) {
           | NotProvided => Doc.nil
           | Provided => Doc.text("provide ")
+          | Abstract => Doc.text("abstract ")
           },
           print_data(~original_source, ~comments=data_comments, decl),
         ]);
@@ -4745,6 +4747,7 @@ let rec toplevel_print =
         switch (provide_flag) {
         | NotProvided => Doc.nil
         | Provided => Doc.text("provide ")
+        | Abstract => Doc.text("abstract ")
         };
       Doc.concat([
         provide,
@@ -4760,6 +4763,7 @@ let rec toplevel_print =
         switch (provide_flag) {
         | NotProvided => Doc.nil
         | Provided => Doc.text("provide ")
+        | Abstract => Doc.text("abstract ")
         };
       Doc.concat([
         provide,
@@ -4794,6 +4798,7 @@ let rec toplevel_print =
         switch (provide_flag) {
         | NotProvided => Doc.nil
         | Provided => Doc.text("provide ")
+        | Abstract => Doc.text("abstract ")
         };
       let cstr = type_exception.ptyexn_constructor;
 
@@ -4956,6 +4961,7 @@ let rec toplevel_print =
         switch (provide_flag) {
         | NotProvided => Doc.nil
         | Provided => Doc.text("provide ")
+        | Abstract => Doc.text("abstract ")
         };
 
       let start_after_brace = Doc.concat([Doc.hardLine, top_level_stmts]);

--- a/compiler/src/parsing/asttypes.re
+++ b/compiler/src/parsing/asttypes.re
@@ -64,7 +64,8 @@ and number_type =
 [@deriving (sexp, yojson)]
 type provide_flag =
   | NotProvided
-  | Provided;
+  | Provided
+  | Abstract;
 
 /** Marker for recursive/nonrecursive let bindings */
 

--- a/compiler/src/parsing/lexer.re
+++ b/compiler/src/parsing/lexer.re
@@ -271,6 +271,7 @@ let rec token = lexbuf => {
   | "include" => positioned(INCLUDE)
   | "use" => positioned(USE)
   | "provide" => positioned(PROVIDE)
+  | "abstract" => positioned(ABSTRACT)
   | "except" => positioned(EXCEPT)
   | "from" => positioned(FROM)
   | "*" => positioned(STAR)

--- a/compiler/src/parsing/parser.messages
+++ b/compiler/src/parsing/parser.messages
@@ -1591,7 +1591,19 @@ program: MODULE UIDENT EOL PROVIDE WHILE
 ## attributes PROVIDE
 ##
 
-Expected a let binding, data declaration, exception, or comma-separated list of identifiers surrounded by `{}`.
+Expected a let binding, type declaration, exception, or comma-separated list of identifiers surrounded by `{}`.
+
+program: MODULE UIDENT EOL ABSTRACT YIELD
+##
+## Ends in an error in state: 827.
+##
+## data_declaration_stmt -> ABSTRACT . data_declaration [ SEMI RBRACE EOL EOF COMMA ]
+##
+## The known suffix of the stack is as follows:
+## ABSTRACT
+##
+
+Expected a type declaration.
 
 program: MODULE UIDENT EOL FAIL WHEN
 ##

--- a/compiler/src/parsing/parser.mly
+++ b/compiler/src/parsing/parser.mly
@@ -36,7 +36,7 @@ module Grain_parsing = struct end
 %token <string> PREFIX_150
 %token <string> INFIX_ASSIGNMENT_10
 
-%token ENUM RECORD TYPE MODULE INCLUDE USE PROVIDE FOREIGN WASM PRIMITIVE
+%token ENUM RECORD TYPE MODULE INCLUDE USE PROVIDE ABSTRACT FOREIGN WASM PRIMITIVE
 %token EXCEPT FROM STAR
 %token SLASH DASH PIPE
 %token EOL EOF
@@ -340,6 +340,7 @@ include_stmt:
   | INCLUDE file_path include_alias? { IncludeDeclaration.mk ~loc:(to_loc $loc) $2 $3 }
 
 data_declaration_stmt:
+  | ABSTRACT data_declaration { (Abstract, $2) }
   | PROVIDE data_declaration { (Provided, $2) }
   | data_declaration { (NotProvided, $1) }
 

--- a/compiler/src/parsing/parsetree.re
+++ b/compiler/src/parsing/parsetree.re
@@ -14,7 +14,8 @@ type loc('a) =
     loc: Location.t,
   };
 
-type provide_flag = Asttypes.provide_flag = | NotProvided | Provided;
+type provide_flag =
+  Asttypes.provide_flag = | NotProvided | Provided | Abstract;
 type rec_flag = Asttypes.rec_flag = | Nonrecursive | Recursive;
 type mut_flag = Asttypes.mut_flag = | Mutable | Immutable;
 

--- a/compiler/src/typed/ctype.re
+++ b/compiler/src/typed/ctype.re
@@ -2189,7 +2189,7 @@ let nondep_instance = (env, level, id, ty) => {
    list (nl2, tl2). raise Not_found if impossible */
 let complete_type_list = (~allow_absent=false, env, nl1, lv2, mty2, nl2, tl2) => {
   let id2 = Ident.create("Pkg");
-  let env' = Env.add_module(id2, mty2, None, env);
+  let env' = Env.add_module(id2, mty2, None, Location.dummy_loc, env);
   let rec complete = (nl1, ntl2) =>
     switch (nl1, ntl2) {
     | ([], _) => ntl2

--- a/compiler/src/typed/env.rei
+++ b/compiler/src/typed/env.rei
@@ -149,7 +149,8 @@ let add_constructor: (Ident.t, constructor_description, t) => t;
 
 /** Adds a constructor with the given name and description. */
 
-let add_module: (~arg: bool=?, Ident.t, module_type, option(string), t) => t;
+let add_module:
+  (~arg: bool=?, Ident.t, module_type, option(string), Location.t, t) => t;
 let add_module_declaration:
   (~arg: bool=?, ~check: bool, Ident.t, module_declaration, t) => t;
 let add_modtype: (Ident.t, modtype_declaration, t) => t;

--- a/compiler/src/typed/mtype.re
+++ b/compiler/src/typed/mtype.re
@@ -567,7 +567,11 @@ and remove_aliases_sig = (env, excl, sg) =>
 
     [
       TSigModule(id, {...md, md_type: mty}, rs),
-      ...remove_aliases_sig(Env.add_module(id, mty, None, env), excl, rem),
+      ...remove_aliases_sig(
+           Env.add_module(id, mty, None, md.md_loc, env),
+           excl,
+           rem,
+         ),
     ];
   | [TSigModType(id, mtd), ...rem] => [
       TSigModType(id, mtd),

--- a/compiler/src/typed/subst.re
+++ b/compiler/src/typed/subst.re
@@ -69,18 +69,7 @@ let add_modtype = (id, ty, s) => {
 
 let for_saving = s => {...s, for_saving: true};
 
-let loc = (s, x) =>
-  if (s.for_saving) {
-    Location.dummy_loc;
-  } else {
-    x;
-  };
-
-let remove_loc =
-  Ast_mapper.{
-    ...default_mapper,
-    location: (_this, _loc) => Location.dummy_loc,
-  };
+let loc = (s, x) => x;
 
 let rec module_path = (s, path) =>
   try(PathMap.find(path, s.modules)) {

--- a/compiler/src/typed/typedecl.rei
+++ b/compiler/src/typed/typedecl.rei
@@ -20,7 +20,11 @@ open Types;
 open Format;
 
 let transl_data_decl:
-  (Env.t, Asttypes.rec_flag, list(Parsetree.data_declaration)) =>
+  (
+    Env.t,
+    Asttypes.rec_flag,
+    list((Asttypes.provide_flag, Parsetree.data_declaration))
+  ) =>
   (list(Typedtree.data_declaration), Env.t);
 
 let transl_value_decl:

--- a/compiler/src/typed/typedtree.re
+++ b/compiler/src/typed/typedtree.re
@@ -36,6 +36,8 @@ type partial =
   | Partial
   | Total;
 
+type provide_flag =
+  Asttypes.provide_flag = | NotProvided | Provided | Abstract;
 type rec_flag = Asttypes.rec_flag = | Nonrecursive | Recursive;
 type mut_flag = Asttypes.mut_flag = | Mutable | Immutable;
 
@@ -392,6 +394,7 @@ type data_declaration = {
   data_type: Types.type_declaration,
   data_kind,
   data_manifest: option(core_type),
+  data_provided: provide_flag,
   [@sexp_drop_if sexp_locs_disabled]
   data_loc: Location.t,
 };
@@ -549,6 +552,7 @@ type module_declaration = {
   tmod_id: Ident.t,
   tmod_decl: Types.module_declaration,
   tmod_statements: list(toplevel_stmt),
+  tmod_provided: provide_flag,
   [@sexp_drop_if sexp_locs_disabled]
   tmod_loc: Location.t,
 }

--- a/compiler/src/typed/typedtree.rei
+++ b/compiler/src/typed/typedtree.rei
@@ -36,6 +36,8 @@ type partial =
   | Partial
   | Total;
 
+type provide_flag =
+  Asttypes.provide_flag = | NotProvided | Provided | Abstract;
 type rec_flag = Asttypes.rec_flag = | Nonrecursive | Recursive;
 type mut_flag = Asttypes.mut_flag = | Mutable | Immutable;
 
@@ -369,6 +371,7 @@ type data_declaration = {
   data_type: Types.type_declaration,
   data_kind,
   data_manifest: option(core_type),
+  data_provided: provide_flag,
   data_loc: Location.t,
 };
 
@@ -512,6 +515,7 @@ type module_declaration = {
   tmod_id: Ident.t,
   tmod_decl: Types.module_declaration,
   tmod_statements: list(toplevel_stmt),
+  tmod_provided: provide_flag,
   [@sexp_drop_if sexp_locs_disabled]
   tmod_loc: Location.t,
 }

--- a/compiler/test/__snapshots__/early_return.1183a893.0.snapshot
+++ b/compiler/test/__snapshots__/early_return.1183a893.0.snapshot
@@ -185,5 +185,5 @@ early return › early_return3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 689
+ ;; custom section \"cmi\", size 843
 )

--- a/compiler/test/__snapshots__/enums.aa34084a.0.snapshot
+++ b/compiler/test/__snapshots__/enums.aa34084a.0.snapshot
@@ -154,5 +154,5 @@ enums › adt_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 490
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
+++ b/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
@@ -10,11 +10,11 @@ enums › enum_recursive_data_definition
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1128 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1126 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1128 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1126 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -590,10 +590,10 @@ enums › enum_recursive_data_definition
        (block $do_backpatches.28
        )
       )
-      (call $print_1128
+      (call $print_1126
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $print_1128)
+        (global.get $print_1126)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
@@ -665,5 +665,5 @@ enums › enum_recursive_data_definition
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 834
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/exceptions.a68ae348.0.snapshot
+++ b/compiler/test/__snapshots__/exceptions.a68ae348.0.snapshot
@@ -150,5 +150,5 @@ exceptions › exception_4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1238
+ ;; custom section \"cmi\", size 1284
 )

--- a/compiler/test/__snapshots__/exceptions.ccac3e71.0.snapshot
+++ b/compiler/test/__snapshots__/exceptions.ccac3e71.0.snapshot
@@ -138,5 +138,5 @@ exceptions › exception_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 613
+ ;; custom section \"cmi\", size 636
 )

--- a/compiler/test/__snapshots__/functions.6eacded0.0.snapshot
+++ b/compiler/test/__snapshots__/functions.6eacded0.0.snapshot
@@ -698,5 +698,5 @@ functions › func_recursive_closure
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 694
+ ;; custom section \"cmi\", size 868
 )

--- a/compiler/test/__snapshots__/functions.d9466880.0.snapshot
+++ b/compiler/test/__snapshots__/functions.d9466880.0.snapshot
@@ -15,13 +15,13 @@ functions › func_record_associativity2
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 1))
- (elem $elem (global.get $relocBase_0) $lam_lambda_1120)
+ (elem $elem (global.get $relocBase_0) $lam_lambda_1118)
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_gtype_metadata\" (func $_gtype_metadata))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $lam_lambda_1120 (param $0 i32) (result i32)
+ (func $lam_lambda_1118 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -384,5 +384,5 @@ functions › func_record_associativity2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 729
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/functions.f647681b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.f647681b.0.snapshot
@@ -15,13 +15,13 @@ functions › func_record_associativity1
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 1))
- (elem $elem (global.get $relocBase_0) $lam_lambda_1116)
+ (elem $elem (global.get $relocBase_0) $lam_lambda_1115)
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_gtype_metadata\" (func $_gtype_metadata))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $lam_lambda_1116 (param $0 i32) (result i32)
+ (func $lam_lambda_1115 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -290,5 +290,5 @@ functions › func_record_associativity1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 482
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/pattern_matching.0539d13e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0539d13e.0.snapshot
@@ -11,11 +11,11 @@ pattern matching › record_match_3
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1123 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1122 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1123 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1122 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -311,10 +311,10 @@ pattern matching › record_match_3
         )
         (br $switch.16_outer
          (block $compile_block.17 (result i32)
-          (call $+_1123
+          (call $+_1122
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $+_1123)
+            (global.get $+_1122)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
@@ -370,5 +370,5 @@ pattern matching › record_match_3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 482
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/pattern_matching.05b60a1e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.05b60a1e.0.snapshot
@@ -489,5 +489,5 @@ pattern matching › adt_match_deep
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 482
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/pattern_matching.14dc7554.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.14dc7554.0.snapshot
@@ -330,5 +330,5 @@ pattern matching › record_match_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 482
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/pattern_matching.46f91987.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.46f91987.0.snapshot
@@ -330,5 +330,5 @@ pattern matching › record_match_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 482
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/pattern_matching.5ff49e44.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.5ff49e44.0.snapshot
@@ -11,11 +11,11 @@ pattern matching › record_match_4
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1124 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1123 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1124 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1123 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -375,10 +375,10 @@ pattern matching › record_match_4
            (local.set $13
             (tuple.extract 0
              (tuple.make
-              (call $+_1124
+              (call $+_1123
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
-                (global.get $+_1124)
+                (global.get $+_1123)
                )
                (call $incRef_0
                 (global.get $GRAIN$EXPORT$incRef_0)
@@ -399,10 +399,10 @@ pattern matching › record_match_4
            (block $do_backpatches.22
            )
           )
-          (call $+_1124
+          (call $+_1123
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $+_1124)
+            (global.get $+_1123)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
@@ -476,5 +476,5 @@ pattern matching › record_match_4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 482
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/pattern_matching.98756c45.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.98756c45.0.snapshot
@@ -356,5 +356,5 @@ pattern matching › record_match_deep
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 731
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/provides.30cbc409.0.snapshot
+++ b/compiler/test/__snapshots__/provides.30cbc409.0.snapshot
@@ -224,5 +224,5 @@ provides › provide_start_function
    )
   )
  )
- ;; custom section \"cmi\", size 690
+ ;; custom section \"cmi\", size 864
 )

--- a/compiler/test/__snapshots__/provides.82c10ab4.0.snapshot
+++ b/compiler/test/__snapshots__/provides.82c10ab4.0.snapshot
@@ -10,21 +10,21 @@ provides › provide12
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1159 (mut i32)))
- (import \"GRAIN$MODULE$providedType\" \"GRAIN$EXPORT$apply\" (global $apply_1157 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1158 (mut i32)))
+ (import \"GRAIN$MODULE$providedType\" \"GRAIN$EXPORT$apply\" (global $apply_1156 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1159 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$providedType\" \"apply\" (func $apply_1157 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1158 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$providedType\" \"apply\" (func $apply_1156 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 1))
- (elem $elem (global.get $relocBase_0) $lam_lambda_1158)
+ (elem $elem (global.get $relocBase_0) $lam_lambda_1157)
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_gtype_metadata\" (func $_gtype_metadata))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $lam_lambda_1158 (param $0 i32) (param $1 i32) (result i32)
+ (func $lam_lambda_1157 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -70,10 +70,10 @@ provides › provide12
        (block $do_backpatches.2
        )
       )
-      (call $print_1159
+      (call $print_1158
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $print_1159)
+        (global.get $print_1158)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
@@ -169,10 +169,10 @@ provides › provide12
         )
        )
       )
-      (call $apply_1157
+      (call $apply_1156
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $apply_1157)
+        (global.get $apply_1156)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)

--- a/compiler/test/__snapshots__/provides.c6bf4567.0.snapshot
+++ b/compiler/test/__snapshots__/provides.c6bf4567.0.snapshot
@@ -124,5 +124,5 @@ provides › let_rec_provide
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 690
+ ;; custom section \"cmi\", size 848
 )

--- a/compiler/test/__snapshots__/records.012b017b.0.snapshot
+++ b/compiler/test/__snapshots__/records.012b017b.0.snapshot
@@ -112,5 +112,5 @@ records › record_spread_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 482
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/records.02742729.0.snapshot
+++ b/compiler/test/__snapshots__/records.02742729.0.snapshot
@@ -11,11 +11,11 @@ records › record_get_multiple
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1116 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1115 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1116 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1115 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -199,10 +199,10 @@ records › record_get_multiple
        (block $do_backpatches.8
        )
       )
-      (call $+_1116
+      (call $+_1115
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $+_1116)
+        (global.get $+_1115)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
@@ -242,5 +242,5 @@ records › record_get_multiple
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 482
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/records.02af5946.0.snapshot
+++ b/compiler/test/__snapshots__/records.02af5946.0.snapshot
@@ -134,5 +134,5 @@ records › record_definition_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 787
+ ;; custom section \"cmi\", size 1021
 )

--- a/compiler/test/__snapshots__/records.2dc39420.0.snapshot
+++ b/compiler/test/__snapshots__/records.2dc39420.0.snapshot
@@ -134,5 +134,5 @@ records › record_pun
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 787
+ ;; custom section \"cmi\", size 957
 )

--- a/compiler/test/__snapshots__/records.49dfc6ff.0.snapshot
+++ b/compiler/test/__snapshots__/records.49dfc6ff.0.snapshot
@@ -296,5 +296,5 @@ records › record_destruct_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 482
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/records.54f5977c.0.snapshot
+++ b/compiler/test/__snapshots__/records.54f5977c.0.snapshot
@@ -11,11 +11,11 @@ records › record_destruct_4
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1124 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1123 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1124 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1123 (param i32 i32 i32) (result i32)))
  (global $bar_1112 (mut i32) (i32.const 0))
  (global $foo_1111 (mut i32) (i32.const 0))
  (global $baz_1113 (mut i32) (i32.const 0))
@@ -351,10 +351,10 @@ records › record_destruct_4
        (local.set $10
         (tuple.extract 0
          (tuple.make
-          (call $+_1124
+          (call $+_1123
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $+_1124)
+            (global.get $+_1123)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
@@ -375,10 +375,10 @@ records › record_destruct_4
        (block $do_backpatches.21
        )
       )
-      (call $+_1124
+      (call $+_1123
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $+_1124)
+        (global.get $+_1123)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
@@ -430,5 +430,5 @@ records › record_destruct_4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 482
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/records.5f340064.0.snapshot
+++ b/compiler/test/__snapshots__/records.5f340064.0.snapshot
@@ -134,5 +134,5 @@ records › record_value_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 787
+ ;; custom section \"cmi\", size 1001
 )

--- a/compiler/test/__snapshots__/records.60c0a141.0.snapshot
+++ b/compiler/test/__snapshots__/records.60c0a141.0.snapshot
@@ -498,5 +498,5 @@ records › record_recursive_data_definition
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 728
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/records.60c7acc4.0.snapshot
+++ b/compiler/test/__snapshots__/records.60c7acc4.0.snapshot
@@ -146,5 +146,5 @@ records › record_pun_mixed_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1091
+ ;; custom section \"cmi\", size 1372
 )

--- a/compiler/test/__snapshots__/records.63a951b8.0.snapshot
+++ b/compiler/test/__snapshots__/records.63a951b8.0.snapshot
@@ -296,5 +296,5 @@ records › record_destruct_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 482
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/records.89d08e01.0.snapshot
+++ b/compiler/test/__snapshots__/records.89d08e01.0.snapshot
@@ -134,5 +134,5 @@ records › record_pun_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 787
+ ;; custom section \"cmi\", size 993
 )

--- a/compiler/test/__snapshots__/records.98824516.0.snapshot
+++ b/compiler/test/__snapshots__/records.98824516.0.snapshot
@@ -322,5 +322,5 @@ records › record_destruct_deep
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 731
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/records.a3299dd2.0.snapshot
+++ b/compiler/test/__snapshots__/records.a3299dd2.0.snapshot
@@ -11,11 +11,11 @@ records › record_destruct_3
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1123 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1122 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1123 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1122 (param i32 i32 i32) (result i32)))
  (global $bar_1112 (mut i32) (i32.const 0))
  (global $foo_1111 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
@@ -287,10 +287,10 @@ records › record_destruct_3
         )
        )
       )
-      (call $+_1123
+      (call $+_1122
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $+_1123)
+        (global.get $+_1122)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
@@ -330,5 +330,5 @@ records › record_destruct_3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 482
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/records.a702778a.0.snapshot
+++ b/compiler/test/__snapshots__/records.a702778a.0.snapshot
@@ -271,5 +271,5 @@ records › record_get_multilevel
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 733
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/records.a9c472b1.0.snapshot
+++ b/compiler/test/__snapshots__/records.a9c472b1.0.snapshot
@@ -206,5 +206,5 @@ records › record_multiple_fields_definition_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1397
+ ;; custom section \"cmi\", size 1865
 )

--- a/compiler/test/__snapshots__/records.b50d234d.0.snapshot
+++ b/compiler/test/__snapshots__/records.b50d234d.0.snapshot
@@ -165,5 +165,5 @@ records › record_get_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 482
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/records.d34c4740.0.snapshot
+++ b/compiler/test/__snapshots__/records.d34c4740.0.snapshot
@@ -146,5 +146,5 @@ records › record_pun_mixed
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1091
+ ;; custom section \"cmi\", size 1318
 )

--- a/compiler/test/__snapshots__/records.d393173c.0.snapshot
+++ b/compiler/test/__snapshots__/records.d393173c.0.snapshot
@@ -11,11 +11,11 @@ records › record_destruct_trailing
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1124 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1123 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1124 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1123 (param i32 i32 i32) (result i32)))
  (global $bar_1112 (mut i32) (i32.const 0))
  (global $foo_1111 (mut i32) (i32.const 0))
  (global $baz_1113 (mut i32) (i32.const 0))
@@ -351,10 +351,10 @@ records › record_destruct_trailing
        (local.set $10
         (tuple.extract 0
          (tuple.make
-          (call $+_1124
+          (call $+_1123
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
-            (global.get $+_1124)
+            (global.get $+_1123)
            )
            (call $incRef_0
             (global.get $GRAIN$EXPORT$incRef_0)
@@ -375,10 +375,10 @@ records › record_destruct_trailing
        (block $do_backpatches.21
        )
       )
-      (call $+_1124
+      (call $+_1123
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $+_1124)
+        (global.get $+_1123)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
@@ -430,5 +430,5 @@ records › record_destruct_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 482
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/records.d44e8007.0.snapshot
+++ b/compiler/test/__snapshots__/records.d44e8007.0.snapshot
@@ -146,5 +146,5 @@ records › record_pun_mixed_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1091
+ ;; custom section \"cmi\", size 1330
 )

--- a/compiler/test/__snapshots__/records.e4326567.0.snapshot
+++ b/compiler/test/__snapshots__/records.e4326567.0.snapshot
@@ -206,5 +206,5 @@ records › record_multiple_fields_both_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1397
+ ;; custom section \"cmi\", size 1817
 )

--- a/compiler/test/__snapshots__/records.e5b56da8.0.snapshot
+++ b/compiler/test/__snapshots__/records.e5b56da8.0.snapshot
@@ -134,5 +134,5 @@ records › record_both_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 787
+ ;; custom section \"cmi\", size 997
 )

--- a/compiler/test/__snapshots__/records.e705a980.0.snapshot
+++ b/compiler/test/__snapshots__/records.e705a980.0.snapshot
@@ -146,5 +146,5 @@ records › record_pun_multiple
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1091
+ ;; custom section \"cmi\", size 1336
 )

--- a/compiler/test/__snapshots__/records.f6e43cdb.0.snapshot
+++ b/compiler/test/__snapshots__/records.f6e43cdb.0.snapshot
@@ -146,5 +146,5 @@ records › record_pun_multiple_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1091
+ ;; custom section \"cmi\", size 1390
 )

--- a/compiler/test/__snapshots__/records.f6feee77.0.snapshot
+++ b/compiler/test/__snapshots__/records.f6feee77.0.snapshot
@@ -206,5 +206,5 @@ records › record_multiple_fields_value_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1397
+ ;; custom section \"cmi\", size 1825
 )

--- a/compiler/test/__snapshots__/records.fae50a8e.0.snapshot
+++ b/compiler/test/__snapshots__/records.fae50a8e.0.snapshot
@@ -146,5 +146,5 @@ records › record_pun_mixed_2_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1091
+ ;; custom section \"cmi\", size 1384
 )

--- a/compiler/test/__snapshots__/stdlib.1c0b04b7.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.1c0b04b7.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_20
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1112 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1111 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1112 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1111 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -299,10 +299,10 @@ stdlib › stdlib_equal_20
        (block $do_backpatches.13
        )
       )
-      (call $==_1112
+      (call $==_1111
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1112)
+        (global.get $==_1111)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
@@ -348,5 +348,5 @@ stdlib › stdlib_equal_20
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 482
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/stdlib.4a5061c2.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.4a5061c2.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_19
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1112 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1111 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1112 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1111 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -299,10 +299,10 @@ stdlib › stdlib_equal_19
        (block $do_backpatches.13
        )
       )
-      (call $==_1112
+      (call $==_1111
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1112)
+        (global.get $==_1111)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
@@ -348,5 +348,5 @@ stdlib › stdlib_equal_19
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 482
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/stdlib.69635cff.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.69635cff.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_21
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1112 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1111 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1112 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1111 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -299,10 +299,10 @@ stdlib › stdlib_equal_21
        (block $do_backpatches.13
        )
       )
-      (call $==_1112
+      (call $==_1111
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1112)
+        (global.get $==_1111)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
@@ -348,5 +348,5 @@ stdlib › stdlib_equal_21
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 482
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/__snapshots__/stdlib.cbf0318e.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.cbf0318e.0.snapshot
@@ -11,11 +11,11 @@ stdlib › stdlib_equal_22
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1112 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$==\" (global $==_1111 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1112 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"==\" (func $==_1111 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (elem $elem (global.get $relocBase_0))
  (export \"memory\" (memory $0))
@@ -299,10 +299,10 @@ stdlib › stdlib_equal_22
        (block $do_backpatches.13
        )
       )
-      (call $==_1112
+      (call $==_1111
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
-        (global.get $==_1112)
+        (global.get $==_1111)
        )
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
@@ -348,5 +348,5 @@ stdlib › stdlib_equal_22
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 482
+ ;; custom section \"cmi\", size 236
 )

--- a/compiler/test/suites/types.re
+++ b/compiler/test/suites/types.re
@@ -202,7 +202,7 @@ describe("aliased types", ({test, testSkip}) => {
   assertRun(
     "regression_annotated_type_func_1",
     {|
-      type AddPrinter = (Number, Number) -> Void
+      abstract type AddPrinter = (Number, Number) -> Void
       provide let add: AddPrinter = (x, y) => print(x + y)
       add(4, 4)
     |},
@@ -211,7 +211,7 @@ describe("aliased types", ({test, testSkip}) => {
   assertRun(
     "regression_annotated_type_func_2",
     {|
-      type AddPrinter<a> = (a, a) -> Void
+      abstract type AddPrinter<a> = (a, a) -> Void
       provide let add: AddPrinter<Number> = (x, y) => print(x + y)
       add(4, 4)
     |},
@@ -236,6 +236,125 @@ describe("abstract types", ({test, testSkip}) => {
     // TODO: This will be a type error when we support fully abstract types
     // "expected of type
     //      Foo",
+  );
+
+  assertCompileError(
+    "type_provided_1",
+    {|
+      type Foo = Number
+      provide let three: Foo = 3
+    |},
+    "value is provided but contains type Foo",
+  );
+  assertCompileError(
+    "type_provided_2",
+    {|
+      enum Foo { Foo }
+      provide let foo = Foo
+    |},
+    "value is provided but contains type Foo",
+  );
+  assertCompileError(
+    "type_provided_3",
+    {|
+      record Foo { foo: String }
+      provide let foo = { foo: "" }
+    |},
+    "value is provided but contains type Foo",
+  );
+  assertCompileError(
+    "type_provided_4",
+    {|
+      type Foo = Number
+      provide type Bar = Foo
+    |},
+    "type is provided but contains type Foo",
+  );
+  assertCompileError(
+    "type_provided_5",
+    {|
+      type Foo = Number
+      provide enum Bar { Bar(Foo) }
+    |},
+    "enum is provided but contains type Foo",
+  );
+  assertCompileError(
+    "type_provided_6",
+    {|
+      type Foo = Number
+      provide record Bar { bar: Foo }
+    |},
+    "record is provided but contains type Foo",
+  );
+  assertCompileError(
+    "type_provided_7",
+    {|
+      type Foo = Number
+      provide module Nested {
+        provide let foo: Foo = 5
+      }
+    |},
+    "module is provided but contains type Foo",
+  );
+  assertCompileError(
+    "type_provided_8",
+    {|
+      module Nested {
+        type Foo = Number
+        provide let three: Foo = 3
+      }
+    |},
+    "value is provided but contains type Foo",
+  );
+  assertCompileError(
+    "type_provided_9",
+    {|
+      module Nested {
+        enum Foo { Foo }
+        provide let foo = Foo
+      }
+    |},
+    "value is provided but contains type Foo",
+  );
+  assertCompileError(
+    "type_provided_10",
+    {|
+      module Nested {
+        record Foo { foo: String }
+        provide let foo = { foo: "" }
+      }
+    |},
+    "value is provided but contains type Foo",
+  );
+  assertCompileError(
+    "type_provided_11",
+    {|
+      module Nested {
+        type Foo = Number
+        provide type Bar = Foo
+      }
+    |},
+    "type is provided but contains type Foo",
+  );
+  assertCompileError(
+    "type_provided_12",
+    {|
+      module Nested {
+        type Foo = Number
+        provide enum Bar { Bar(Foo) }
+      }
+    |},
+    "enum is provided but contains type Foo",
+  );
+  assertCompileError(
+    "type_provided_13",
+    {|
+      module Nested {
+        type Foo = Number
+        provide record Bar { bar: Foo }
+      }
+    |},
+    "record is provided but contains type Foo",
   );
 
   assertRun(

--- a/compiler/test/test-libs/aliases.gr
+++ b/compiler/test/test-libs/aliases.gr
@@ -3,8 +3,8 @@ module Aliases
 provide type Foo = Number
 provide type Bar<a> = List<a>
 
-type Baz = Number
-type Qux<a> = a
+abstract type Baz = Number
+abstract type Qux<a> = a
 
 provide let baz = 5: Baz
 provide let qux = 7: Qux<Number>

--- a/stdlib/buffer.gr
+++ b/stdlib/buffer.gr
@@ -20,7 +20,7 @@ include "char"
 include "runtime/numbers"
 from Numbers use { coerceNumberToWasmI32 }
 
-record Buffer {
+abstract record Buffer {
   mut len: Number,
   initialSize: Number,
   mut data: Bytes,

--- a/stdlib/immutablearray.gr
+++ b/stdlib/immutablearray.gr
@@ -79,7 +79,7 @@ record Builder<a> {
 
 // A "tail" of < 32 values at the end of the array is kept as a performance
 // optimization
-record ImmutableArray<a> {
+abstract record ImmutableArray<a> {
   length: Number,
   shift: Number,
   root: Tree<a>,

--- a/stdlib/immutablemap.gr
+++ b/stdlib/immutablemap.gr
@@ -24,7 +24,7 @@ record Node<k, v> {
 /**
  * @section Types: Type declarations included in the ImmutableMap module.
  */
-enum ImmutableMap<k, v> {
+abstract enum ImmutableMap<k, v> {
   Empty,
   Tree(Node<k, v>),
 }

--- a/stdlib/immutablepriorityqueue.gr
+++ b/stdlib/immutablepriorityqueue.gr
@@ -36,7 +36,7 @@ record PQRoot<a> {
 /**
  * Immutable data structure which maintains a priority order for its elements.
  */
-record ImmutablePriorityQueue<a> {
+abstract record ImmutablePriorityQueue<a> {
   comp: (a, a) -> Number,
   size: Number,
   root: Option<PQRoot<a>>,

--- a/stdlib/immutableset.gr
+++ b/stdlib/immutableset.gr
@@ -23,7 +23,7 @@ record Node<a> {
 /**
  * @section Types: Type declarations included in the ImmutableSet module.
  */
-enum ImmutableSet<a> {
+abstract enum ImmutableSet<a> {
   Empty,
   Tree(Node<a>),
 }

--- a/stdlib/map.gr
+++ b/stdlib/map.gr
@@ -28,7 +28,7 @@ record Bucket<k, v> {
  * @section Types: Type declarations included in the Map module.
  */
 
-record Map<k, v> {
+abstract record Map<k, v> {
   mut size: Number,
   mut buckets: Array<Option<Bucket<k, v>>>,
 }

--- a/stdlib/path.gr
+++ b/stdlib/path.gr
@@ -104,28 +104,28 @@ provide enum AbsoluteRoot {
 /**
  * Represents a relative path.
  */
-record Relative {
+abstract record Relative {
   _rel: Void,
 }
 
 /**
  * Represents an absolute path.
  */
-record Absolute {
+abstract record Absolute {
   _abs: Void,
 }
 
 /**
  * Represents a path referencing a file.
  */
-record File {
+abstract record File {
   _file: Void,
 }
 
 /**
  * Represents a path referencing a directory.
  */
-record Directory {
+abstract record Directory {
   _directory: Void,
 }
 
@@ -133,7 +133,7 @@ record Directory {
  * Represents a path typed on (`Absolute` or `Relative`) and (`File` or
  * `Directory`)
  */
-type TypedPath<a, b> = (TBase<a>, TFileType<b>, List<String>),
+abstract type TypedPath<a, b> = (TBase<a>, TFileType<b>, List<String>),
 /**
  * Represents a system path.
  */

--- a/stdlib/priorityqueue.gr
+++ b/stdlib/priorityqueue.gr
@@ -20,7 +20,7 @@ include "option"
 /**
  * Mutable data structure which maintains a priority order for its elements.
  */
-record PriorityQueue<a> {
+abstract record PriorityQueue<a> {
   mut size: Number,
   mut array: Array<Option<a>>,
   comp: (a, a) -> Number,

--- a/stdlib/queue.gr
+++ b/stdlib/queue.gr
@@ -16,7 +16,7 @@ include "list"
  * @section Types: Type declarations included in the Queue module.
  */
 
-record Queue<a> {
+abstract record Queue<a> {
   forwards: List<a>,
   backwards: List<a>,
 }

--- a/stdlib/random.gr
+++ b/stdlib/random.gr
@@ -21,7 +21,7 @@ include "runtime/dataStructures" as DS
  * @section Types: Type declarations included in the Random module.
  */
 
-record Random {
+abstract record Random {
   seed: Uint64,
   mut counter: Uint64,
   mut initialized: Bool,

--- a/stdlib/regex.gr
+++ b/stdlib/regex.gr
@@ -3315,8 +3315,7 @@ let interp = (compiledRe, matchBuffer, pos, start, limitOrEnd, state) => {
   compiledRe(matchBuffer, pos, start, limitOrEnd, limitOrEnd, state, [])
 }
 
-// Should be provided as abstract type when possible
-record RegularExpression {
+abstract record RegularExpression {
   reParsed: ParsedRegularExpression,
   reNumGroups: Number,
   reReferences: Bool,

--- a/stdlib/set.gr
+++ b/stdlib/set.gr
@@ -22,7 +22,7 @@ record Bucket<t> {
  * @section Types: Type declarations included in the Set module.
  */
 
-record Set<k> {
+abstract record Set<k> {
   mut size: Number,
   mut buckets: Array<Option<Bucket<k>>>,
 }

--- a/stdlib/stack.gr
+++ b/stdlib/stack.gr
@@ -19,7 +19,7 @@ include "list"
 /**
  * Stacks are immutable data structures that store their data in a List.
  */
-record Stack<a> {
+abstract record Stack<a> {
   data: List<a>,
 }
 


### PR DESCRIPTION
Previously, any type defined in a module that was not provided was still provided by the compiler as an abstract type. Now, types must explicitly be marked with a new `abstract` keyword to indicate that the type should be visible but the implementation hidden.

This is a breaking change because types not marked with `provide` or `abstract` no longer appear in module signatures. If a value is provided by a module but uses a type that is not also provided or abstract, the compiler shows an error, as this type is private and not accessible by consuming modules.

Closes #1240 