### PR TITLE
chore(graindoc)!: Remove section attribute

### DIFF
--- a/compiler/src/diagnostics/comment_attributes.re
+++ b/compiler/src/diagnostics/comment_attributes.re
@@ -17,12 +17,7 @@ type t =
       attr_desc,
       attr_type,
     })
-  // Currently only accepts single-line examples
   | Example({attr_desc})
-  | Section({
-      attr_name,
-      attr_desc,
-    })
   | Deprecated({attr_desc})
   | Since({attr_version})
   | History({

--- a/compiler/src/diagnostics/comments.re
+++ b/compiler/src/diagnostics/comments.re
@@ -90,13 +90,6 @@ module Attribute = {
     };
   };
 
-  let is_section = attr => {
-    switch (attr) {
-    | Section(_) => true
-    | _ => false
-    };
-  };
-
   let is_deprecated = attr => {
     switch (attr) {
     | Deprecated(_) => true
@@ -254,16 +247,6 @@ module Doc = {
       };
     };
     ending_on_lnum_help(lnum, true);
-  };
-
-  let find_sections = (module C: OrderedComments) => {
-    let section_comments = ref([]);
-    C.iter((_, (_comment, _desc, attrs) as comment) =>
-      if (List.exists(Attribute.is_section, attrs)) {
-        section_comments := [comment, ...section_comments^];
-      }
-    );
-    List.rev(section_comments^);
   };
 };
 

--- a/compiler/src/diagnostics/graindoc_lexer.re
+++ b/compiler/src/diagnostics/graindoc_lexer.re
@@ -60,7 +60,6 @@ and lexer_mode =
   | Start
   | Default
   | Param
-  | Section
   | Since
   | History
   | Throws
@@ -71,7 +70,6 @@ let rec token = (state, lexbuf) => {
   | Start => start(state, lexbuf)
   | Default => default(state, lexbuf)
   | Param => param(state, lexbuf)
-  | Section => section(state, lexbuf)
   | Since => since(state, lexbuf)
   | History => history(state, lexbuf)
   | Throws => throws(state, lexbuf)
@@ -102,9 +100,6 @@ and default = (state, lexbuf) => {
   | "@example" =>
     state.lexer_mode = FreeTextAttribute;
     EXAMPLE;
-  | "@section" =>
-    state.lexer_mode = Section;
-    SECTION;
   | "@deprecated" =>
     state.lexer_mode = FreeTextAttribute;
     DEPRECATED;

--- a/compiler/src/diagnostics/graindoc_parser.messages
+++ b/compiler/src/diagnostics/graindoc_parser.messages
@@ -125,15 +125,6 @@ graindoc: THROWS CONSTRUCTOR THROWS
 ## The known suffix of the stack is as follows:
 ## THROWS CONSTRUCTOR
 ##
-graindoc: SECTION TEXT THROWS
-##
-## Ends in an error in state: 24.
-##
-## attribute -> SECTION TEXT . COLON attribute_text [ THROWS SINCE SECTION RETURNS PARAM HISTORY EXAMPLE EOL EOF DEPRECATED ]
-##
-## The known suffix of the stack is as follows:
-## SECTION TEXT
-##
 graindoc: PARAM IDENT THROWS
 ##
 ## Ends in an error in state: 30.
@@ -174,15 +165,6 @@ graindoc: DEPRECATED EOL THROWS
 ##
 ## The known suffix of the stack is as follows:
 ## eols
-##
-graindoc: SECTION TEXT COLON THROWS
-##
-## Ends in an error in state: 25.
-##
-## attribute -> SECTION TEXT COLON . attribute_text [ THROWS SINCE SECTION RETURNS PARAM HISTORY EXAMPLE EOL EOF DEPRECATED ]
-##
-## The known suffix of the stack is as follows:
-## SECTION TEXT COLON
 ##
 graindoc: RETURNS THROWS
 ##
@@ -252,18 +234,6 @@ graindoc: HISTORY THROWS
 ##
 
 Expected a version number in Semantic Versioning format, e.g. `v1.2.3`.
-
-graindoc: SECTION THROWS
-##
-## Ends in an error in state: 23.
-##
-## attribute -> SECTION . TEXT COLON attribute_text [ THROWS SINCE SECTION RETURNS PARAM HISTORY EXAMPLE EOL EOF DEPRECATED ]
-##
-## The known suffix of the stack is as follows:
-## SECTION
-##
-
-Expected a section title.
 
 graindoc: PARAM THROWS
 ##

--- a/compiler/src/diagnostics/graindoc_parser.mly
+++ b/compiler/src/diagnostics/graindoc_parser.mly
@@ -30,7 +30,6 @@ attribute:
   | PARAM IDENT COLON attribute_text { Param({ attr_name=$2; attr_type=None; attr_desc=$4 }) }
   | RETURNS attribute_text { Returns({ attr_desc=$2; attr_type=None }) }
   | EXAMPLE attribute_text { Example({attr_desc=$2}) }
-  | SECTION TEXT COLON attribute_text { Section({ attr_name=$2; attr_desc=$4; }) }
   | DEPRECATED attribute_text { Deprecated({attr_desc=$2}) }
   | SINCE SEMVER { Since({attr_version=$2}) }
   | HISTORY SEMVER COLON attribute_text { History({ attr_version=$2; attr_desc=$4; }) }

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -18,10 +18,6 @@ include "runtime/exception"
 include "runtime/numbers"
 from Numbers use { coerceNumberToWasmI32 }
 
-/**
- * @section Values: Functions for working with the Array data type.
- */
-
 @unsafe
 let mut _ARRAY_LENGTH_OFFSET = 4n
 @unsafe

--- a/stdlib/array.md
+++ b/stdlib/array.md
@@ -23,7 +23,7 @@ include "array"
 
 ## Values
 
-Functions for working with the Array data type.
+Functions and constants included in the Array module.
 
 ### Array.**length**
 

--- a/stdlib/bigint.gr
+++ b/stdlib/bigint.gr
@@ -20,10 +20,6 @@ from Numbers use {
 }
 
 /**
- * @section Conversions: Functions for converting between Numbers and the BigInt type.
- */
-
-/**
  * Converts a Number to a BigInt.
  *
  * @param number: The value to convert
@@ -41,10 +37,6 @@ provide { fromNumber }
  * @since v0.5.0
  */
 provide { toNumber }
-
-/**
- * @section Operations: Mathematical operations for BigInt values.
- */
 
 /**
  * Increments the value by one.
@@ -218,10 +210,6 @@ provide let gcd = (num1: BigInt, num2: BigInt) => {
 }
 
 /**
- * @section Bitwise operations: Functions for operating on bits of BigInt values.
- */
-
-/**
  * Shifts the bits of the value left by the given number of bits.
  *
  * @param num: The value to shift
@@ -252,10 +240,6 @@ provide let shr = (num: BigInt, places: Int32) => {
   let places = WasmI32.load(WasmI32.fromGrain(places), 8n)
   WasmI32.toGrain(BI.shrS(num, places)): BigInt
 }
-
-/**
- * @section Comparisons: Functions for comparing BigInt values.
- */
 
 /**
  * Checks if the given value is equal to zero.
@@ -366,10 +350,6 @@ provide let gte = (num1: BigInt, num2: BigInt) => {
   let num2 = WasmI32.fromGrain(num2)
   BI.gte(num1, num2)
 }
-
-/**
- * @section Bitwise logic: Boolean operations on the bits of BigInt values.
- */
 
 /**
  * Computes the bitwise NOT of the given value.
@@ -483,10 +463,6 @@ provide let popcnt = (num: BigInt) => {
     None
   }
 }
-
-/**
- * @section Other: Other functions on BigInts.
- */
 
 /**
  * Converts the given operand to a string.

--- a/stdlib/bigint.md
+++ b/stdlib/bigint.md
@@ -13,9 +13,9 @@ No other changes yet.
 include "bigint"
 ```
 
-## Conversions
+## Values
 
-Functions for converting between Numbers and the BigInt type.
+Functions and constants included in the BigInt module.
 
 ### BigInt.**fromNumber**
 
@@ -66,10 +66,6 @@ Returns:
 |type|description|
 |----|-----------|
 |`Number`|The BigInt represented as a Number|
-
-## Operations
-
-Mathematical operations for BigInt values.
 
 ### BigInt.**incr**
 
@@ -355,10 +351,6 @@ Returns:
 |----|-----------|
 |`BigInt`|The greatest common divisor of its operands|
 
-## Bitwise operations
-
-Functions for operating on bits of BigInt values.
-
 ### BigInt.**shl**
 
 <details disabled>
@@ -410,10 +402,6 @@ Returns:
 |type|description|
 |----|-----------|
 |`BigInt`|The shifted value|
-
-## Comparisons
-
-Functions for comparing BigInt values.
 
 ### BigInt.**eqz**
 
@@ -596,10 +584,6 @@ Returns:
 |----|-----------|
 |`Bool`|`true` if the first value is greater than or equal to the second value or `false` otherwise|
 
-## Bitwise logic
-
-Boolean operations on the bits of BigInt values.
-
 ### BigInt.**lnot**
 
 <details disabled>
@@ -779,10 +763,6 @@ Returns:
 |type|description|
 |----|-----------|
 |`Option<Int64>`|The amount of 1-bits in its operand|
-
-## Other
-
-Other functions on BigInts.
 
 ### BigInt.**toString**
 

--- a/stdlib/buffer.gr
+++ b/stdlib/buffer.gr
@@ -105,10 +105,6 @@ let addInt32help = (value, buffer) => {
 }
 
 /**
- * @section Values: Functions for working with the Buffer data type.
- */
-
-/**
  * Creates a fresh buffer, initially empty.
  *
  * The `initialSize` parameter is the initial size of the internal byte sequence that holds the buffer contents.
@@ -415,10 +411,6 @@ provide let addBuffer = (srcBuffer, dstBuffer) => {
 provide let addBufferSlice = (start, length, srcBuffer, dstBuffer) => {
   addBytesSlice(start, length, srcBuffer.data, dstBuffer)
 }
-
-/**
- * @section Binary operations on integers: Functions for encoding and decoding integers stored in a buffer.
- */
 
 /**
  * Gets a signed 8-bit integer starting at the given byte index.

--- a/stdlib/buffer.md
+++ b/stdlib/buffer.md
@@ -15,9 +15,19 @@ No other changes yet.
 include "buffer"
 ```
 
+## Types
+
+Type declarations included in the Buffer module.
+
+### Buffer.**Buffer**
+
+```grain
+type Buffer
+```
+
 ## Values
 
-Functions for working with the Buffer data type.
+Functions and constants included in the Buffer module.
 
 ### Buffer.**make**
 
@@ -426,10 +436,6 @@ Parameters:
 |`length`|`Number`|The number of bytes to append|
 |`srcBuffer`|`Buffer`|The buffer to append|
 |`dstBuffer`|`Buffer`|The buffer to mutate|
-
-## Binary operations on integers
-
-Functions for encoding and decoding integers stored in a buffer.
 
 ### Buffer.**getInt8S**
 

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -57,10 +57,6 @@ let checkIndexIsInBounds = (i, byteSize, max) => {
 let getSize = ptr => WasmI32.load(ptr, _SIZE_OFFSET)
 
 /**
- * @section Values: Functions for working with the Bytes data type.
- */
-
-/**
  * Creates a new byte sequence of the input size.
  *
  * @param size: The number of bytes to store
@@ -337,10 +333,6 @@ provide let clear = (bytes: Bytes) => {
   let size = getSize(src)
   Memory.fill(src + _VALUE_OFFSET, 0n, size)
 }
-
-/**
- * @section Binary operations on integers: Functions for encoding and decoding integers stored in a byte sequence.
- */
 
 /**
  * Gets a signed 8-bit integer starting at the given byte index.

--- a/stdlib/bytes.md
+++ b/stdlib/bytes.md
@@ -15,7 +15,7 @@ include "bytes"
 
 ## Values
 
-Functions for working with the Bytes data type.
+Functions and constants included in the Bytes module.
 
 ### Bytes.**make**
 
@@ -318,10 +318,6 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`bytes`|`Bytes`|The byte sequence to clear|
-
-## Binary operations on integers
-
-Functions for encoding and decoding integers stored in a byte sequence.
 
 ### Bytes.**getInt8S**
 

--- a/stdlib/char.gr
+++ b/stdlib/char.gr
@@ -18,10 +18,6 @@ from DataStructures use { tagSimpleNumber, tagChar, untagChar, allocateString }
 exception MalformedUtf8
 
 /**
- * @section Values: Functions and constants included in the Char module.
- */
-
-/**
  * The minimum valid Unicode scalar value.
  *
  * @since 0.3.0

--- a/stdlib/exception.gr
+++ b/stdlib/exception.gr
@@ -15,10 +15,6 @@ include "runtime/unsafe/memory"
 include "runtime/exception"
 
 /**
- * @section Values: Functions included in the Exception module.
- */
-
-/**
  * Registers an exception printer. When an exception is thrown, all registered
  * printers are called in order from the most recently registered printer to
  * the least recently registered printer. The first `Some` value returned is

--- a/stdlib/exception.md
+++ b/stdlib/exception.md
@@ -17,7 +17,7 @@ include "exception"
 
 ## Values
 
-Functions included in the Exception module.
+Functions and constants included in the Exception module.
 
 ### Exception.**registerPrinter**
 

--- a/stdlib/float32.gr
+++ b/stdlib/float32.gr
@@ -20,10 +20,6 @@ from Numbers use {
 }
 
 /**
- * @section Constants: Float32 constant values.
- */
-
-/**
  * Infinity represented as a Float32 value.
  *
  * @since v0.4.0
@@ -69,9 +65,6 @@ provide let tau = 6.2831853f
  * @since v0.5.2
  */
 provide let e = 2.7182817f
-/**
- * @section Conversions: Functions for converting between Numbers and the Float32 type.
- */
 
 /**
  * Converts a Number to a Float32.
@@ -92,10 +85,6 @@ provide { fromNumber }
  * @since v0.2.0
  */
 provide { toNumber }
-
-/**
- * @section Operations: Mathematical operations for Float32 values.
- */
 
 /**
  * Computes the sum of its operands.
@@ -164,10 +153,6 @@ provide let div = (x: Float32, y: Float32) => {
   let ptr = newFloat32(WasmF32.div(xv, yv))
   WasmI32.toGrain(ptr): Float32
 }
-
-/**
- * @section Comparisons: Functions for comparing Float32 values.
- */
 
 /**
  * Checks if the first value is less than the second value.

--- a/stdlib/float32.md
+++ b/stdlib/float32.md
@@ -13,9 +13,9 @@ No other changes yet.
 include "float32"
 ```
 
-## Constants
+## Values
 
-Float32 constant values.
+Functions and constants included in the Float32 module.
 
 ### Float32.**infinity**
 
@@ -82,10 +82,6 @@ e : Float32
 
 Euler's number represented as a Float32 value.
 
-## Conversions
-
-Functions for converting between Numbers and the Float32 type.
-
 ### Float32.**fromNumber**
 
 <details disabled>
@@ -135,10 +131,6 @@ Returns:
 |type|description|
 |----|-----------|
 |`Number`|The Float32 represented as a Number|
-
-## Operations
-
-Mathematical operations for Float32 values.
 
 ### Float32.**add**
 
@@ -243,10 +235,6 @@ Returns:
 |type|description|
 |----|-----------|
 |`Float32`|The quotient of the two operands|
-
-## Comparisons
-
-Functions for comparing Float32 values.
 
 ### Float32.**lt**
 

--- a/stdlib/float64.gr
+++ b/stdlib/float64.gr
@@ -20,10 +20,6 @@ from Numbers use {
 }
 
 /**
- * @section Constants: Float64 constant values.
- */
-
-/**
  * Infinity represented as a Float64 value.
  *
  * @since v0.4.0
@@ -75,10 +71,6 @@ provide let tau = 6.283185307179586d
 provide let e = 2.718281828459045d
 
 /**
- * @section Conversions: Functions for converting between Numbers and the Float64 type.
- */
-
-/**
  * Converts a Number to a Float64.
  *
  * @param number: The value to convert
@@ -97,10 +89,6 @@ provide { fromNumber }
  * @since v0.2.0
  */
 provide { toNumber }
-
-/**
- * @section Operations: Mathematical operations for Float64 values.
- */
 
 /**
  * Computes the sum of its operands.
@@ -169,10 +157,6 @@ provide let div = (x: Float64, y: Float64) => {
   let ptr = newFloat64(WasmF64.div(xv, yv))
   WasmI32.toGrain(ptr): Float64
 }
-
-/**
- * @section Comparisons: Functions for comparing Float64 values.
- */
 
 /**
  * Checks if the first value is less than the second value.

--- a/stdlib/float64.md
+++ b/stdlib/float64.md
@@ -13,9 +13,9 @@ No other changes yet.
 include "float64"
 ```
 
-## Constants
+## Values
 
-Float64 constant values.
+Functions and constants included in the Float64 module.
 
 ### Float64.**infinity**
 
@@ -82,10 +82,6 @@ e : Float64
 
 Euler's number represented as a Float64 value.
 
-## Conversions
-
-Functions for converting between Numbers and the Float64 type.
-
 ### Float64.**fromNumber**
 
 <details disabled>
@@ -135,10 +131,6 @@ Returns:
 |type|description|
 |----|-----------|
 |`Number`|The Float64 represented as a Number|
-
-## Operations
-
-Mathematical operations for Float64 values.
 
 ### Float64.**add**
 
@@ -243,10 +235,6 @@ Returns:
 |type|description|
 |----|-----------|
 |`Float64`|The quotient of the two operands|
-
-## Comparisons
-
-Functions for comparing Float64 values.
 
 ### Float64.**lt**
 

--- a/stdlib/hash.gr
+++ b/stdlib/hash.gr
@@ -236,9 +236,6 @@ let rec hashOne = (val, depth) => {
     hash32(val)
   }
 }
-/**
- * @section Values: Functions for hashing.
- */
 
 /**
  * A generic hash function that produces an integer from any value. If `a == b` then `Hash.hash(a) == Hash.hash(b)`.

--- a/stdlib/hash.md
+++ b/stdlib/hash.md
@@ -15,7 +15,7 @@ include "hash"
 
 ## Values
 
-Functions for hashing.
+Functions and constants included in the Hash module.
 
 ### Hash.**hash**
 

--- a/stdlib/immutablearray.gr
+++ b/stdlib/immutablearray.gr
@@ -73,10 +73,6 @@ record Builder<a> {
   numNodes: Number,
 }
 
-/**
- * @section Types: Type declarations included in the ImmutableArray module.
- */
-
 // A "tail" of < 32 values at the end of the array is kept as a performance
 // optimization
 abstract record ImmutableArray<a> {
@@ -85,10 +81,6 @@ abstract record ImmutableArray<a> {
   root: Tree<a>,
   tail: Array<a>,
 }
-
-/**
- * @section Values: Functions and constants for working with immutable arrays.
- */
 
 /**
  * An empty array.

--- a/stdlib/immutablearray.md
+++ b/stdlib/immutablearray.md
@@ -25,7 +25,7 @@ type ImmutableArray<a>
 
 ## Values
 
-Functions and constants for working with immutable arrays.
+Functions and constants included in the ImmutableArray module.
 
 ### ImmutableArray.**empty**
 

--- a/stdlib/immutablemap.gr
+++ b/stdlib/immutablemap.gr
@@ -21,17 +21,10 @@ record Node<k, v> {
   left: ImmutableMap<k, v>,
   right: ImmutableMap<k, v>,
 },
-/**
- * @section Types: Type declarations included in the ImmutableMap module.
- */
 abstract enum ImmutableMap<k, v> {
   Empty,
   Tree(Node<k, v>),
 }
-
-/**
- * @section Values: Functions and constants for working with ImmutableMaps.
- */
 
 // semi-arbitrary value chosen for algorithm for determining when to balance
 // trees; no tree can have a left subtree containing this number of times

--- a/stdlib/immutablemap.md
+++ b/stdlib/immutablemap.md
@@ -25,7 +25,7 @@ type ImmutableMap<k, v>
 
 ## Values
 
-Functions and constants for working with ImmutableMaps.
+Functions and constants included in the ImmutableMap module.
 
 ### ImmutableMap.**empty**
 

--- a/stdlib/immutablepriorityqueue.gr
+++ b/stdlib/immutablepriorityqueue.gr
@@ -30,10 +30,6 @@ record PQRoot<a> {
 }
 
 /**
- * @section Types: Type declarations included in the ImmutablePriorityQueue module.
- */
-
-/**
  * Immutable data structure which maintains a priority order for its elements.
  */
 abstract record ImmutablePriorityQueue<a> {
@@ -41,10 +37,6 @@ abstract record ImmutablePriorityQueue<a> {
   size: Number,
   root: Option<PQRoot<a>>,
 }
-
-/**
- * @section Values: Functions and constants for working with ImmutablePriorityQueues.
- */
 
 /**
  * An empty priority queue with the default `compare` comparator.

--- a/stdlib/immutablepriorityqueue.md
+++ b/stdlib/immutablepriorityqueue.md
@@ -27,7 +27,7 @@ Immutable data structure which maintains a priority order for its elements.
 
 ## Values
 
-Functions and constants for working with ImmutablePriorityQueues.
+Functions and constants included in the ImmutablePriorityQueue module.
 
 ### ImmutablePriorityQueue.**empty**
 

--- a/stdlib/immutableset.gr
+++ b/stdlib/immutableset.gr
@@ -20,17 +20,10 @@ record Node<a> {
   left: ImmutableSet<a>,
   right: ImmutableSet<a>,
 },
-/**
- * @section Types: Type declarations included in the ImmutableSet module.
- */
 abstract enum ImmutableSet<a> {
   Empty,
   Tree(Node<a>),
 }
-
-/**
- * @section Values: Functions and constants for working with ImmutableSets.
- */
 
 // semi-arbitrary value chosen for algorithm for determining when to balance
 // trees; no tree can have a left subtree containing this number of times

--- a/stdlib/immutableset.md
+++ b/stdlib/immutableset.md
@@ -25,7 +25,7 @@ type ImmutableSet<a>
 
 ## Values
 
-Functions and constants for working with ImmutableSets.
+Functions and constants included in the ImmutableSet module.
 
 ### ImmutableSet.**empty**
 

--- a/stdlib/int32.gr
+++ b/stdlib/int32.gr
@@ -21,10 +21,6 @@ from Numbers use {
 }
 
 /**
- * @section Conversions: Functions for converting between Numbers and the Int32 type.
- */
-
-/**
  * Converts a Number to an Int32.
  *
  * @param number: The value to convert
@@ -49,7 +45,7 @@ provide { toNumber }
  *
  * @param number: The value to convert
  * @returns The Uint32 represented as a Int32
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -58,10 +54,6 @@ provide let fromUint32 = (x: Uint32) => {
   let result = newInt32(x)
   WasmI32.toGrain(result): Int32
 }
-
-/**
- * @section Operations: Mathematical operations for Int32 values.
- */
 
 /**
  * Increments the value by one.
@@ -222,10 +214,6 @@ provide let mod = (x: Int32, y: Int32) => {
 }
 
 /**
- * @section Bitwise operations: Functions for operating on bits of Int32 values.
- */
-
-/**
  * Rotates the bits of the value left by the given number of bits.
  *
  * @param value: The value to rotate
@@ -292,10 +280,6 @@ provide let shr = (value: Int32, amount: Int32) => {
   let ptr = newInt32(WasmI32.shrS(xv, yv))
   WasmI32.toGrain(ptr): Int32
 }
-
-/**
- * @section Comparisons: Functions for comparing Int32 values.
- */
 
 /**
  * Checks if the first value is equal to the second value.
@@ -406,10 +390,6 @@ provide let gte = (x: Int32, y: Int32) => {
   let yv = WasmI32.load(WasmI32.fromGrain(y), 8n)
   WasmI32.geS(xv, yv)
 }
-
-/**
- * @section Bitwise logic: Boolean operations on the bits of Int32 values.
- */
 
 /**
  * Computes the bitwise NOT of the given value.

--- a/stdlib/int32.md
+++ b/stdlib/int32.md
@@ -13,9 +13,9 @@ No other changes yet.
 include "int32"
 ```
 
-## Conversions
+## Values
 
-Functions for converting between Numbers and the Int32 type.
+Functions and constants included in the Int32 module.
 
 ### Int32.**fromNumber**
 
@@ -91,10 +91,6 @@ Returns:
 |type|description|
 |----|-----------|
 |`Int32`|The Uint32 represented as a Int32|
-
-## Operations
-
-Mathematical operations for Int32 values.
 
 ### Int32.**incr**
 
@@ -309,10 +305,6 @@ Throws:
 
 * When `y` is zero
 
-## Bitwise operations
-
-Functions for operating on bits of Int32 values.
-
 ### Int32.**rotl**
 
 <details disabled>
@@ -416,10 +408,6 @@ Returns:
 |type|description|
 |----|-----------|
 |`Int32`|The shifted value|
-
-## Comparisons
-
-Functions for comparing Int32 values.
 
 ### Int32.**eq**
 
@@ -601,10 +589,6 @@ Returns:
 |type|description|
 |----|-----------|
 |`Bool`|`true` if the first value is greater than or equal to the second value or `false` otherwise|
-
-## Bitwise logic
-
-Boolean operations on the bits of Int32 values.
 
 ### Int32.**lnot**
 

--- a/stdlib/int64.gr
+++ b/stdlib/int64.gr
@@ -22,10 +22,6 @@ from Numbers use {
 }
 
 /**
- * @section Conversions: Functions for converting between Numbers and the Int64 type.
- */
-
-/**
  * Converts a Number to an Int64.
  *
  * @param number: The value to convert
@@ -50,7 +46,7 @@ provide { toNumber }
  *
  * @param number: The value to convert
  * @returns The Uint64 represented as a Int64
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -59,10 +55,6 @@ provide let fromUint64 = (x: Uint64) => {
   let result = newInt64(x)
   WasmI32.toGrain(result): Int64
 }
-
-/**
- * @section Operations: Mathematical operations for Int64 values.
- */
 
 /**
  * Increments the value by one.
@@ -223,10 +215,6 @@ provide let mod = (x: Int64, y: Int64) => {
 }
 
 /**
- * @section Bitwise operations: Functions for operating on bits of Int64 values.
- */
-
-/**
  * Rotates the bits of the value left by the given number of bits.
  *
  * @param value: The value to rotate
@@ -293,10 +281,6 @@ provide let shr = (value: Int64, amount: Int64) => {
   let ptr = newInt64(WasmI64.shrS(xv, yv))
   WasmI32.toGrain(ptr): Int64
 }
-
-/**
- * @section Comparisons: Functions for comparing Int64 values.
- */
 
 /**
  * Checks if the first value is equal to the second value.
@@ -407,10 +391,6 @@ provide let gte = (x: Int64, y: Int64) => {
   let yv = WasmI64.load(WasmI32.fromGrain(y), 8n)
   WasmI64.geS(xv, yv)
 }
-
-/**
- * @section Bitwise logic: Boolean operations on the bits of Int64 values.
- */
 
 /**
  * Computes the bitwise NOT of the given value.

--- a/stdlib/int64.md
+++ b/stdlib/int64.md
@@ -13,9 +13,9 @@ No other changes yet.
 include "int64"
 ```
 
-## Conversions
+## Values
 
-Functions for converting between Numbers and the Int64 type.
+Functions and constants included in the Int64 module.
 
 ### Int64.**fromNumber**
 
@@ -91,10 +91,6 @@ Returns:
 |type|description|
 |----|-----------|
 |`Int64`|The Uint64 represented as a Int64|
-
-## Operations
-
-Mathematical operations for Int64 values.
 
 ### Int64.**incr**
 
@@ -309,10 +305,6 @@ Throws:
 
 * When `y` is zero
 
-## Bitwise operations
-
-Functions for operating on bits of Int64 values.
-
 ### Int64.**rotl**
 
 <details disabled>
@@ -416,10 +408,6 @@ Returns:
 |type|description|
 |----|-----------|
 |`Int64`|The shifted value|
-
-## Comparisons
-
-Functions for comparing Int64 values.
 
 ### Int64.**eq**
 
@@ -601,10 +589,6 @@ Returns:
 |type|description|
 |----|-----------|
 |`Bool`|`true` if the first value is greater than or equal to the second value or `false` otherwise|
-
-## Bitwise logic
-
-Boolean operations on the bits of Int64 values.
 
 ### Int64.**lnot**
 

--- a/stdlib/list.gr
+++ b/stdlib/list.gr
@@ -11,10 +11,6 @@
 module List
 
 /**
- * @section Values: Functions for working with the List data type.
- */
-
-/**
  * Creates a new list of the specified length where each element is
  * initialized with the result of an initializer function. The initializer
  * is called with the index of each list element.

--- a/stdlib/list.md
+++ b/stdlib/list.md
@@ -23,7 +23,7 @@ include "list"
 
 ## Values
 
-Functions for working with the List data type.
+Functions and constants included in the List module.
 
 ### List.**init**
 

--- a/stdlib/map.gr
+++ b/stdlib/map.gr
@@ -24,18 +24,10 @@ record Bucket<k, v> {
   mut next: Option<Bucket<k, v>>,
 }
 
-/**
- * @section Types: Type declarations included in the Map module.
- */
-
 abstract record Map<k, v> {
   mut size: Number,
   mut buckets: Array<Option<Bucket<k, v>>>,
 }
-
-/**
- * @section Values: Functions for working with Maps.
- */
 
 /**
  * Creates a new empty map with an initial storage of the given size. As values are added or removed, the internal storage may grow or shrink. Generally, you won't need to care about the storage size of your map and can use `Map.make()` instead.

--- a/stdlib/map.md
+++ b/stdlib/map.md
@@ -25,7 +25,7 @@ type Map<k, v>
 
 ## Values
 
-Functions for working with Maps.
+Functions and constants included in the Map module.
 
 ### Map.**makeSized**
 

--- a/stdlib/marshal.gr
+++ b/stdlib/marshal.gr
@@ -22,10 +22,6 @@ module Marshal
   or a "pointer" to a heap-allocated value.
 */
 
-/**
- * @section Values: Functions for marshaling and unmarshaling data.
- */
-
 include "runtime/unsafe/wasmi32"
 from WasmI32 use {
   add as (+),

--- a/stdlib/marshal.md
+++ b/stdlib/marshal.md
@@ -15,7 +15,7 @@ include "marshal"
 
 ## Values
 
-Functions for marshaling and unmarshaling data.
+Functions and constants included in the Marshal module.
 
 ### Marshal.**marshal**
 

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -32,10 +32,6 @@ include "runtime/unsafe/tags"
 include "runtime/exception"
 
 /**
- * @section Constants: Number constant values.
- */
-
-/**
  * Pi represented as a Number value.
  *
  * @since v0.5.2
@@ -55,10 +51,6 @@ provide let tau = 6.283185307179586
  * @since v0.5.2
  */
 provide let e = 2.718281828459045
-
-/**
- * @section Operations: Functions for operating on values of the Number type.
- */
 
 /**
  * Computes the sum of its operands.

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -13,9 +13,9 @@ No other changes yet.
 include "number"
 ```
 
-## Constants
+## Values
 
-Number constant values.
+Functions and constants included in the Number module.
 
 ### Number.**pi**
 
@@ -55,10 +55,6 @@ e : Number
 ```
 
 Euler's number represented as a Number value.
-
-## Operations
-
-Functions for operating on values of the Number type.
 
 ### Number.**add**
 

--- a/stdlib/option.gr
+++ b/stdlib/option.gr
@@ -14,10 +14,6 @@
 module Option
 
 /**
- * @section Values: Functions for working with the Option data type.
- */
-
-/**
  * Checks if the Option is the `Some` variant.
  *
  * @param option: The option to check

--- a/stdlib/option.md
+++ b/stdlib/option.md
@@ -25,7 +25,7 @@ let noValue = None // Creates an Option containing nothing
 
 ## Values
 
-Functions for working with the Option data type.
+Functions and constants included in the Option module.
 
 ### Option.**isSome**
 

--- a/stdlib/path.gr
+++ b/stdlib/path.gr
@@ -88,10 +88,6 @@ record TBase<a> {
   base: Base,
 },
 /**
- * @section Types: Type declarations included in the Path module.
- */
-
-/**
  * Represents an absolute path's anchor point.
  */
 provide enum AbsoluteRoot {
@@ -193,10 +189,6 @@ provide enum RelativizationError {
   Incompatible(IncompatibilityError),
   ImpossibleRelativization,
 }
-
-/**
- * @section Values: Functions for working with Paths.
- */
 
 let makeToken = str => {
   match (str) {

--- a/stdlib/path.md
+++ b/stdlib/path.md
@@ -167,7 +167,7 @@ Represents possible errors for the `relativeTo` operation.
 
 ## Values
 
-Functions for working with Paths.
+Functions and constants included in the Path module.
 
 ### Path.**fromString**
 

--- a/stdlib/pervasives.gr
+++ b/stdlib/pervasives.gr
@@ -44,10 +44,6 @@ include "runtime/string"
 from String use { toString, print, concat as (++) }
 
 /**
- * @section Boolean operations: Infix functions for working with Boolean values.
- */
-
-/**
  * Computes the logical NOT (`!`) of the given operand.
  * Inverts the given Boolean value.
  *
@@ -88,10 +84,6 @@ provide primitive (&&): (Bool, Bool) -> Bool = "@and"
  * @since v0.1.0
  */
 provide primitive (||): (Bool, Bool) -> Bool = "@or"
-
-/**
- * @section Comparison operations: Infix functions for comparing values.
- */
 
 /**
  * Check that two values are equal. This checks for structural equality,
@@ -140,10 +132,6 @@ provide primitive (is): (a, a) -> Bool = "@is"
  * @since v0.2.0
  */
 provide let (isnt): (a, a) -> Bool = (x, y) => !(x is y)
-
-/**
- * @section Number comparisons: Infix functions for comparing Number values.
- */
 
 /**
  * Checks if the first operand is less than the second operand.
@@ -201,10 +189,6 @@ provide { (>=) }
  * @since v0.5.3
  */
 provide { compare }
-
-/**
- * @section Math operations: Infix functions for working with Number values.
- */
 
 /**
  * Computes the sum of its operands.
@@ -283,10 +267,6 @@ provide { incr }
 provide { decr }
 
 /**
- * @section String operations: Infix functions for operating on String values.
- */
-
-/**
  * Concatenate two strings.
  *
  * @param str1: The beginning string
@@ -298,10 +278,6 @@ provide { decr }
  * @since v0.2.0
  */
 provide { (++) }
-
-/**
- * @section Bitwise operations: Infix functions for operating on bits of Number values.
- */
 
 /**
  * Computes the bitwise NOT of the operand.
@@ -399,10 +375,6 @@ provide { (>>) }
 // foreign wasm convertInexactToExact : Number -> Number as exact from "stdlib-external/runtime"
 
 /**
- * @section Printing: Functions that deal with printing.
- */
-
-/**
  * Converts the given operand to a string.
  * Provides a better representation of data types if those types are provided from the module.
  *
@@ -425,10 +397,6 @@ provide { toString }
 provide { print }
 
 /**
- * @section Type helpers: Functions that help with typechecking.
- */
-
-/**
  * Accepts any value and always returns `void`.
  *
  * @param value: The value to ignore
@@ -436,10 +404,6 @@ provide { print }
  * @since v0.1.0
  */
 provide primitive ignore: a -> Void = "@ignore"
-
-/**
- * @section Assertions: Functions that raise if conditions are not met.
- */
 
 /**
  * Assert that the given Boolean condition is `true`.
@@ -454,10 +418,6 @@ provide primitive ignore: a -> Void = "@ignore"
  * @since v0.1.0
  */
 provide primitive assert: Bool -> Void = "@assert"
-
-/**
- * @section Failures: Functions that throw an Exception unconditionally.
- */
 
 // Exceptions
 provide exception Failure(String)
@@ -483,10 +443,6 @@ provide primitive throw: Exception -> a = "@throw"
 provide let fail: String -> a = msg => throw Failure(msg)
 
 /**
- * @section Other: Other functions on values.
- */
-
-/**
  * Provides the operand untouched.
  *
  * @param value: The value to return
@@ -495,10 +451,6 @@ provide let fail: String -> a = msg => throw Failure(msg)
  * @since v0.2.0
  */
 provide let identity = x => x
-
-/**
- * @section Box operations: Functions for working with Box values.
- */
 
 /**
  * Creates a box containing the given initial value.

--- a/stdlib/pervasives.md
+++ b/stdlib/pervasives.md
@@ -13,9 +13,9 @@ No other changes yet.
 include "pervasives"
 ```
 
-## Boolean operations
+## Values
 
-Infix functions for working with Boolean values.
+Functions and constants included in the Pervasives module.
 
 ### Pervasives.**(!)**
 
@@ -110,10 +110,6 @@ Returns:
 |type|description|
 |----|-----------|
 |`Bool`|The first operand if it is `true` or the value of the second operand otherwise|
-
-## Comparison operations
-
-Infix functions for comparing values.
 
 ### Pervasives.**(==)**
 
@@ -222,10 +218,6 @@ Returns:
 |type|description|
 |----|-----------|
 |`Bool`|`false` if the values are physically equal or `true` otherwise|
-
-## Number comparisons
-
-Infix functions for comparing Number values.
 
 ### Pervasives.**(<)**
 
@@ -358,10 +350,6 @@ Returns:
 |type|description|
 |----|-----------|
 |`Number`|A negative integer if the first operand is less than the second operand, `0` if they are equal, or a positive integer otherwise|
-
-## Math operations
-
-Infix functions for working with Number values.
 
 ### Pervasives.**(+)**
 
@@ -544,10 +532,6 @@ Returns:
 |----|-----------|
 |`Number`|The decremented value|
 
-## String operations
-
-Infix functions for operating on String values.
-
 ### Pervasives.**(++)**
 
 <details disabled>
@@ -579,10 +563,6 @@ Examples:
 ```grain
 "Foo" ++ "Bar" == "FooBar"
 ```
-
-## Bitwise operations
-
-Infix functions for operating on bits of Number values.
 
 ### Pervasives.**lnot**
 
@@ -814,10 +794,6 @@ Returns:
 |----|-----------|
 |`Number`|The shifted value|
 
-## Printing
-
-Functions that deal with printing.
-
 ### Pervasives.**toString**
 
 <details disabled>
@@ -865,10 +841,6 @@ Parameters:
 |-----|----|-----------|
 |`value`|`a`|The operand|
 
-## Type helpers
-
-Functions that help with typechecking.
-
 ### Pervasives.**ignore**
 
 <details disabled>
@@ -887,10 +859,6 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`value`|`a`|The value to ignore|
-
-## Assertions
-
-Functions that raise if conditions are not met.
 
 ### Pervasives.**assert**
 
@@ -926,10 +894,6 @@ assert 3 > 2
 ```grain
 assert true
 ```
-
-## Failures
-
-Functions that throw an Exception unconditionally.
 
 ### Pervasives.**throw**
 
@@ -977,10 +941,6 @@ Returns:
 |----|-----------|
 |`a`|Anything and nothing—your program won't continue past a fail expression|
 
-## Other
-
-Other functions on values.
-
 ### Pervasives.**identity**
 
 <details disabled>
@@ -1005,10 +965,6 @@ Returns:
 |type|description|
 |----|-----------|
 |`a`|The value untouched|
-
-## Box operations
-
-Functions for working with Box values.
 
 ### Pervasives.**box**
 

--- a/stdlib/priorityqueue.gr
+++ b/stdlib/priorityqueue.gr
@@ -14,10 +14,6 @@ include "number"
 include "option"
 
 /**
- * @section Types: Type declarations included in the PriorityQueue module.
- */
-
-/**
  * Mutable data structure which maintains a priority order for its elements.
  */
 abstract record PriorityQueue<a> {
@@ -25,10 +21,6 @@ abstract record PriorityQueue<a> {
   mut array: Array<Option<a>>,
   comp: (a, a) -> Number,
 }
-
-/**
- * @section Values: Functions for working with PriorityQueues.
- */
 
 let swap = (i1, i2, array) => {
   let t = array[i2]

--- a/stdlib/priorityqueue.md
+++ b/stdlib/priorityqueue.md
@@ -27,7 +27,7 @@ Mutable data structure which maintains a priority order for its elements.
 
 ## Values
 
-Functions for working with PriorityQueues.
+Functions and constants included in the PriorityQueue module.
 
 ### PriorityQueue.**makeSized**
 

--- a/stdlib/queue.gr
+++ b/stdlib/queue.gr
@@ -12,18 +12,10 @@ module Queue
 
 include "list"
 
-/**
- * @section Types: Type declarations included in the Queue module.
- */
-
 abstract record Queue<a> {
   forwards: List<a>,
   backwards: List<a>,
 }
-
-/**
- * @section Values: Functions and constants for working with queues.
- */
 
 /**
  * An empty queue.

--- a/stdlib/queue.md
+++ b/stdlib/queue.md
@@ -27,7 +27,7 @@ type Queue<a>
 
 ## Values
 
-Functions and constants for working with queues.
+Functions and constants included in the Queue module.
 
 ### Queue.**empty**
 

--- a/stdlib/random.gr
+++ b/stdlib/random.gr
@@ -17,19 +17,11 @@ include "runtime/unsafe/wasmi64"
 include "runtime/unsafe/memory"
 include "runtime/dataStructures" as DS
 
-/**
- * @section Types: Type declarations included in the Random module.
- */
-
 abstract record Random {
   seed: Uint64,
   mut counter: Uint64,
   mut initialized: Bool,
 }
-
-/**
- * @section Values: Functions for working with pseudo-random number generators.
- */
 
 let incCounter = random => {
   random.counter = Uint64.incr(random.counter)

--- a/stdlib/random.md
+++ b/stdlib/random.md
@@ -25,7 +25,7 @@ type Random
 
 ## Values
 
-Functions for working with pseudo-random number generators.
+Functions and constants included in the Random module.
 
 ### Random.**make**
 

--- a/stdlib/range.gr
+++ b/stdlib/range.gr
@@ -9,20 +9,12 @@
 module Range
 
 /**
- * @section Types: Type declarations included in the Range module.
- */
-
-/**
  * Ranges can be inclusive or exclusive. When `Inclusive`, the end value will be included in operations. When `Exclusive`, the end value will be excluded from operations.
  */
 provide enum Range {
   Inclusive(Number, Number),
   Exclusive(Number, Number),
 }
-
-/**
- * @section Values: Functions and constants included in the Range module.
- */
 
 /**
  * Checks if the given number is within the range.

--- a/stdlib/regex.gr
+++ b/stdlib/regex.gr
@@ -3334,10 +3334,6 @@ abstract record RegularExpression {
   reStartRange: Option<RERange>,
 }
 
-/**
- * @section Values: Functions for working with regular expressions.
- */
-
 // TODO(#661): re-add the following pieces of documentation:
 /*
  [Under POSIX character classes]

--- a/stdlib/regex.md
+++ b/stdlib/regex.md
@@ -13,9 +13,66 @@ No other changes yet.
 include "regex"
 ```
 
+## Types
+
+Type declarations included in the Regex module.
+
+### Regex.**RegularExpression**
+
+```grain
+type RegularExpression
+```
+
+### Regex.**MatchResult**
+
+```grain
+record MatchResult {
+  group: Number -> Option<String>,
+  groupPosition: Number -> Option<(Number, Number)>,
+  numGroups: Number,
+  allGroups: () -> Array<Option<String>>,
+  allGroupPositions: () -> Array<Option<(Number, Number)>>,
+}
+```
+
+This object contains the results
+of a regular expression match. The results can be obtained using
+the following accessors:
+
+```grain
+group : Number -> Option<String>
+```
+
+Returns the contents of the given group. Note that group 0 contains
+the entire matched substring, and group 1 contains the first parenthesized group.
+
+```grain
+groupPosition : Number -> Option<(Number, Number)>
+```
+
+Returns the position of the given group.
+
+```grain
+numGroups : Number
+```
+
+The number of defined groups in this match object (including group 0).
+
+```grain
+allGroups : () -> Array<Option<String>>
+```
+
+Returns the contents of all groups matched in this match object.
+
+```grain
+allGroupPositions : () -> Array<Option<(Number, Number)>>
+```
+
+Returns the positions of all groups matched in this match object.
+
 ## Values
 
-Functions for working with regular expressions.
+Functions and constants included in the Regex module.
 
 ### Regex.**make**
 
@@ -129,53 +186,6 @@ Examples:
 ```grain
 Regex.make("(foo|bar)[0-9]+")
 ```
-
-### Regex.**MatchResult**
-
-```grain
-record MatchResult {
-  group: Number -> Option<String>,
-  groupPosition: Number -> Option<(Number, Number)>,
-  numGroups: Number,
-  allGroups: () -> Array<Option<String>>,
-  allGroupPositions: () -> Array<Option<(Number, Number)>>,
-}
-```
-
-This object contains the results
-of a regular expression match. The results can be obtained using
-the following accessors:
-
-```grain
-group : Number -> Option<String>
-```
-
-Returns the contents of the given group. Note that group 0 contains
-the entire matched substring, and group 1 contains the first parenthesized group.
-
-```grain
-groupPosition : Number -> Option<(Number, Number)>
-```
-
-Returns the position of the given group.
-
-```grain
-numGroups : Number
-```
-
-The number of defined groups in this match object (including group 0).
-
-```grain
-allGroups : () -> Array<Option<String>>
-```
-
-Returns the contents of all groups matched in this match object.
-
-```grain
-allGroupPositions : () -> Array<Option<(Number, Number)>>
-```
-
-Returns the positions of all groups matched in this match object.
 
 ### Regex.**isMatch**
 

--- a/stdlib/result.gr
+++ b/stdlib/result.gr
@@ -15,10 +15,6 @@
 module Result
 
 /**
- * @section Values: Functions for working with the Result data type.
- */
-
-/**
  * Checks if the Result is the `Ok` variant.
  *
  * @param result: The result to check

--- a/stdlib/result.md
+++ b/stdlib/result.md
@@ -26,7 +26,7 @@ let failure = Err("Something bad happened") // Creates an unsuccessful Result co
 
 ## Values
 
-Functions for working with the Result data type.
+Functions and constants included in the Result module.
 
 ### Result.**isOk**
 

--- a/stdlib/runtime/atof/common.md
+++ b/stdlib/runtime/atof/common.md
@@ -2,6 +2,10 @@
 title: Common
 ---
 
+## Types
+
+Type declarations included in the Common module.
+
 ### Common.**BiasedFp**
 
 ```grain
@@ -10,6 +14,10 @@ record BiasedFp {
   e: Int32,
 }
 ```
+
+## Values
+
+Functions and constants included in the Common module.
 
 ### Common.**_MINIMUM_EXPONENT**
 

--- a/stdlib/runtime/atof/decimal.md
+++ b/stdlib/runtime/atof/decimal.md
@@ -2,6 +2,10 @@
 title: Decimal
 ---
 
+## Types
+
+Type declarations included in the Decimal module.
+
 ### Decimal.**Decimal**
 
 ```grain
@@ -12,6 +16,10 @@ record Decimal {
   digits: Bytes,
 }
 ```
+
+## Values
+
+Functions and constants included in the Decimal module.
 
 ### Decimal.**_DECIMAL_POINT_RANGE**
 

--- a/stdlib/runtime/atof/lemire.md
+++ b/stdlib/runtime/atof/lemire.md
@@ -2,6 +2,10 @@
 title: Lemire
 ---
 
+## Values
+
+Functions and constants included in the Lemire module.
+
 ### Lemire.**computeFloat**
 
 ```grain

--- a/stdlib/runtime/atof/parse.md
+++ b/stdlib/runtime/atof/parse.md
@@ -2,6 +2,10 @@
 title: Parse
 ---
 
+## Values
+
+Functions and constants included in the Parse module.
+
 ### Parse.**isFastPath**
 
 ```grain

--- a/stdlib/runtime/atof/slow.md
+++ b/stdlib/runtime/atof/slow.md
@@ -2,6 +2,10 @@
 title: Slow
 ---
 
+## Values
+
+Functions and constants included in the Slow module.
+
 ### Slow.**parseLongMantissa**
 
 ```grain

--- a/stdlib/runtime/atof/table.md
+++ b/stdlib/runtime/atof/table.md
@@ -2,6 +2,10 @@
 title: Table
 ---
 
+## Values
+
+Functions and constants included in the Table module.
+
 ### Table.**get_F64_POWERS10_FAST_PATH**
 
 ```grain

--- a/stdlib/runtime/atoi/parse.md
+++ b/stdlib/runtime/atoi/parse.md
@@ -2,6 +2,10 @@
 title: Parse
 ---
 
+## Values
+
+Functions and constants included in the Parse module.
+
 ### Parse.**parseInt**
 
 ```grain

--- a/stdlib/runtime/bigint.md
+++ b/stdlib/runtime/bigint.md
@@ -2,6 +2,10 @@
 title: Bigint
 ---
 
+## Values
+
+Functions and constants included in the Bigint module.
+
 ### Bigint.**debugDumpNumber**
 
 ```grain

--- a/stdlib/runtime/compare.md
+++ b/stdlib/runtime/compare.md
@@ -2,6 +2,10 @@
 title: Compare
 ---
 
+## Values
+
+Functions and constants included in the Compare module.
+
 ### Compare.**compare**
 
 ```grain

--- a/stdlib/runtime/dataStructures.md
+++ b/stdlib/runtime/dataStructures.md
@@ -2,6 +2,10 @@
 title: DataStructures
 ---
 
+## Values
+
+Functions and constants included in the DataStructures module.
+
 ### DataStructures.**allocateArray**
 
 ```grain

--- a/stdlib/runtime/debug.md
+++ b/stdlib/runtime/debug.md
@@ -2,6 +2,10 @@
 title: Debug
 ---
 
+## Values
+
+Functions and constants included in the Debug module.
+
 ### Debug.**debug**
 
 ```grain

--- a/stdlib/runtime/debugPrint.md
+++ b/stdlib/runtime/debugPrint.md
@@ -2,6 +2,10 @@
 title: DebugPrint
 ---
 
+## Values
+
+Functions and constants included in the DebugPrint module.
+
 ### DebugPrint.**print**
 
 ```grain

--- a/stdlib/runtime/equal.md
+++ b/stdlib/runtime/equal.md
@@ -2,6 +2,10 @@
 title: Equal
 ---
 
+## Values
+
+Functions and constants included in the Equal module.
+
 ### Equal.**equal**
 
 ```grain

--- a/stdlib/runtime/exception.md
+++ b/stdlib/runtime/exception.md
@@ -2,6 +2,10 @@
 title: Exception
 ---
 
+## Values
+
+Functions and constants included in the Exception module.
+
 ### Exception.**printers**
 
 ```grain

--- a/stdlib/runtime/gc.md
+++ b/stdlib/runtime/gc.md
@@ -2,6 +2,10 @@
 title: GC
 ---
 
+## Values
+
+Functions and constants included in the GC module.
+
 ### GC.**decimalCount32**
 
 ```grain

--- a/stdlib/runtime/malloc.md
+++ b/stdlib/runtime/malloc.md
@@ -2,6 +2,10 @@
 title: Malloc
 ---
 
+## Values
+
+Functions and constants included in the Malloc module.
+
 ### Malloc.**_RESERVED_RUNTIME_SPACE**
 
 ```grain

--- a/stdlib/runtime/numberUtils.md
+++ b/stdlib/runtime/numberUtils.md
@@ -2,6 +2,10 @@
 title: NumberUtils
 ---
 
+## Values
+
+Functions and constants included in the NumberUtils module.
+
 ### NumberUtils.**_MAX_DOUBLE_LENGTH**
 
 ```grain

--- a/stdlib/runtime/numbers.md
+++ b/stdlib/runtime/numbers.md
@@ -2,6 +2,10 @@
 title: Numbers
 ---
 
+## Values
+
+Functions and constants included in the Numbers module.
+
 ### Numbers.**isBoxedNumber**
 
 ```grain

--- a/stdlib/runtime/string.md
+++ b/stdlib/runtime/string.md
@@ -2,6 +2,10 @@
 title: String
 ---
 
+## Values
+
+Functions and constants included in the String module.
+
 ### String.**concat**
 
 ```grain

--- a/stdlib/runtime/unsafe/constants.md
+++ b/stdlib/runtime/unsafe/constants.md
@@ -2,6 +2,10 @@
 title: Constants
 ---
 
+## Values
+
+Functions and constants included in the Constants module.
+
 ### Constants.**_SMIN_I32**
 
 ```grain

--- a/stdlib/runtime/unsafe/conv.md
+++ b/stdlib/runtime/unsafe/conv.md
@@ -2,6 +2,10 @@
 title: Conv
 ---
 
+## Values
+
+Functions and constants included in the Conv module.
+
 ### Conv.**toInt32**
 
 ```grain

--- a/stdlib/runtime/unsafe/errors.md
+++ b/stdlib/runtime/unsafe/errors.md
@@ -2,6 +2,10 @@
 title: Errors
 ---
 
+## Values
+
+Functions and constants included in the Errors module.
+
 ### Errors.**_GRAIN_ERR_NOT_NUMBER_COMP**
 
 ```grain

--- a/stdlib/runtime/unsafe/memory.md
+++ b/stdlib/runtime/unsafe/memory.md
@@ -2,6 +2,10 @@
 title: Memory
 ---
 
+## Values
+
+Functions and constants included in the Memory module.
+
 ### Memory.**malloc**
 
 ```grain

--- a/stdlib/runtime/unsafe/tags.md
+++ b/stdlib/runtime/unsafe/tags.md
@@ -2,6 +2,10 @@
 title: Tags
 ---
 
+## Values
+
+Functions and constants included in the Tags module.
+
 ### Tags.**_GRAIN_NUMBER_TAG_TYPE**
 
 ```grain

--- a/stdlib/runtime/unsafe/wasmf32.md
+++ b/stdlib/runtime/unsafe/wasmf32.md
@@ -2,6 +2,10 @@
 title: WasmF32
 ---
 
+## Values
+
+Functions and constants included in the WasmF32 module.
+
 ### WasmF32.**load**
 
 ```grain

--- a/stdlib/runtime/unsafe/wasmf64.md
+++ b/stdlib/runtime/unsafe/wasmf64.md
@@ -2,6 +2,10 @@
 title: WasmF64
 ---
 
+## Values
+
+Functions and constants included in the WasmF64 module.
+
 ### WasmF64.**load**
 
 ```grain

--- a/stdlib/runtime/unsafe/wasmi32.md
+++ b/stdlib/runtime/unsafe/wasmi32.md
@@ -2,6 +2,10 @@
 title: WasmI32
 ---
 
+## Values
+
+Functions and constants included in the WasmI32 module.
+
 ### WasmI32.**load**
 
 ```grain

--- a/stdlib/runtime/unsafe/wasmi64.md
+++ b/stdlib/runtime/unsafe/wasmi64.md
@@ -2,6 +2,10 @@
 title: WasmI64
 ---
 
+## Values
+
+Functions and constants included in the WasmI64 module.
+
 ### WasmI64.**load**
 
 ```grain

--- a/stdlib/runtime/utils/printing.md
+++ b/stdlib/runtime/utils/printing.md
@@ -2,6 +2,10 @@
 title: Printing
 ---
 
+## Values
+
+Functions and constants included in the Printing module.
+
 ### Printing.**numberToString**
 
 ```grain

--- a/stdlib/runtime/wasi.md
+++ b/stdlib/runtime/wasi.md
@@ -2,6 +2,10 @@
 title: Wasi
 ---
 
+## Values
+
+Functions and constants included in the Wasi module.
+
 ### Wasi.**args_get**
 
 ```grain

--- a/stdlib/set.gr
+++ b/stdlib/set.gr
@@ -18,18 +18,10 @@ record Bucket<t> {
   mut next: Option<Bucket<t>>,
 }
 
-/**
- * @section Types: Type declarations included in the Set module.
- */
-
 abstract record Set<k> {
   mut size: Number,
   mut buckets: Array<Option<Bucket<k>>>,
 }
-
-/**
- * @section Values: Functions for working with Sets.
- */
 
 // TODO: This could take an `eq` function to custom comparisons
 /**

--- a/stdlib/set.md
+++ b/stdlib/set.md
@@ -25,7 +25,7 @@ type Set<k>
 
 ## Values
 
-Functions for working with Sets.
+Functions and constants included in the Set module.
 
 ### Set.**makeSized**
 

--- a/stdlib/stack.gr
+++ b/stdlib/stack.gr
@@ -13,19 +13,11 @@ module Stack
 include "list"
 
 /**
- * @section Types: Type declarations included in the Stack module.
- */
-
-/**
  * Stacks are immutable data structures that store their data in a List.
  */
 abstract record Stack<a> {
   data: List<a>,
 }
-
-/**
- * @section Values: Functions and constants included in the Stack module.
- */
 
 /**
  * An empty stack.

--- a/stdlib/string.gr
+++ b/stdlib/string.gr
@@ -26,10 +26,6 @@ from DataStructures use {
 }
 
 /**
- * @section Types: Type declarations included in the String module.
- */
-
-/**
  * Byte encodings
  */
 provide enum Encoding {
@@ -41,10 +37,6 @@ provide enum Encoding {
 }
 
 exception MalformedUnicode
-
-/**
- * @section Values: Functions for working with the String data type.
- */
 
 /**
  * Concatenate two strings.

--- a/stdlib/string.md
+++ b/stdlib/string.md
@@ -41,7 +41,7 @@ Byte encodings
 
 ## Values
 
-Functions for working with the String data type.
+Functions and constants included in the String module.
 
 ### String.**concat**
 

--- a/stdlib/sys/file.gr
+++ b/stdlib/sys/file.gr
@@ -41,10 +41,6 @@ from DataStructures use {
 include "list"
 
 /**
- * @section Types: Type declarations included in the File module.
- */
-
-/**
  * Represents a handle to an open file on the system.
  */
 provide enum FileDescriptor {
@@ -424,10 +420,6 @@ provide record DirectoryEntry {
   filetype: Filetype,
   path: String,
 }
-
-/**
- * @section Values: Functions and constants included in the File module.
- */
 
 /**
  * The `FileDescriptor` for `stdin`.

--- a/stdlib/sys/process.gr
+++ b/stdlib/sys/process.gr
@@ -25,10 +25,6 @@ include "runtime/dataStructures"
 from DataStructures use { tagSimpleNumber, allocateArray, allocateString }
 
 /**
- * @section Types: Type declarations included in the Process module.
- */
-
-/**
  * Signals that can be sent to the host system.
  */
 provide enum Signal {
@@ -89,10 +85,6 @@ provide enum Signal {
   // Bad system call.
   SYS,
 }
-
-/**
- * @section Values: Functions and constants included in the Process module.
- */
 
 /**
  * Access command line arguments.

--- a/stdlib/sys/random.gr
+++ b/stdlib/sys/random.gr
@@ -15,10 +15,6 @@ include "runtime/dataStructures"
 from DataStructures use { tagSimpleNumber, newUint32, newUint64 }
 
 /**
- * @section Values: Functions and constants included in the Random module.
- */
-
-/**
  * Produce a random 32-bit integer. This function can be slow, so it's best to seed a generator if lots of random data is needed.
  *
  * @returns `Ok(num)` of a random Uint32 if successful or `Err(exception)` otherwise

--- a/stdlib/sys/time.gr
+++ b/stdlib/sys/time.gr
@@ -14,10 +14,6 @@ include "runtime/unsafe/errors"
 include "runtime/dataStructures"
 from DataStructures use { allocateInt64, tagSimpleNumber }
 
-/**
- * @section Values: Functions and constants included in the Time module.
- */
-
 @unsafe
 let getClockTime = (clockid, precision) => {
   let int64Ptr = allocateInt64()

--- a/stdlib/uint32.gr
+++ b/stdlib/uint32.gr
@@ -1,7 +1,7 @@
 /**
  * Utilities for working with the Uint32 type.
  * @example include "uint32"
- * 
+ *
  * @since v0.6.0
  */
 
@@ -20,15 +20,11 @@ from DataStructures use { newUint32 }
 let _VALUE_OFFSET = 4n
 
 /**
- * @section Conversions: Functions for converting between Numbers and the Uint32 type.
- */
-
-/**
  * Converts a Number to a Uint32.
  *
  * @param number: The value to convert
  * @returns The Number represented as a Uint32
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -42,7 +38,7 @@ provide let fromNumber = (x: Number) => {
  *
  * @param value: The value to convert
  * @returns The Uint32 represented as a Number
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -59,7 +55,7 @@ provide let toNumber = (x: Uint32) => {
  *
  * @param number: The value to convert
  * @returns The Int32 represented as a Uint32
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -70,15 +66,11 @@ provide let fromInt32 = (x: Int32) => {
 }
 
 /**
- * @section Operations: Mathematical operations for Uint32 values.
- */
-
-/**
  * Increments the value by one.
  *
  * @param value: The value to increment
  * @returns The incremented value
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -93,7 +85,7 @@ provide let incr = (value: Uint32) => {
  *
  * @param value: The value to decrement
  * @returns The decremented value
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -109,7 +101,7 @@ provide let decr = (value: Uint32) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The sum of the two operands
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -126,7 +118,7 @@ provide let (+) = (x: Uint32, y: Uint32) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The difference of the two operands
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -143,7 +135,7 @@ provide let (-) = (x: Uint32, y: Uint32) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The product of the two operands
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -160,7 +152,7 @@ provide let (*) = (x: Uint32, y: Uint32) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The quotient of its operands
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -177,7 +169,7 @@ provide let (/) = (x: Uint32, y: Uint32) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The remainder of its operands
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -189,16 +181,12 @@ provide let (%) = (x: Uint32, y: Uint32) => {
 }
 
 /**
- * @section Bitwise operations: Functions for operating on bits of Uint32 values.
- */
-
-/**
  * Rotates the bits of the value left by the given number of bits.
  *
  * @param value: The value to rotate
  * @param amount: The number of bits to rotate by
  * @returns The rotated value
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -215,7 +203,7 @@ provide let rotl = (value: Uint32, amount: Uint32) => {
  * @param value: The value to rotate
  * @param amount: The number of bits to rotate by
  * @returns The rotated value
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -232,7 +220,7 @@ provide let rotr = (value: Uint32, amount: Uint32) => {
  * @param value: The value to shift
  * @param amount: The number of bits to shift by
  * @returns The shifted value
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -249,7 +237,7 @@ provide let (<<) = (value: Uint32, amount: Uint32) => {
  * @param value: The value to shift
  * @param amount: The amount to shift by
  * @returns The shifted value
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -261,16 +249,12 @@ provide let (>>) = (value: Uint32, amount: Uint32) => {
 }
 
 /**
- * @section Comparisons: Functions for comparing Uint32 values.
- */
-
-/**
  * Checks if the first value is equal to the second value.
  *
  * @param x: The first value
  * @param y: The second value
  * @returns `true` if the first value is equal to the second value or `false` otherwise
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -286,7 +270,7 @@ provide let (==) = (x: Uint32, y: Uint32) => {
  * @param x: The first value
  * @param y: The second value
  * @returns `true` if the first value is not equal to the second value or `false` otherwise
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -301,7 +285,7 @@ provide let (!=) = (x: Uint32, y: Uint32) => {
  *
  * @param value: The value to inspect
  * @returns `true` if the first value is equal to zero or `false` otherwise
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -375,15 +359,11 @@ provide let (>=) = (x: Uint32, y: Uint32) => {
 }
 
 /**
- * @section Bitwise logic: Boolean operations on the bits of Uint32 values.
- */
-
-/**
  * Computes the bitwise NOT of the given value.
  *
  * @param value: The given value
  * @returns Containing the inverted bits of the given value
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -399,7 +379,7 @@ provide let lnot = (value: Uint32) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns Containing a `1` in each bit position for which the corresponding bits of both operands are `1`
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -416,7 +396,7 @@ provide let (&) = (x: Uint32, y: Uint32) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns Containing a `1` in each bit position for which the corresponding bits of either or both operands are `1`
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -433,7 +413,7 @@ provide let (|) = (x: Uint32, y: Uint32) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns Containing a `1` in each bit position for which the corresponding bits of either but not both operands are `1`
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -449,7 +429,7 @@ provide let (^) = (x: Uint32, y: Uint32) => {
  *
  * @param value: The value to inspect
  * @returns The amount of leading zeros
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -464,7 +444,7 @@ provide let clz = (value: Uint32) => {
  *
  * @param value: The value to inspect
  * @returns The amount of trailing zeros
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -479,7 +459,7 @@ provide let ctz = (value: Uint32) => {
  *
  * @param value: The value to inspect
  * @returns The amount of 1-bits in its operand
- * 
+ *
  * @since v0.6.0
  */
 @unsafe

--- a/stdlib/uint32.md
+++ b/stdlib/uint32.md
@@ -13,9 +13,9 @@ No other changes yet.
 include "uint32"
 ```
 
-## Conversions
+## Values
 
-Functions for converting between Numbers and the Uint32 type.
+Functions and constants included in the Uint32 module.
 
 ### Uint32.**fromNumber**
 
@@ -91,10 +91,6 @@ Returns:
 |type|description|
 |----|-----------|
 |`Uint32`|The Int32 represented as a Uint32|
-
-## Operations
-
-Mathematical operations for Uint32 values.
 
 ### Uint32.**incr**
 
@@ -276,10 +272,6 @@ Returns:
 |----|-----------|
 |`Uint32`|The remainder of its operands|
 
-## Bitwise operations
-
-Functions for operating on bits of Uint32 values.
-
 ### Uint32.**rotl**
 
 <details disabled>
@@ -383,10 +375,6 @@ Returns:
 |type|description|
 |----|-----------|
 |`Uint32`|The shifted value|
-
-## Comparisons
-
-Functions for comparing Uint32 values.
 
 ### Uint32.**(==)**
 
@@ -568,10 +556,6 @@ Returns:
 |type|description|
 |----|-----------|
 |`Bool`|`true` if the first value is greater than or equal to the second value or `false` otherwise|
-
-## Bitwise logic
-
-Boolean operations on the bits of Uint32 values.
 
 ### Uint32.**lnot**
 

--- a/stdlib/uint64.gr
+++ b/stdlib/uint64.gr
@@ -1,7 +1,7 @@
 /**
  * Utilities for working with the Uint64 type.
  * @example include "uint64"
- * 
+ *
  * @since v0.6.0
  */
 
@@ -21,15 +21,11 @@ from DataStructures use { newUint64 }
 let _VALUE_OFFSET = 8n
 
 /**
- * @section Conversions: Functions for converting between Numbers and the Uint64 type.
- */
-
-/**
  * Converts a Number to a Uint64.
  *
  * @param number: The value to convert
  * @returns The Number represented as a Uint64
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -43,7 +39,7 @@ provide let fromNumber = (x: Number) => {
  *
  * @param value: The value to convert
  * @returns The Uint64 represented as a Number
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -58,7 +54,7 @@ provide let toNumber = (x: Uint64) => {
  *
  * @param number: The value to convert
  * @returns The Int64 represented as a Uint64
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -69,15 +65,11 @@ provide let fromInt64 = (x: Int64) => {
 }
 
 /**
- * @section Operations: Mathematical operations for Uint64 values.
- */
-
-/**
  * Increments the value by one.
  *
  * @param value: The value to increment
  * @returns The incremented value
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -92,7 +84,7 @@ provide let incr = (value: Uint64) => {
  *
  * @param value: The value to decrement
  * @returns The decremented value
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -108,7 +100,7 @@ provide let decr = (value: Uint64) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The sum of the two operands
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -125,7 +117,7 @@ provide let (+) = (x: Uint64, y: Uint64) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The difference of the two operands
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -142,7 +134,7 @@ provide let (-) = (x: Uint64, y: Uint64) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The product of the two operands
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -159,7 +151,7 @@ provide let (*) = (x: Uint64, y: Uint64) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The quotient of its operands
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -176,7 +168,7 @@ provide let (/) = (x: Uint64, y: Uint64) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The remainder of its operands
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -188,16 +180,12 @@ provide let (%) = (x: Uint64, y: Uint64) => {
 }
 
 /**
- * @section Bitwise operations: Functions for operating on bits of Uint64 values.
- */
-
-/**
  * Rotates the bits of the value left by the given number of bits.
  *
  * @param value: The value to rotate
  * @param amount: The number of bits to rotate by
  * @returns The rotated value
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -214,7 +202,7 @@ provide let rotl = (value: Uint64, amount: Uint64) => {
  * @param value: The value to rotate
  * @param amount: The number of bits to rotate by
  * @returns The rotated value
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -231,7 +219,7 @@ provide let rotr = (value: Uint64, amount: Uint64) => {
  * @param value: The value to shift
  * @param amount: The number of bits to shift by
  * @returns The shifted value
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -248,7 +236,7 @@ provide let (<<) = (value: Uint64, amount: Uint64) => {
  * @param value: The value to shift
  * @param amount: The amount to shift by
  * @returns The shifted value
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -260,16 +248,12 @@ provide let (>>) = (value: Uint64, amount: Uint64) => {
 }
 
 /**
- * @section Comparisons: Functions for comparing Uint64 values.
- */
-
-/**
  * Checks if the first value is equal to the second value.
  *
  * @param x: The first value
  * @param y: The second value
  * @returns `true` if the first value is equal to the second value or `false` otherwise
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -285,7 +269,7 @@ provide let (==) = (x: Uint64, y: Uint64) => {
  * @param x: The first value
  * @param y: The second value
  * @returns `true` if the first value is not equal to the second value or `false` otherwise
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -300,7 +284,7 @@ provide let (!=) = (x: Uint64, y: Uint64) => {
  *
  * @param value: The value to inspect
  * @returns `true` if the first value is equal to zero or `false` otherwise
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -374,15 +358,11 @@ provide let (>=) = (x: Uint64, y: Uint64) => {
 }
 
 /**
- * @section Bitwise logic: Boolean operations on the bits of Uint64 values.
- */
-
-/**
  * Computes the bitwise NOT of the given value.
  *
  * @param value: The given value
  * @returns Containing the inverted bits of the given value
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -398,7 +378,7 @@ provide let lnot = (value: Uint64) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns Containing a `1` in each bit position for which the corresponding bits of both operands are `1`
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -415,7 +395,7 @@ provide let (&) = (x: Uint64, y: Uint64) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns Containing a `1` in each bit position for which the corresponding bits of either or both operands are `1`
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -432,7 +412,7 @@ provide let (|) = (x: Uint64, y: Uint64) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns Containing a `1` in each bit position for which the corresponding bits of either but not both operands are `1`
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -448,7 +428,7 @@ provide let (^) = (x: Uint64, y: Uint64) => {
  *
  * @param value: The value to inspect
  * @returns The amount of leading zeros
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -463,7 +443,7 @@ provide let clz = (value: Uint64) => {
  *
  * @param value: The value to inspect
  * @returns The amount of trailing zeros
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -478,7 +458,7 @@ provide let ctz = (value: Uint64) => {
  *
  * @param value: The value to inspect
  * @returns The amount of 1-bits in its operand
- * 
+ *
  * @since v0.6.0
  */
 @unsafe

--- a/stdlib/uint64.md
+++ b/stdlib/uint64.md
@@ -13,9 +13,9 @@ No other changes yet.
 include "uint64"
 ```
 
-## Conversions
+## Values
 
-Functions for converting between Numbers and the Uint64 type.
+Functions and constants included in the Uint64 module.
 
 ### Uint64.**fromNumber**
 
@@ -91,10 +91,6 @@ Returns:
 |type|description|
 |----|-----------|
 |`Uint64`|The Int64 represented as a Uint64|
-
-## Operations
-
-Mathematical operations for Uint64 values.
 
 ### Uint64.**incr**
 
@@ -276,10 +272,6 @@ Returns:
 |----|-----------|
 |`Uint64`|The remainder of its operands|
 
-## Bitwise operations
-
-Functions for operating on bits of Uint64 values.
-
 ### Uint64.**rotl**
 
 <details disabled>
@@ -383,10 +375,6 @@ Returns:
 |type|description|
 |----|-----------|
 |`Uint64`|The shifted value|
-
-## Comparisons
-
-Functions for comparing Uint64 values.
 
 ### Uint64.**(==)**
 
@@ -568,10 +556,6 @@ Returns:
 |type|description|
 |----|-----------|
 |`Bool`|`true` if the first value is greater than or equal to the second value or `false` otherwise|
-
-## Bitwise logic
-
-Boolean operations on the bits of Uint64 values.
 
 ### Uint64.**lnot**
 


### PR DESCRIPTION
This removes Docblocks that use the `@section` attribute. We plan to replace these "Sections" with submodules (and docblocks on them).

I wanted to remove sections before adding submodule support because the diff gives us a great view into the structure of our stdlib. We need to bikeshed inline on which sections should become submodules and which should remain in the top-level grouping.

I also did some light cleanup and renaming.

Ref #1621 