### PR TITLE
feat(compiler)!: Remove 32-bit numbers from `Number` type

### DIFF
--- a/compiler/src/codegen/compcore.re
+++ b/compiler/src/codegen/compcore.re
@@ -1298,27 +1298,12 @@ let compile_array_op = (wasm_mod, env, arr_imm, op) => {
                     Op.or_int32,
                     Expression.Binary.make(
                       wasm_mod,
-                      Op.or_int32,
-                      Expression.Binary.make(
+                      Op.eq_int32,
+                      get_swap(1),
+                      Expression.Const.make(
                         wasm_mod,
-                        Op.eq_int32,
-                        get_swap(1),
-                        Expression.Const.make(
-                          wasm_mod,
-                          const_int32(
-                            tag_val_of_boxed_number_tag_type(BoxedInt32),
-                          ),
-                        ),
-                      ),
-                      Expression.Binary.make(
-                        wasm_mod,
-                        Op.eq_int32,
-                        get_swap(1),
-                        Expression.Const.make(
-                          wasm_mod,
-                          const_int32(
-                            tag_val_of_boxed_number_tag_type(BoxedInt64),
-                          ),
+                        const_int32(
+                          tag_val_of_boxed_number_tag_type(BoxedInt64),
                         ),
                       ),
                     ),
@@ -2046,17 +2031,21 @@ let allocate_record = (wasm_mod, env, ttag, elts) => {
   );
 };
 
-let allocate_uint_uninitialized = (wasm_mod, env, is_32_bit) => {
+// "Alt" number here is defined as one not belonging to the `Number` type
+let allocate_alt_num_uninitialized = (wasm_mod, env, tag) => {
   let get_swap = () => get_swap(wasm_mod, env, 0);
-  let make_alloc = () =>
-    heap_allocate(wasm_mod, env, if (is_32_bit) {2} else {4});
-
-  let (tag, label) =
-    if (is_32_bit) {
-      (Uint32Type, "allocate_unitialized_uint32");
-    } else {
-      (Uint64Type, "allocate_unitialized_uint64");
+  let (num_words, label) =
+    switch (tag) {
+    | Int32Type => (2, "allocate_unitialized_int32")
+    | Float32Type => (2, "allocate_unitialized_float32")
+    | Uint32Type => (2, "allocate_unitialized_uint32")
+    | Uint64Type => (4, "allocate_unitialized_uint64")
+    | _ =>
+      failwith(
+        "Impossible: allocate_alt_num_uninitialized given non-alt-num tag",
+      )
     };
+  let make_alloc = () => heap_allocate(wasm_mod, env, num_words);
 
   let preamble = [
     store(
@@ -2077,15 +2066,29 @@ let allocate_uint_uninitialized = (wasm_mod, env, is_32_bit) => {
   );
 };
 
-type alloc_uint_type =
+type alloc_alt_num_type =
+  | Int32(Expression.t)
+  | Float32(Expression.t)
   | Uint32(Expression.t)
   | Uint64(Expression.t);
 
-let allocate_uint = (wasm_mod, env, uint_value) => {
+let allocate_alt_num = (wasm_mod, env, num_value) => {
   let get_swap = () => get_swap(wasm_mod, env, 0);
 
   let (tag, instrs, needed_words, label) =
-    switch (uint_value) {
+    switch (num_value) {
+    | Int32(int32) => (
+        Int32Type,
+        [store(~offset=4, ~ty=Type.int32, wasm_mod, get_swap(), int32)],
+        2,
+        "allocate_int32",
+      )
+    | Float32(float32) => (
+        Float32Type,
+        [store(~offset=4, ~ty=Type.float32, wasm_mod, get_swap(), float32)],
+        2,
+        "allocate_float32",
+      )
     | Uint32(uint32) => (
         Uint32Type,
         [store(~offset=4, ~ty=Type.int32, wasm_mod, get_swap(), uint32)],
@@ -2126,18 +2129,8 @@ let allocate_uint = (wasm_mod, env, uint_value) => {
   );
 };
 
-let allocate_uint32 = (wasm_mod, env, i) => {
-  allocate_uint(wasm_mod, env, Uint32(i));
-};
-
-let allocate_uint64 = (wasm_mod, env, i) => {
-  allocate_uint(wasm_mod, env, Uint64(i));
-};
-
 type alloc_number_type =
-  | Int32(Expression.t)
   | Int64(Expression.t)
-  | Float32(Expression.t)
   | Float64(Expression.t)
   | Rational(Expression.t, Expression.t)
   | BigInt(Expression.t, list(Expression.t));
@@ -2150,14 +2143,6 @@ let allocate_number = (wasm_mod, env, number) => {
 
   let (number_tag, swap_slot, instrs, needed_words) =
     switch (number) {
-    | Int32(int32) =>
-      let slot = 0;
-      (
-        BoxedInt32,
-        slot,
-        [store(~offset=8, ~ty=Type.int32, wasm_mod, get_swap(slot), int32)],
-        3,
-      );
     | Int64(int64) =>
       let slot = 0;
       (
@@ -2165,22 +2150,6 @@ let allocate_number = (wasm_mod, env, number) => {
         slot,
         [store(~offset=8, ~ty=Type.int64, wasm_mod, get_swap(slot), int64)],
         4,
-      );
-    | Float32(float32) =>
-      let slot = 0;
-      (
-        BoxedFloat32,
-        slot,
-        [
-          store(
-            ~offset=8,
-            ~ty=Type.float32,
-            wasm_mod,
-            get_swap(slot),
-            float32,
-          ),
-        ],
-        3,
       );
     | Float64(float64) =>
       let slot = 0;
@@ -2343,7 +2312,7 @@ let allocate_number_uninitialized =
 };
 
 let allocate_float32 = (wasm_mod, env, i) => {
-  allocate_number(wasm_mod, env, Float32(i));
+  allocate_alt_num(wasm_mod, env, Float32(i));
 };
 
 let allocate_float64 = (wasm_mod, env, i) => {
@@ -2351,7 +2320,7 @@ let allocate_float64 = (wasm_mod, env, i) => {
 };
 
 let allocate_int32 = (wasm_mod, env, i) => {
-  allocate_number(wasm_mod, env, Int32(i));
+  allocate_alt_num(wasm_mod, env, Int32(i));
 };
 
 let allocate_int64 = (wasm_mod, env, i) => {
@@ -2364,6 +2333,14 @@ let allocate_rational = (wasm_mod, env, n, d) => {
 
 let allocate_big_int = (wasm_mod, env, n, d) => {
   allocate_number(wasm_mod, env, BigInt(n, d));
+};
+
+let allocate_uint32 = (wasm_mod, env, i) => {
+  allocate_alt_num(wasm_mod, env, Uint32(i));
+};
+
+let allocate_uint64 = (wasm_mod, env, i) => {
+  allocate_alt_num(wasm_mod, env, Uint64(i));
 };
 
 let tag_short_value = (wasm_mod, compiled_arg, tag) => {
@@ -2382,16 +2359,18 @@ let tag_short_value = (wasm_mod, compiled_arg, tag) => {
 
 let compile_prim0 = (wasm_mod, env, p0): Expression.t => {
   switch (p0) {
-  | AllocateInt32 => allocate_number_uninitialized(wasm_mod, env, BoxedInt32)
+  | AllocateInt32 => allocate_alt_num_uninitialized(wasm_mod, env, Int32Type)
   | AllocateInt64 => allocate_number_uninitialized(wasm_mod, env, BoxedInt64)
   | AllocateFloat32 =>
-    allocate_number_uninitialized(wasm_mod, env, BoxedFloat32)
+    allocate_alt_num_uninitialized(wasm_mod, env, Float32Type)
   | AllocateFloat64 =>
     allocate_number_uninitialized(wasm_mod, env, BoxedFloat64)
   | AllocateRational =>
     allocate_number_uninitialized(wasm_mod, env, BoxedRational)
-  | AllocateUint32 => allocate_uint_uninitialized(wasm_mod, env, true)
-  | AllocateUint64 => allocate_uint_uninitialized(wasm_mod, env, false)
+  | AllocateUint32 =>
+    allocate_alt_num_uninitialized(wasm_mod, env, Uint32Type)
+  | AllocateUint64 =>
+    allocate_alt_num_uninitialized(wasm_mod, env, Uint64Type)
   | WasmMemorySize => Expression.Memory_size.make(wasm_mod)
   | Unreachable => Expression.Unreachable.make(wasm_mod)
   };
@@ -2412,12 +2391,12 @@ let compile_prim1 = (wasm_mod, env, p1, arg, loc): Expression.t => {
       env,
       BoxedBigInt,
     )
-  | NewInt32 => allocate_number(wasm_mod, env, Int32(compiled_arg))
+  | NewInt32 => allocate_alt_num(wasm_mod, env, Int32(compiled_arg))
   | NewInt64 => allocate_number(wasm_mod, env, Int64(compiled_arg))
-  | NewFloat32 => allocate_number(wasm_mod, env, Float32(compiled_arg))
+  | NewFloat32 => allocate_alt_num(wasm_mod, env, Float32(compiled_arg))
   | NewFloat64 => allocate_number(wasm_mod, env, Float64(compiled_arg))
-  | NewUint32 => allocate_uint(wasm_mod, env, Uint32(compiled_arg))
-  | NewUint64 => allocate_uint(wasm_mod, env, Uint64(compiled_arg))
+  | NewUint32 => allocate_alt_num(wasm_mod, env, Uint32(compiled_arg))
+  | NewUint64 => allocate_alt_num(wasm_mod, env, Uint64(compiled_arg))
   | LoadAdtVariant => load(~offset=12, wasm_mod, compiled_arg)
   | StringSize
   | BytesSize => load(~offset=4, wasm_mod, compiled_arg)

--- a/compiler/src/codegen/transl_anf.re
+++ b/compiler/src/codegen/transl_anf.re
@@ -870,11 +870,6 @@ let rec compile_comp = (~id=?, env, c) => {
     | CNumber(Const_number_int(n))
         when n <= Literals.simple_number_max && n >= Literals.simple_number_min =>
       MImmediate(MImmConst(MConstI32(Int64.to_int32(n))))
-    | CNumber(Const_number_int(n))
-        when
-          n <= Int64.of_int32(Int32.max_int)
-          && n >= Int64.of_int32(Int32.min_int) =>
-      MAllocate(MInt32(Int64.to_int32(n)))
     | CNumber(Const_number_int(n)) => MAllocate(MInt64(n))
     | CNumber(Const_number_float(f)) => MAllocate(MFloat64(f))
     | CNumber(

--- a/compiler/src/codegen/value_tags.re
+++ b/compiler/src/codegen/value_tags.re
@@ -11,6 +11,8 @@ type heap_tag_type =
   | LambdaType
   | TupleType
   | BytesType
+  | Int32Type
+  | Float32Type
   | Uint32Type
   | Uint64Type;
 
@@ -24,8 +26,10 @@ let tag_val_of_heap_tag_type =
   | LambdaType => 6
   | TupleType => 7
   | BytesType => 8
-  | Uint32Type => 9
-  | Uint64Type => 10;
+  | Int32Type => 9
+  | Float32Type => 10
+  | Uint32Type => 11
+  | Uint64Type => 12;
 
 let heap_tag_type_of_tag_val =
   fun
@@ -37,36 +41,32 @@ let heap_tag_type_of_tag_val =
   | 6 => LambdaType
   | 7 => TupleType
   | 8 => BytesType
-  | 9 => Uint32Type
-  | 10 => Uint64Type
+  | 9 => Int32Type
+  | 10 => Float32Type
+  | 11 => Uint32Type
+  | 12 => Uint64Type
   | x => failwith(Printf.sprintf("Unknown tag type: %d", x));
 
 [@deriving sexp]
 type boxed_number_tag_type =
-  | BoxedInt32
   | BoxedInt64
   | BoxedRational
-  | BoxedFloat32
   | BoxedFloat64
   | BoxedBigInt;
 
 let tag_val_of_boxed_number_tag_type =
   fun
-  | BoxedFloat32 => 1
-  | BoxedFloat64 => 2
-  | BoxedInt32 => 3
-  | BoxedInt64 => 4
-  | BoxedRational => 5
-  | BoxedBigInt => 6;
+  | BoxedFloat64 => 1
+  | BoxedInt64 => 2
+  | BoxedRational => 3
+  | BoxedBigInt => 4;
 
 let boxed_number_tag_type_of_tag_val =
   fun
-  | 1 => BoxedFloat32
-  | 2 => BoxedFloat64
-  | 3 => BoxedInt32
-  | 4 => BoxedInt64
-  | 5 => BoxedRational
-  | 6 => BoxedBigInt
+  | 1 => BoxedFloat64
+  | 2 => BoxedInt64
+  | 3 => BoxedRational
+  | 4 => BoxedBigInt
   | x => failwith(Printf.sprintf("Unknown boxed num tag type: %d", x));
 
 [@deriving sexp]

--- a/compiler/test/__snapshots__/arrays.0f9e7d37.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.0f9e7d37.0.snapshot
@@ -109,19 +109,13 @@ arrays › array_access
           (drop
            (if (result i32)
             (i32.or
-             (i32.or
-              (i32.eq
-               (local.get $1)
-               (i32.const 3)
-              )
-              (i32.eq
-               (local.get $1)
-               (i32.const 4)
-              )
+             (i32.eq
+              (local.get $1)
+              (i32.const 2)
              )
              (i32.eq
               (local.get $1)
-              (i32.const 6)
+              (i32.const 4)
              )
             )
             (call $panicWithException_0

--- a/compiler/test/__snapshots__/arrays.1deb7b51.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.1deb7b51.0.snapshot
@@ -109,19 +109,13 @@ arrays › array_access5
           (drop
            (if (result i32)
             (i32.or
-             (i32.or
-              (i32.eq
-               (local.get $1)
-               (i32.const 3)
-              )
-              (i32.eq
-               (local.get $1)
-               (i32.const 4)
-              )
+             (i32.eq
+              (local.get $1)
+              (i32.const 2)
              )
              (i32.eq
               (local.get $1)
-              (i32.const 6)
+              (i32.const 4)
              )
             )
             (call $panicWithException_0

--- a/compiler/test/__snapshots__/arrays.28fcc534.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.28fcc534.0.snapshot
@@ -109,19 +109,13 @@ arrays › array_access4
           (drop
            (if (result i32)
             (i32.or
-             (i32.or
-              (i32.eq
-               (local.get $1)
-               (i32.const 3)
-              )
-              (i32.eq
-               (local.get $1)
-               (i32.const 4)
-              )
+             (i32.eq
+              (local.get $1)
+              (i32.const 2)
              )
              (i32.eq
               (local.get $1)
-              (i32.const 6)
+              (i32.const 4)
              )
             )
             (call $panicWithException_0

--- a/compiler/test/__snapshots__/arrays.4c8c9f91.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.4c8c9f91.0.snapshot
@@ -109,19 +109,13 @@ arrays › array_access2
           (drop
            (if (result i32)
             (i32.or
-             (i32.or
-              (i32.eq
-               (local.get $1)
-               (i32.const 3)
-              )
-              (i32.eq
-               (local.get $1)
-               (i32.const 4)
-              )
+             (i32.eq
+              (local.get $1)
+              (i32.const 2)
              )
              (i32.eq
               (local.get $1)
-              (i32.const 6)
+              (i32.const 4)
              )
             )
             (call $panicWithException_0

--- a/compiler/test/__snapshots__/arrays.6eac4e1f.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.6eac4e1f.0.snapshot
@@ -109,19 +109,13 @@ arrays › array_access3
           (drop
            (if (result i32)
             (i32.or
-             (i32.or
-              (i32.eq
-               (local.get $1)
-               (i32.const 3)
-              )
-              (i32.eq
-               (local.get $1)
-               (i32.const 4)
-              )
+             (i32.eq
+              (local.get $1)
+              (i32.const 2)
              )
              (i32.eq
               (local.get $1)
-              (i32.const 6)
+              (i32.const 4)
              )
             )
             (call $panicWithException_0

--- a/compiler/test/__snapshots__/arrays.74d79181.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.74d79181.0.snapshot
@@ -109,19 +109,13 @@ arrays › array_access5
           (drop
            (if (result i32)
             (i32.or
-             (i32.or
-              (i32.eq
-               (local.get $1)
-               (i32.const 3)
-              )
-              (i32.eq
-               (local.get $1)
-               (i32.const 4)
-              )
+             (i32.eq
+              (local.get $1)
+              (i32.const 2)
              )
              (i32.eq
               (local.get $1)
-              (i32.const 6)
+              (i32.const 4)
              )
             )
             (call $panicWithException_0

--- a/compiler/test/__snapshots__/basic_functionality.27a7e2f7.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.27a7e2f7.0.snapshot
@@ -48,7 +48,7 @@ basic functionality › bigint_start_pos
        )
        (i32.store offset=4
         (local.get $0)
-        (i32.const 6)
+        (i32.const 4)
        )
        (i32.store offset=8
         (local.get $0)

--- a/compiler/test/__snapshots__/basic_functionality.2cb30a54.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.2cb30a54.0.snapshot
@@ -48,7 +48,7 @@ basic functionality › bigint_start_neg
        )
        (i32.store offset=4
         (local.get $0)
-        (i32.const 6)
+        (i32.const 4)
        )
        (i32.store offset=8
         (local.get $0)

--- a/compiler/test/__snapshots__/basic_functionality.31e0d562.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.31e0d562.0.snapshot
@@ -48,7 +48,7 @@ basic functionality › infinity
        )
        (i32.store offset=4
         (local.get $0)
-        (i32.const 2)
+        (i32.const 1)
        )
        (f64.store offset=8
         (local.get $0)

--- a/compiler/test/__snapshots__/basic_functionality.34dcfbdd.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.34dcfbdd.0.snapshot
@@ -48,7 +48,7 @@ basic functionality › int64_1
        )
        (i32.store offset=4
         (local.get $0)
-        (i32.const 4)
+        (i32.const 2)
        )
        (i64.store offset=8
         (local.get $0)

--- a/compiler/test/__snapshots__/basic_functionality.427c6671.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.427c6671.0.snapshot
@@ -44,7 +44,7 @@ basic functionality › uint64_1
           (i32.const 16)
          )
         )
-        (i32.const 10)
+        (i32.const 12)
        )
        (i64.store offset=8
         (local.get $0)

--- a/compiler/test/__snapshots__/basic_functionality.4d1501b9.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.4d1501b9.0.snapshot
@@ -48,7 +48,7 @@ basic functionality › nan
        )
        (i32.store offset=4
         (local.get $0)
-        (i32.const 2)
+        (i32.const 1)
        )
        (f64.store offset=8
         (local.get $0)

--- a/compiler/test/__snapshots__/basic_functionality.4f5bd247.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.4f5bd247.0.snapshot
@@ -48,7 +48,7 @@ basic functionality › heap_number_i64_wrapper
        )
        (i32.store offset=4
         (local.get $0)
-        (i32.const 4)
+        (i32.const 2)
        )
        (i64.store offset=8
         (local.get $0)

--- a/compiler/test/__snapshots__/basic_functionality.7bb7b0d4.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.7bb7b0d4.0.snapshot
@@ -44,7 +44,7 @@ basic functionality › uint32_1
           (i32.const 8)
          )
         )
-        (i32.const 9)
+        (i32.const 11)
        )
        (i32.store offset=4
         (local.get $0)

--- a/compiler/test/__snapshots__/basic_functionality.7ccc4940.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.7ccc4940.0.snapshot
@@ -48,7 +48,7 @@ basic functionality › division1
        )
        (i32.store offset=4
         (local.get $1)
-        (i32.const 5)
+        (i32.const 3)
        )
        (i32.store offset=8
         (local.get $1)
@@ -64,7 +64,7 @@ basic functionality › division1
          )
          (i32.store offset=4
           (local.get $0)
-          (i32.const 6)
+          (i32.const 4)
          )
          (i32.store offset=8
           (local.get $0)
@@ -95,7 +95,7 @@ basic functionality › division1
          )
          (i32.store offset=4
           (local.get $0)
-          (i32.const 6)
+          (i32.const 4)
          )
          (i32.store offset=8
           (local.get $0)

--- a/compiler/test/__snapshots__/basic_functionality.8e01d666.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.8e01d666.0.snapshot
@@ -48,7 +48,7 @@ basic functionality › infinity_neg
        )
        (i32.store offset=4
         (local.get $0)
-        (i32.const 2)
+        (i32.const 1)
        )
        (f64.store offset=8
         (local.get $0)

--- a/compiler/test/__snapshots__/basic_functionality.a3f7e180.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.a3f7e180.0.snapshot
@@ -60,7 +60,7 @@ basic functionality › bigint_1
            )
            (i32.store offset=4
             (local.get $0)
-            (i32.const 4)
+            (i32.const 2)
            )
            (i64.store offset=8
             (local.get $0)

--- a/compiler/test/__snapshots__/basic_functionality.e6ea6b06.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.e6ea6b06.0.snapshot
@@ -36,21 +36,17 @@ basic functionality › int32_1
    (block $cleanup_locals.3 (result i32)
     (local.set $0
      (block $compile_block.2 (result i32)
-      (block $allocate_number.1 (result i32)
+      (block $allocate_int32.1 (result i32)
        (i32.store
         (local.tee $0
          (call $malloc_0
           (global.get $GRAIN$EXPORT$malloc_0)
-          (i32.const 12)
+          (i32.const 8)
          )
         )
-        (i32.const 5)
+        (i32.const 9)
        )
        (i32.store offset=4
-        (local.get $0)
-        (i32.const 3)
-       )
-       (i32.store offset=8
         (local.get $0)
         (i32.const 42)
        )

--- a/compiler/test/__snapshots__/basic_functionality.f90a3baa.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.f90a3baa.0.snapshot
@@ -41,18 +41,18 @@ basic functionality › heap_number_i32_wrapper_max
         (local.tee $0
          (call $malloc_0
           (global.get $GRAIN$EXPORT$malloc_0)
-          (i32.const 12)
+          (i32.const 16)
          )
         )
         (i32.const 5)
        )
        (i32.store offset=4
         (local.get $0)
-        (i32.const 3)
+        (i32.const 2)
        )
-       (i32.store offset=8
+       (i64.store offset=8
         (local.get $0)
-        (i32.const 2147483647)
+        (i64.const 2147483647)
        )
        (local.get $0)
       )

--- a/compiler/test/__snapshots__/basic_functionality.f9743171.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.f9743171.0.snapshot
@@ -41,18 +41,18 @@ basic functionality › heap_number_i32_wrapper
         (local.tee $0
          (call $malloc_0
           (global.get $GRAIN$EXPORT$malloc_0)
-          (i32.const 12)
+          (i32.const 16)
          )
         )
         (i32.const 5)
        )
        (i32.store offset=4
         (local.get $0)
-        (i32.const 3)
+        (i32.const 2)
        )
-       (i32.store offset=8
+       (i64.store offset=8
         (local.get $0)
-        (i32.const 1073741824)
+        (i64.const 1073741824)
        )
        (local.get $0)
       )

--- a/compiler/test/__snapshots__/basic_functionality.fe19cffe.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.fe19cffe.0.snapshot
@@ -48,7 +48,7 @@ basic functionality › bigint_2
        )
        (i32.store offset=4
         (local.get $0)
-        (i32.const 6)
+        (i32.const 4)
        )
        (i32.store offset=8
         (local.get $0)

--- a/compiler/test/__snapshots__/pattern_matching.64686134.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.64686134.0.snapshot
@@ -63,7 +63,7 @@ pattern matching › constant_match_1
            )
            (i32.store offset=4
             (local.get $1)
-            (i32.const 5)
+            (i32.const 3)
            )
            (i32.store offset=8
             (local.get $1)
@@ -79,7 +79,7 @@ pattern matching › constant_match_1
              )
              (i32.store offset=4
               (local.get $0)
-              (i32.const 6)
+              (i32.const 4)
              )
              (i32.store offset=8
               (local.get $0)
@@ -110,7 +110,7 @@ pattern matching › constant_match_1
              )
              (i32.store offset=4
               (local.get $0)
-              (i32.const 6)
+              (i32.const 4)
              )
              (i32.store offset=8
               (local.get $0)
@@ -183,7 +183,7 @@ pattern matching › constant_match_1
                )
                (i32.store offset=4
                 (local.get $1)
-                (i32.const 5)
+                (i32.const 3)
                )
                (i32.store offset=8
                 (local.get $1)
@@ -199,7 +199,7 @@ pattern matching › constant_match_1
                  )
                  (i32.store offset=4
                   (local.get $0)
-                  (i32.const 6)
+                  (i32.const 4)
                  )
                  (i32.store offset=8
                   (local.get $0)
@@ -230,7 +230,7 @@ pattern matching › constant_match_1
                  )
                  (i32.store offset=4
                   (local.get $0)
-                  (i32.const 6)
+                  (i32.const 4)
                  )
                  (i32.store offset=8
                   (local.get $0)

--- a/compiler/test/stdlib/float32.test.gr
+++ b/compiler/test/stdlib/float32.test.gr
@@ -33,3 +33,10 @@ assert !gt(5.0f, 5.0f)
 assert !gte(5.0f, 22.0f)
 assert !lt(5.0f, -17.0f)
 assert !lte(5.0f, 4.0f)
+
+assert compare(1.0f, 2.0f) < 0
+assert compare(3.0f, 2.0f) > 0
+assert compare(1.0f, 1.0f) == 0
+assert compare(nan, nan) == 0
+assert compare(1.0f, nan) > 0
+assert compare(nan, 1.0f) < 0

--- a/compiler/test/stdlib/int32.test.gr
+++ b/compiler/test/stdlib/int32.test.gr
@@ -9,6 +9,8 @@ assert fromNumber(5) == 5l
 assert fromNumber(0) == 0l
 
 assert toNumber(555l) == 555
+assert toNumber(0x40000000l) == 0x40000000
+assert toNumber(-0x40000001l) == -0x40000001
 assert toNumber(0l) == 0
 
 assert fromUint32(1ul) == 1l

--- a/docs/contributor/data_representations.md
+++ b/docs/contributor/data_representations.md
@@ -189,18 +189,6 @@ All heap-allocated numbers have the following structure on the heap.
 The boxed number tag describes which variant the structure is an instance of, and, correspondingly,
 what the shape of the rest of the structure is.
 
-#### Int32
-
-The payload for Int32 values is a single, signed, 32-bit integer.
-
-```plaintext
-╔══════╦═══════════╤══════════════════╤══════════════╗
-║ size ║ 32        │ 32               │ 32           ║
-╠══════╬═══════════╪══════════════════╪══════════════╣
-║ what ║ value tag │ boxed number tag │ value (i32)  ║
-╚══════╩═══════════╧══════════════════╧══════════════╝
-```
-
 #### Int64
 
 The payload for Int64 values is a single, signed, 64-bit integer.
@@ -210,18 +198,6 @@ The payload for Int64 values is a single, signed, 64-bit integer.
 ║ size ║ 32        │ 32               │ 64           ║
 ╠══════╬═══════════╪══════════════════╪══════════════╣
 ║ what ║ value tag │ boxed number tag │ value (i64)  ║
-╚══════╩═══════════╧══════════════════╧══════════════╝
-```
-
-#### Float32
-
-The payload for Float32 values is a single, signed, 32-bit float.
-
-```plaintext
-╔══════╦═══════════╤══════════════════╤══════════════╗
-║ size ║ 32        │ 32               │ 32           ║
-╠══════╬═══════════╪══════════════════╪══════════════╣
-║ what ║ value tag │ boxed number tag │ value (f32)  ║
 ╚══════╩═══════════╧══════════════════╧══════════════╝
 ```
 
@@ -265,9 +241,33 @@ bitflag, 16 bits of reserved space, and the 64-bit limbs containing the value.
 ╚══════╩═══════════╧══════════════════╧═════════════════╧═════════════════╧═════════════════════════════════════════╝
 ```
 
-### Unsigned Integers
+### Alternative Heap-Allocated Numbers
 
-Unsigned integers are distinct from `Number`s, which always represent signed numbers.
+Some number types (`Int32`, `Float32`, `Uint32`, and `Uint64`) are not encapsulated into the unified `Number` type and are rather their own unique types.
+
+#### Int32
+
+The payload for Int32 values is a single, signed, 32-bit integer.
+
+```plaintext
+╔══════╦═══════════╤══════════════╗
+║ size ║ 32        │ 32           ║
+╠══════╬═══════════╪══════════════╣
+║ what ║ value tag │ value (i32)  ║
+╚══════╩═══════════╧══════════════╝
+```
+
+#### Float32
+
+The payload for Float32 values is a single, signed, 32-bit float.
+
+```plaintext
+╔══════╦═══════════╤══════════════╗
+║ size ║ 32        │ 32           ║
+╠══════╬═══════════╪══════════════╣
+║ what ║ value tag │ value (f32)  ║
+╚══════╩═══════════╧══════════════╝
+```
 
 #### Uint32
 

--- a/stdlib/bigint.gr
+++ b/stdlib/bigint.gr
@@ -204,7 +204,7 @@ provide let gcd = (num1: BigInt, num2: BigInt) => {
 @unsafe
 provide let shl = (num: BigInt, places: Int32) => {
   let num = WasmI32.fromGrain(num)
-  let places = WasmI32.load(WasmI32.fromGrain(places), 8n)
+  let places = WasmI32.load(WasmI32.fromGrain(places), 4n)
   WasmI32.toGrain(BI.shl(num, places)): BigInt
 }
 
@@ -220,7 +220,7 @@ provide let shl = (num: BigInt, places: Int32) => {
 @unsafe
 provide let shr = (num: BigInt, places: Int32) => {
   let num = WasmI32.fromGrain(num)
-  let places = WasmI32.load(WasmI32.fromGrain(places), 8n)
+  let places = WasmI32.load(WasmI32.fromGrain(places), 4n)
   WasmI32.toGrain(BI.shrS(num, places)): BigInt
 }
 

--- a/stdlib/float32.gr
+++ b/stdlib/float32.gr
@@ -19,6 +19,9 @@ from Numbers use {
   coerceFloat32ToNumber as toNumber,
 }
 
+@unsafe
+let _VALUE_OFFSET = 4n
+
 /**
  * Infinity represented as a Float32 value.
  *
@@ -79,8 +82,8 @@ provide { fromNumber, toNumber }
  */
 @unsafe
 provide let add = (x: Float32, y: Float32) => {
-  let xv = WasmF32.load(WasmI32.fromGrain(x), 8n)
-  let yv = WasmF32.load(WasmI32.fromGrain(y), 8n)
+  let xv = WasmF32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
+  let yv = WasmF32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   let ptr = newFloat32(WasmF32.add(xv, yv))
   WasmI32.toGrain(ptr): Float32
 }
@@ -96,8 +99,8 @@ provide let add = (x: Float32, y: Float32) => {
  */
 @unsafe
 provide let sub = (x: Float32, y: Float32) => {
-  let xv = WasmF32.load(WasmI32.fromGrain(x), 8n)
-  let yv = WasmF32.load(WasmI32.fromGrain(y), 8n)
+  let xv = WasmF32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
+  let yv = WasmF32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   let ptr = newFloat32(WasmF32.sub(xv, yv))
   WasmI32.toGrain(ptr): Float32
 }
@@ -113,8 +116,8 @@ provide let sub = (x: Float32, y: Float32) => {
  */
 @unsafe
 provide let mul = (x: Float32, y: Float32) => {
-  let xv = WasmF32.load(WasmI32.fromGrain(x), 8n)
-  let yv = WasmF32.load(WasmI32.fromGrain(y), 8n)
+  let xv = WasmF32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
+  let yv = WasmF32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   let ptr = newFloat32(WasmF32.mul(xv, yv))
   WasmI32.toGrain(ptr): Float32
 }
@@ -130,8 +133,8 @@ provide let mul = (x: Float32, y: Float32) => {
  */
 @unsafe
 provide let div = (x: Float32, y: Float32) => {
-  let xv = WasmF32.load(WasmI32.fromGrain(x), 8n)
-  let yv = WasmF32.load(WasmI32.fromGrain(y), 8n)
+  let xv = WasmF32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
+  let yv = WasmF32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   let ptr = newFloat32(WasmF32.div(xv, yv))
   WasmI32.toGrain(ptr): Float32
 }
@@ -147,8 +150,8 @@ provide let div = (x: Float32, y: Float32) => {
  */
 @unsafe
 provide let lt = (x: Float32, y: Float32) => {
-  let xv = WasmF32.load(WasmI32.fromGrain(x), 8n)
-  let yv = WasmF32.load(WasmI32.fromGrain(y), 8n)
+  let xv = WasmF32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
+  let yv = WasmF32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   WasmF32.lt(xv, yv)
 }
 
@@ -163,8 +166,8 @@ provide let lt = (x: Float32, y: Float32) => {
  */
 @unsafe
 provide let gt = (x: Float32, y: Float32) => {
-  let xv = WasmF32.load(WasmI32.fromGrain(x), 8n)
-  let yv = WasmF32.load(WasmI32.fromGrain(y), 8n)
+  let xv = WasmF32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
+  let yv = WasmF32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   WasmF32.gt(xv, yv)
 }
 
@@ -179,8 +182,8 @@ provide let gt = (x: Float32, y: Float32) => {
  */
 @unsafe
 provide let lte = (x: Float32, y: Float32) => {
-  let xv = WasmF32.load(WasmI32.fromGrain(x), 8n)
-  let yv = WasmF32.load(WasmI32.fromGrain(y), 8n)
+  let xv = WasmF32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
+  let yv = WasmF32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   WasmF32.le(xv, yv)
 }
 
@@ -195,7 +198,7 @@ provide let lte = (x: Float32, y: Float32) => {
  */
 @unsafe
 provide let gte = (x: Float32, y: Float32) => {
-  let xv = WasmF32.load(WasmI32.fromGrain(x), 8n)
-  let yv = WasmF32.load(WasmI32.fromGrain(y), 8n)
+  let xv = WasmF32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
+  let yv = WasmF32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   WasmF32.ge(xv, yv)
 }

--- a/stdlib/hash.gr
+++ b/stdlib/hash.gr
@@ -188,9 +188,6 @@ let rec hashOne = (val, depth) => {
       t when t == Tags._GRAIN_BOXED_NUM_HEAP_TAG => {
         let tag = WasmI32.load(heapPtr, 4n)
         match (tag) {
-          t when t == Tags._GRAIN_INT32_BOXED_NUM_TAG => {
-            hash32(WasmI32.load(heapPtr, 8n))
-          },
           t when t == Tags._GRAIN_INT64_BOXED_NUM_TAG => {
             hash32(WasmI32.load(heapPtr, 8n))
             hash32(WasmI32.load(heapPtr, 12n))
@@ -203,9 +200,6 @@ let rec hashOne = (val, depth) => {
             for (let mut i = 0n; i < size; i += 1n) {
               hash64(BI.getLimb(heapPtr, i))
             }
-          },
-          t when t == Tags._GRAIN_FLOAT32_BOXED_NUM_TAG => {
-            hash32(WasmI32.load(heapPtr, 8n))
           },
           t when t == Tags._GRAIN_FLOAT64_BOXED_NUM_TAG => {
             hash32(WasmI32.load(heapPtr, 8n))
@@ -220,7 +214,11 @@ let rec hashOne = (val, depth) => {
           },
         }
       },
-      t when t == Tags._GRAIN_UINT32_HEAP_TAG => {
+      t when (
+        t == Tags._GRAIN_INT32_HEAP_TAG ||
+        t == Tags._GRAIN_FLOAT32_HEAP_TAG ||
+        t == Tags._GRAIN_UINT32_HEAP_TAG
+      ) => {
         hash32(WasmI32.load(heapPtr, 4n))
       },
       t when t == Tags._GRAIN_UINT64_HEAP_TAG => {

--- a/stdlib/int32.gr
+++ b/stdlib/int32.gr
@@ -9,6 +9,7 @@
 module Int32
 
 include "runtime/unsafe/wasmi32"
+include "runtime/unsafe/wasmi64"
 include "runtime/exception"
 
 include "runtime/dataStructures"
@@ -19,6 +20,9 @@ from Numbers use {
   coerceNumberToInt32 as fromNumber,
   coerceInt32ToNumber as toNumber,
 }
+
+@unsafe
+let _VALUE_OFFSET = 4n
 
 provide { fromNumber, toNumber }
 
@@ -32,7 +36,7 @@ provide { fromNumber, toNumber }
  */
 @unsafe
 provide let fromUint32 = (x: Uint32) => {
-  let x = WasmI32.load(WasmI32.fromGrain(x), 4n)
+  let x = WasmI32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
   let result = newInt32(x)
   WasmI32.toGrain(result): Int32
 }
@@ -48,7 +52,7 @@ provide let fromUint32 = (x: Uint32) => {
 @unsafe
 provide let incr = (value: Int32) => {
   let value = WasmI32.fromGrain(value)
-  let ptr = newInt32(WasmI32.add(WasmI32.load(value, 8n), 1n))
+  let ptr = newInt32(WasmI32.add(WasmI32.load(value, _VALUE_OFFSET), 1n))
   WasmI32.toGrain(ptr): Int32
 }
 
@@ -63,7 +67,7 @@ provide let incr = (value: Int32) => {
 @unsafe
 provide let decr = (value: Int32) => {
   let value = WasmI32.fromGrain(value)
-  let ptr = newInt32(WasmI32.sub(WasmI32.load(value, 8n), 1n))
+  let ptr = newInt32(WasmI32.sub(WasmI32.load(value, _VALUE_OFFSET), 1n))
   WasmI32.toGrain(ptr): Int32
 }
 
@@ -78,8 +82,8 @@ provide let decr = (value: Int32) => {
  */
 @unsafe
 provide let add = (x: Int32, y: Int32) => {
-  let xv = WasmI32.load(WasmI32.fromGrain(x), 8n)
-  let yv = WasmI32.load(WasmI32.fromGrain(y), 8n)
+  let xv = WasmI32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
+  let yv = WasmI32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   let ptr = newInt32(WasmI32.add(xv, yv))
   WasmI32.toGrain(ptr): Int32
 }
@@ -95,8 +99,8 @@ provide let add = (x: Int32, y: Int32) => {
  */
 @unsafe
 provide let sub = (x: Int32, y: Int32) => {
-  let xv = WasmI32.load(WasmI32.fromGrain(x), 8n)
-  let yv = WasmI32.load(WasmI32.fromGrain(y), 8n)
+  let xv = WasmI32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
+  let yv = WasmI32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   let ptr = newInt32(WasmI32.sub(xv, yv))
   WasmI32.toGrain(ptr): Int32
 }
@@ -112,8 +116,8 @@ provide let sub = (x: Int32, y: Int32) => {
  */
 @unsafe
 provide let mul = (x: Int32, y: Int32) => {
-  let xv = WasmI32.load(WasmI32.fromGrain(x), 8n)
-  let yv = WasmI32.load(WasmI32.fromGrain(y), 8n)
+  let xv = WasmI32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
+  let yv = WasmI32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   let ptr = newInt32(WasmI32.mul(xv, yv))
   WasmI32.toGrain(ptr): Int32
 }
@@ -129,8 +133,8 @@ provide let mul = (x: Int32, y: Int32) => {
  */
 @unsafe
 provide let div = (x: Int32, y: Int32) => {
-  let xv = WasmI32.load(WasmI32.fromGrain(x), 8n)
-  let yv = WasmI32.load(WasmI32.fromGrain(y), 8n)
+  let xv = WasmI32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
+  let yv = WasmI32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   let ptr = newInt32(WasmI32.divS(xv, yv))
   WasmI32.toGrain(ptr): Int32
 }
@@ -146,8 +150,8 @@ provide let div = (x: Int32, y: Int32) => {
  */
 @unsafe
 provide let rem = (x: Int32, y: Int32) => {
-  let xv = WasmI32.load(WasmI32.fromGrain(x), 8n)
-  let yv = WasmI32.load(WasmI32.fromGrain(y), 8n)
+  let xv = WasmI32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
+  let yv = WasmI32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   let ptr = newInt32(WasmI32.remS(xv, yv))
   WasmI32.toGrain(ptr): Int32
 }
@@ -172,8 +176,8 @@ let abs = n => {
  */
 @unsafe
 provide let mod = (x: Int32, y: Int32) => {
-  let xval = WasmI32.load(WasmI32.fromGrain(x), 8n)
-  let yval = WasmI32.load(WasmI32.fromGrain(y), 8n)
+  let xval = WasmI32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
+  let yval = WasmI32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
 
   if (WasmI32.eqz(yval)) {
     throw Exception.ModuloByZero
@@ -206,8 +210,8 @@ provide let mod = (x: Int32, y: Int32) => {
  */
 @unsafe
 provide let rotl = (value: Int32, amount: Int32) => {
-  let xv = WasmI32.load(WasmI32.fromGrain(value), 8n)
-  let yv = WasmI32.load(WasmI32.fromGrain(amount), 8n)
+  let xv = WasmI32.load(WasmI32.fromGrain(value), _VALUE_OFFSET)
+  let yv = WasmI32.load(WasmI32.fromGrain(amount), _VALUE_OFFSET)
   let ptr = newInt32(WasmI32.rotl(xv, yv))
   WasmI32.toGrain(ptr): Int32
 }
@@ -223,8 +227,8 @@ provide let rotl = (value: Int32, amount: Int32) => {
  */
 @unsafe
 provide let rotr = (value: Int32, amount: Int32) => {
-  let xv = WasmI32.load(WasmI32.fromGrain(value), 8n)
-  let yv = WasmI32.load(WasmI32.fromGrain(amount), 8n)
+  let xv = WasmI32.load(WasmI32.fromGrain(value), _VALUE_OFFSET)
+  let yv = WasmI32.load(WasmI32.fromGrain(amount), _VALUE_OFFSET)
   let ptr = newInt32(WasmI32.rotr(xv, yv))
   WasmI32.toGrain(ptr): Int32
 }
@@ -240,8 +244,8 @@ provide let rotr = (value: Int32, amount: Int32) => {
  */
 @unsafe
 provide let shl = (value: Int32, amount: Int32) => {
-  let xv = WasmI32.load(WasmI32.fromGrain(value), 8n)
-  let yv = WasmI32.load(WasmI32.fromGrain(amount), 8n)
+  let xv = WasmI32.load(WasmI32.fromGrain(value), _VALUE_OFFSET)
+  let yv = WasmI32.load(WasmI32.fromGrain(amount), _VALUE_OFFSET)
   let ptr = newInt32(WasmI32.shl(xv, yv))
   WasmI32.toGrain(ptr): Int32
 }
@@ -257,8 +261,8 @@ provide let shl = (value: Int32, amount: Int32) => {
  */
 @unsafe
 provide let shr = (value: Int32, amount: Int32) => {
-  let xv = WasmI32.load(WasmI32.fromGrain(value), 8n)
-  let yv = WasmI32.load(WasmI32.fromGrain(amount), 8n)
+  let xv = WasmI32.load(WasmI32.fromGrain(value), _VALUE_OFFSET)
+  let yv = WasmI32.load(WasmI32.fromGrain(amount), _VALUE_OFFSET)
   let ptr = newInt32(WasmI32.shrS(xv, yv))
   WasmI32.toGrain(ptr): Int32
 }
@@ -274,8 +278,8 @@ provide let shr = (value: Int32, amount: Int32) => {
  */
 @unsafe
 provide let eq = (x: Int32, y: Int32) => {
-  let xv = WasmI32.load(WasmI32.fromGrain(x), 8n)
-  let yv = WasmI32.load(WasmI32.fromGrain(y), 8n)
+  let xv = WasmI32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
+  let yv = WasmI32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   WasmI32.eq(xv, yv)
 }
 
@@ -290,8 +294,8 @@ provide let eq = (x: Int32, y: Int32) => {
  */
 @unsafe
 provide let ne = (x: Int32, y: Int32) => {
-  let xv = WasmI32.load(WasmI32.fromGrain(x), 8n)
-  let yv = WasmI32.load(WasmI32.fromGrain(y), 8n)
+  let xv = WasmI32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
+  let yv = WasmI32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   WasmI32.ne(xv, yv)
 }
 
@@ -305,7 +309,7 @@ provide let ne = (x: Int32, y: Int32) => {
  */
 @unsafe
 provide let eqz = (value: Int32) => {
-  let xv = WasmI32.load(WasmI32.fromGrain(value), 8n)
+  let xv = WasmI32.load(WasmI32.fromGrain(value), _VALUE_OFFSET)
   WasmI32.eqz(xv)
 }
 
@@ -320,8 +324,8 @@ provide let eqz = (value: Int32) => {
  */
 @unsafe
 provide let lt = (x: Int32, y: Int32) => {
-  let xv = WasmI32.load(WasmI32.fromGrain(x), 8n)
-  let yv = WasmI32.load(WasmI32.fromGrain(y), 8n)
+  let xv = WasmI32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
+  let yv = WasmI32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   WasmI32.ltS(xv, yv)
 }
 
@@ -336,8 +340,8 @@ provide let lt = (x: Int32, y: Int32) => {
  */
 @unsafe
 provide let gt = (x: Int32, y: Int32) => {
-  let xv = WasmI32.load(WasmI32.fromGrain(x), 8n)
-  let yv = WasmI32.load(WasmI32.fromGrain(y), 8n)
+  let xv = WasmI32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
+  let yv = WasmI32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   WasmI32.gtS(xv, yv)
 }
 
@@ -352,8 +356,8 @@ provide let gt = (x: Int32, y: Int32) => {
  */
 @unsafe
 provide let lte = (x: Int32, y: Int32) => {
-  let xv = WasmI32.load(WasmI32.fromGrain(x), 8n)
-  let yv = WasmI32.load(WasmI32.fromGrain(y), 8n)
+  let xv = WasmI32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
+  let yv = WasmI32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   WasmI32.leS(xv, yv)
 }
 
@@ -368,8 +372,8 @@ provide let lte = (x: Int32, y: Int32) => {
  */
 @unsafe
 provide let gte = (x: Int32, y: Int32) => {
-  let xv = WasmI32.load(WasmI32.fromGrain(x), 8n)
-  let yv = WasmI32.load(WasmI32.fromGrain(y), 8n)
+  let xv = WasmI32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
+  let yv = WasmI32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   WasmI32.geS(xv, yv)
 }
 
@@ -383,7 +387,7 @@ provide let gte = (x: Int32, y: Int32) => {
  */
 @unsafe
 provide let lnot = (value: Int32) => {
-  let xv = WasmI32.load(WasmI32.fromGrain(value), 8n)
+  let xv = WasmI32.load(WasmI32.fromGrain(value), _VALUE_OFFSET)
   let ptr = newInt32(WasmI32.xor(xv, 0xffffffffn))
   WasmI32.toGrain(ptr): Int32
 }
@@ -399,8 +403,8 @@ provide let lnot = (value: Int32) => {
  */
 @unsafe
 provide let land = (x: Int32, y: Int32) => {
-  let xv = WasmI32.load(WasmI32.fromGrain(x), 8n)
-  let yv = WasmI32.load(WasmI32.fromGrain(y), 8n)
+  let xv = WasmI32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
+  let yv = WasmI32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   let ptr = newInt32(WasmI32.and(xv, yv))
   WasmI32.toGrain(ptr): Int32
 }
@@ -416,8 +420,8 @@ provide let land = (x: Int32, y: Int32) => {
  */
 @unsafe
 provide let lor = (x: Int32, y: Int32) => {
-  let xv = WasmI32.load(WasmI32.fromGrain(x), 8n)
-  let yv = WasmI32.load(WasmI32.fromGrain(y), 8n)
+  let xv = WasmI32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
+  let yv = WasmI32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   let ptr = newInt32(WasmI32.or(xv, yv))
   WasmI32.toGrain(ptr): Int32
 }
@@ -433,8 +437,8 @@ provide let lor = (x: Int32, y: Int32) => {
  */
 @unsafe
 provide let lxor = (x: Int32, y: Int32) => {
-  let xv = WasmI32.load(WasmI32.fromGrain(x), 8n)
-  let yv = WasmI32.load(WasmI32.fromGrain(y), 8n)
+  let xv = WasmI32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
+  let yv = WasmI32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   let ptr = newInt32(WasmI32.xor(xv, yv))
   WasmI32.toGrain(ptr): Int32
 }
@@ -449,7 +453,7 @@ provide let lxor = (x: Int32, y: Int32) => {
  */
 @unsafe
 provide let clz = (value: Int32) => {
-  let nv = WasmI32.load(WasmI32.fromGrain(value), 8n)
+  let nv = WasmI32.load(WasmI32.fromGrain(value), _VALUE_OFFSET)
   let ptr = newInt32(WasmI32.clz(nv))
   WasmI32.toGrain(ptr): Int32
 }
@@ -464,7 +468,7 @@ provide let clz = (value: Int32) => {
  */
 @unsafe
 provide let ctz = (value: Int32) => {
-  let nv = WasmI32.load(WasmI32.fromGrain(value), 8n)
+  let nv = WasmI32.load(WasmI32.fromGrain(value), _VALUE_OFFSET)
   let ptr = newInt32(WasmI32.ctz(nv))
   WasmI32.toGrain(ptr): Int32
 }
@@ -479,7 +483,7 @@ provide let ctz = (value: Int32) => {
  */
 @unsafe
 provide let popcnt = (value: Int32) => {
-  let nv = WasmI32.load(WasmI32.fromGrain(value), 8n)
+  let nv = WasmI32.load(WasmI32.fromGrain(value), _VALUE_OFFSET)
   let ptr = newInt32(WasmI32.popcnt(nv))
   WasmI32.toGrain(ptr): Int32
 }

--- a/stdlib/marshal.gr
+++ b/stdlib/marshal.gr
@@ -143,13 +143,9 @@ let rec size = (value, acc, valuesSeen, toplevel) => {
           let tag = load(heapPtr, 4n)
           match (tag) {
             t when (
-              t == Tags._GRAIN_INT32_BOXED_NUM_TAG ||
               t == Tags._GRAIN_INT64_BOXED_NUM_TAG ||
-              t == Tags._GRAIN_FLOAT32_BOXED_NUM_TAG ||
               t == Tags._GRAIN_FLOAT64_BOXED_NUM_TAG
             ) => {
-              // The 32-bit values only take 12 bytes of memory, but we report 16
-              // for alignment
               acc + 16n
             },
             t when t == Tags._GRAIN_BIGINT_BOXED_NUM_TAG => {
@@ -166,7 +162,11 @@ let rec size = (value, acc, valuesSeen, toplevel) => {
             },
           }
         },
-        t when t == Tags._GRAIN_UINT32_HEAP_TAG => {
+        t when (
+          t == Tags._GRAIN_INT32_HEAP_TAG ||
+          t == Tags._GRAIN_FLOAT32_HEAP_TAG ||
+          t == Tags._GRAIN_UINT32_HEAP_TAG
+        ) => {
           acc + 8n
         },
         t when t == Tags._GRAIN_UINT64_HEAP_TAG => {
@@ -221,7 +221,7 @@ let rec marshalHeap = (heapPtr, buf, offset, valuesSeen) => {
           let asInt32 = toGrain(newInt32(value)): Int32
           match (Map.get(asInt32, valuesSeen)) {
             Some(value) => {
-              let ptr = load(fromGrain(value), 8n)
+              let ptr = load(fromGrain(value), 4n)
               store(buf, ptr, offset + i + 20n)
             },
             None => {
@@ -250,7 +250,7 @@ let rec marshalHeap = (heapPtr, buf, offset, valuesSeen) => {
           let asInt32 = toGrain(newInt32(value)): Int32
           match (Map.get(asInt32, valuesSeen)) {
             Some(value) => {
-              let ptr = load(fromGrain(value), 8n)
+              let ptr = load(fromGrain(value), 4n)
               store(buf, ptr, offset + i + 16n)
             },
             None => {
@@ -279,7 +279,7 @@ let rec marshalHeap = (heapPtr, buf, offset, valuesSeen) => {
           let asInt32 = toGrain(newInt32(value)): Int32
           match (Map.get(asInt32, valuesSeen)) {
             Some(value) => {
-              let ptr = load(fromGrain(value), 8n)
+              let ptr = load(fromGrain(value), 4n)
               store(buf, ptr, offset + i + 8n)
             },
             None => {
@@ -308,7 +308,7 @@ let rec marshalHeap = (heapPtr, buf, offset, valuesSeen) => {
           let asInt32 = toGrain(newInt32(value)): Int32
           match (Map.get(asInt32, valuesSeen)) {
             Some(value) => {
-              let ptr = load(fromGrain(value), 8n)
+              let ptr = load(fromGrain(value), 4n)
               store(buf, ptr, offset + i + 8n)
             },
             None => {
@@ -337,7 +337,7 @@ let rec marshalHeap = (heapPtr, buf, offset, valuesSeen) => {
           let asInt32 = toGrain(newInt32(value)): Int32
           match (Map.get(asInt32, valuesSeen)) {
             Some(value) => {
-              let ptr = load(fromGrain(value), 8n)
+              let ptr = load(fromGrain(value), 4n)
               store(buf, ptr, offset + i + 16n)
             },
             None => {
@@ -355,10 +355,6 @@ let rec marshalHeap = (heapPtr, buf, offset, valuesSeen) => {
     t when t == Tags._GRAIN_BOXED_NUM_HEAP_TAG => {
       let tag = load(heapPtr, 4n)
       match (tag) {
-        t when t == Tags._GRAIN_INT32_BOXED_NUM_TAG => {
-          Memory.copy(buf + offset, heapPtr, 12n)
-          offset + 16n
-        },
         t when t == Tags._GRAIN_INT64_BOXED_NUM_TAG => {
           Memory.copy(buf + offset, heapPtr, 16n)
           offset + 16n
@@ -367,10 +363,6 @@ let rec marshalHeap = (heapPtr, buf, offset, valuesSeen) => {
           let size = 16n + load(heapPtr, 8n) * 8n
           Memory.copy(buf + offset, heapPtr, size)
           offset + size
-        },
-        t when t == Tags._GRAIN_FLOAT32_BOXED_NUM_TAG => {
-          Memory.copy(buf + offset, heapPtr, 12n)
-          offset + 16n
         },
         t when t == Tags._GRAIN_FLOAT64_BOXED_NUM_TAG => {
           Memory.copy(buf + offset, heapPtr, 16n)
@@ -400,7 +392,11 @@ let rec marshalHeap = (heapPtr, buf, offset, valuesSeen) => {
         },
       }
     },
-    t when t == Tags._GRAIN_UINT32_HEAP_TAG => {
+    t when (
+      t == Tags._GRAIN_INT32_HEAP_TAG ||
+      t == Tags._GRAIN_FLOAT32_HEAP_TAG ||
+      t == Tags._GRAIN_UINT32_HEAP_TAG
+    ) => {
       Memory.copy(buf + offset, heapPtr, 8n)
       offset + 8n
     },
@@ -642,16 +638,6 @@ let rec validateHeap = (buf, bufSize, offset, valuesChecked) => {
     t when t == Tags._GRAIN_BOXED_NUM_HEAP_TAG => {
       let tag = load(valuePtr, 4n)
       match (tag) {
-        t when t == Tags._GRAIN_INT32_BOXED_NUM_TAG => {
-          if (offset + 12n > bufSize) {
-            reportError(
-              "Not enough bytes remaining in buffer for Int32/Number",
-              offset
-            )
-          } else {
-            None
-          }
-        },
         t when t == Tags._GRAIN_INT64_BOXED_NUM_TAG => {
           if (offset + 16n > bufSize) {
             reportError(
@@ -666,16 +652,6 @@ let rec validateHeap = (buf, bufSize, offset, valuesChecked) => {
           let size = 16n + load(valuePtr, 8n) * 8n
           if (offset + size > bufSize) {
             reportError("BigInt/Number payload size exeeds buffer size", offset)
-          } else {
-            None
-          }
-        },
-        t when t == Tags._GRAIN_FLOAT32_BOXED_NUM_TAG => {
-          if (offset + 12n > bufSize) {
-            reportError(
-              "Not enough bytes remaining in buffer for Float32/Number",
-              offset
-            )
           } else {
             None
           }
@@ -738,6 +714,20 @@ let rec validateHeap = (buf, bufSize, offset, valuesChecked) => {
         _ => {
           None
         },
+      }
+    },
+    t when t == Tags._GRAIN_INT32_HEAP_TAG => {
+      if (offset + 8n > bufSize) {
+        reportError("Not enough bytes remaining in buffer for Int32", offset)
+      } else {
+        None
+      }
+    },
+    t when t == Tags._GRAIN_FLOAT32_HEAP_TAG => {
+      if (offset + 8n > bufSize) {
+        reportError("Not enough bytes remaining in buffer for Float32", offset)
+      } else {
+        None
       }
     },
     t when t == Tags._GRAIN_UINT32_HEAP_TAG => {
@@ -822,7 +812,7 @@ let rec unmarshalHeap = (buf, offset, valuesUnmarshaled) => {
           let asInt32 = toGrain(newInt32(subvalue)): Int32
           match (Map.get(asInt32, valuesUnmarshaled)) {
             Some(ptr) => {
-              let ptr = load(fromGrain(ptr), 8n)
+              let ptr = load(fromGrain(ptr), 4n)
               store(value + i, Memory.incRef(ptr), 20n)
             },
             None => {
@@ -857,7 +847,7 @@ let rec unmarshalHeap = (buf, offset, valuesUnmarshaled) => {
           let asInt32 = toGrain(newInt32(subvalue)): Int32
           match (Map.get(asInt32, valuesUnmarshaled)) {
             Some(ptr) => {
-              let ptr = load(fromGrain(ptr), 8n)
+              let ptr = load(fromGrain(ptr), 4n)
               store(value + i, Memory.incRef(ptr), 16n)
             },
             None => {
@@ -892,7 +882,7 @@ let rec unmarshalHeap = (buf, offset, valuesUnmarshaled) => {
           let asInt32 = toGrain(newInt32(subvalue)): Int32
           match (Map.get(asInt32, valuesUnmarshaled)) {
             Some(ptr) => {
-              let ptr = load(fromGrain(ptr), 8n)
+              let ptr = load(fromGrain(ptr), 4n)
               store(value + i, Memory.incRef(ptr), 8n)
             },
             None => {
@@ -927,7 +917,7 @@ let rec unmarshalHeap = (buf, offset, valuesUnmarshaled) => {
           let asInt32 = toGrain(newInt32(subvalue)): Int32
           match (Map.get(asInt32, valuesUnmarshaled)) {
             Some(ptr) => {
-              let ptr = load(fromGrain(ptr), 8n)
+              let ptr = load(fromGrain(ptr), 4n)
               store(value + i, Memory.incRef(ptr), 8n)
             },
             None => {
@@ -962,7 +952,7 @@ let rec unmarshalHeap = (buf, offset, valuesUnmarshaled) => {
           let asInt32 = toGrain(newInt32(subvalue)): Int32
           match (Map.get(asInt32, valuesUnmarshaled)) {
             Some(ptr) => {
-              let ptr = load(fromGrain(ptr), 8n)
+              let ptr = load(fromGrain(ptr), 4n)
               store(value + i, Memory.incRef(ptr), 16n)
             },
             None => {
@@ -983,15 +973,6 @@ let rec unmarshalHeap = (buf, offset, valuesUnmarshaled) => {
     t when t == Tags._GRAIN_BOXED_NUM_HEAP_TAG => {
       let tag = load(valuePtr, 4n)
       match (tag) {
-        t when t == Tags._GRAIN_INT32_BOXED_NUM_TAG => {
-          let value = Memory.malloc(12n)
-          Memory.copy(value, valuePtr, 12n)
-
-          let asInt32 = toGrain(newInt32(value)): Int32
-          Map.set(offsetAsInt32, asInt32, valuesUnmarshaled)
-
-          value
-        },
         t when t == Tags._GRAIN_INT64_BOXED_NUM_TAG => {
           let value = Memory.malloc(16n)
           Memory.copy(value, valuePtr, 16n)
@@ -1005,15 +986,6 @@ let rec unmarshalHeap = (buf, offset, valuesUnmarshaled) => {
           let size = 16n + load(valuePtr, 8n) * 8n
           let value = Memory.malloc(size)
           Memory.copy(value, valuePtr, size)
-
-          let asInt32 = toGrain(newInt32(value)): Int32
-          Map.set(offsetAsInt32, asInt32, valuesUnmarshaled)
-
-          value
-        },
-        t when t == Tags._GRAIN_FLOAT32_BOXED_NUM_TAG => {
-          let value = Memory.malloc(12n)
-          Memory.copy(value, valuePtr, 12n)
 
           let asInt32 = toGrain(newInt32(value)): Int32
           Map.set(offsetAsInt32, asInt32, valuesUnmarshaled)
@@ -1047,7 +1019,11 @@ let rec unmarshalHeap = (buf, offset, valuesUnmarshaled) => {
         },
       }
     },
-    t when t == Tags._GRAIN_UINT32_HEAP_TAG => {
+    t when (
+      t == Tags._GRAIN_INT32_HEAP_TAG ||
+      t == Tags._GRAIN_FLOAT32_HEAP_TAG ||
+      t == Tags._GRAIN_UINT32_HEAP_TAG
+    ) => {
       let value = Memory.malloc(8n)
       Memory.copy(value, valuePtr, 8n)
 

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -347,9 +347,6 @@ provide let isFinite = (x: Number) => {
       //  -inf - -inf == NaN, inf - -inf == inf, -inf - inf == -inf)
       let wf64 = WasmF64.load(asPtr, 8n)
       WasmF64.eq(WasmF64.sub(wf64, wf64), 0.W)
-    } else if (WasmI32.eq(tag, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG)) {
-      let wf32 = WasmF32.load(asPtr, 8n)
-      WasmF32.eq(WasmF32.sub(wf32, wf32), 0.w)
     } else {
       // Neither rational numbers nor boxed integers can be infinite or NaN.
       // Grain doesn't allow creating a rational with denominator of zero either.
@@ -394,9 +391,6 @@ provide let isInfinite = (x: Number) => {
     if (WasmI32.eq(tag, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG)) {
       let wf64 = WasmF64.load(asPtr, 8n)
       WasmF64.ne(WasmF64.sub(wf64, wf64), 0.W) && WasmF64.eq(wf64, wf64)
-    } else if (WasmI32.eq(tag, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG)) {
-      let wf32 = WasmF32.load(asPtr, 8n)
-      WasmF32.ne(WasmF32.sub(wf32, wf32), 0.w) && WasmF32.eq(wf32, wf32)
     } else {
       false
     }

--- a/stdlib/runtime/atof/common.gr
+++ b/stdlib/runtime/atof/common.gr
@@ -192,7 +192,7 @@ provide let fullMultiplication = (a: WasmI64, b: WasmI64) => {
 @unsafe
 provide let biasedFpToNumber = (fp, negative) => {
   let f = WasmI64.load(WasmI32.fromGrain(fp.f), 8n)
-  let e = WasmI64.extendI32S(WasmI32.load(WasmI32.fromGrain(fp.e), 8n))
+  let e = WasmI64.extendI32S(WasmI32.load(WasmI32.fromGrain(fp.e), 4n))
   let word = WasmI64.or(f, WasmI64.shl(e, _MANTISSA_EXPLICIT_BITS_64))
   let mut float = WasmF64.reinterpretI64(word)
   if (negative) {

--- a/stdlib/runtime/atof/decimal.gr
+++ b/stdlib/runtime/atof/decimal.gr
@@ -110,7 +110,7 @@ let new = () => {
 @unsafe
 provide let tryAddDigit = (d, digit) => {
   let (+) = WasmI32.add
-  let numDigits = WasmI32.load(WasmI32.fromGrain(d.numDigits), 8n)
+  let numDigits = WasmI32.load(WasmI32.fromGrain(d.numDigits), 4n)
   if (WasmI32.ltU(numDigits, _MAX_DIGITS)) {
     let digits = WasmI32.fromGrain(d.digits)
     WasmI32.store8(digits + numDigits, digit, 8n)
@@ -133,7 +133,7 @@ let trim = d => {
   //
   // Trim is only called in `rightShift` and `leftShift`.
   let digits = WasmI32.fromGrain(d.digits)
-  let mut numDigits = WasmI32.load(WasmI32.fromGrain(d.numDigits), 8n)
+  let mut numDigits = WasmI32.load(WasmI32.fromGrain(d.numDigits), 4n)
   while (
     numDigits != 0n &&
     WasmI32.eqz(WasmI32.load8U(digits + (numDigits - 1n), 8n))
@@ -154,8 +154,8 @@ provide let round = d => {
   let (<) = WasmI32.ltS
   let (&) = WasmI32.and
   let digits = WasmI32.fromGrain(d.digits)
-  let mut numDigits = WasmI32.load(WasmI32.fromGrain(d.numDigits), 8n)
-  let mut decimalPoint = WasmI32.load(WasmI32.fromGrain(d.decimalPoint), 8n)
+  let mut numDigits = WasmI32.load(WasmI32.fromGrain(d.numDigits), 4n)
+  let mut decimalPoint = WasmI32.load(WasmI32.fromGrain(d.decimalPoint), 4n)
   if (numDigits == 0n || decimalPoint < 0n) {
     0N
   } else if (decimalPoint > 18n) {
@@ -334,7 +334,7 @@ let numberOfDigitsDecimalLeftShift = (d, shift) => {
   let tablePow5 = get_TABLE_POW5()
 
   let digits = WasmI32.fromGrain(d.digits)
-  let mut numDigits = WasmI32.load(WasmI32.fromGrain(d.numDigits), 8n)
+  let mut numDigits = WasmI32.load(WasmI32.fromGrain(d.numDigits), 4n)
 
   let shift = (shift & 63n) << 1n
   let x_a = WasmI32.load16U(table + shift, 0n)
@@ -378,8 +378,8 @@ provide let leftShift = (d, shift) => {
   let (<<) = WasmI64.shl
 
   let digits = WasmI32.fromGrain(d.digits)
-  let mut numDigits = WasmI32.load(WasmI32.fromGrain(d.numDigits), 8n)
-  let mut decimalPoint = WasmI32.load(WasmI32.fromGrain(d.decimalPoint), 8n)
+  let mut numDigits = WasmI32.load(WasmI32.fromGrain(d.numDigits), 4n)
+  let mut decimalPoint = WasmI32.load(WasmI32.fromGrain(d.decimalPoint), 4n)
 
   if (numDigits != 0n) {
     let numNewDigits = numberOfDigitsDecimalLeftShift(d, shift)
@@ -443,8 +443,8 @@ provide let rightShift = (d, shift) => {
   let (*) = WasmI64.mul
 
   let digits = WasmI32.fromGrain(d.digits)
-  let mut numDigits = WasmI32.load(WasmI32.fromGrain(d.numDigits), 8n)
-  let mut decimalPoint = WasmI32.load(WasmI32.fromGrain(d.decimalPoint), 8n)
+  let mut numDigits = WasmI32.load(WasmI32.fromGrain(d.numDigits), 4n)
+  let mut decimalPoint = WasmI32.load(WasmI32.fromGrain(d.decimalPoint), 4n)
 
   let mut readIndex = 0n
   let mut writeIndex = 0n
@@ -555,7 +555,7 @@ provide let parseDecimal = (s: String) => {
   let c = WasmI32.load8U(s + i, 8n)
   if (c == _CHAR_CODE_DOT) {
     i += 1n
-    let mut numDigits = WasmI32.load(WasmI32.fromGrain(d.numDigits), 8n)
+    let mut numDigits = WasmI32.load(WasmI32.fromGrain(d.numDigits), 4n)
     let numDigitsBeforeDecimal = numDigits
     // Skip leading zeros.
     if (numDigits == 0n) {
@@ -594,12 +594,12 @@ provide let parseDecimal = (s: String) => {
         break
       }
     }
-    numDigits = WasmI32.load(WasmI32.fromGrain(d.numDigits), 8n)
+    numDigits = WasmI32.load(WasmI32.fromGrain(d.numDigits), 4n)
     d.decimalPoint = WasmI32.toGrain(
       newInt32(numDigitsBeforeDecimal - numDigits)
     )
   }
-  let mut numDigits = WasmI32.load(WasmI32.fromGrain(d.numDigits), 8n)
+  let mut numDigits = WasmI32.load(WasmI32.fromGrain(d.numDigits), 4n)
   if (numDigits != 0n) {
     // Ignore the trailing zeros if there are any
     let mut nTrailingZeros = 0n
@@ -613,7 +613,7 @@ provide let parseDecimal = (s: String) => {
         break
       }
     }
-    let mut decimalPoint = WasmI32.load(WasmI32.fromGrain(d.decimalPoint), 8n)
+    let mut decimalPoint = WasmI32.load(WasmI32.fromGrain(d.decimalPoint), 4n)
     decimalPoint += nTrailingZeros
     numDigits -= nTrailingZeros
     decimalPoint += numDigits
@@ -650,7 +650,7 @@ provide let parseDecimal = (s: String) => {
         break
       }
     }
-    let mut decimalPoint = WasmI32.load(WasmI32.fromGrain(d.decimalPoint), 8n)
+    let mut decimalPoint = WasmI32.load(WasmI32.fromGrain(d.decimalPoint), 4n)
     decimalPoint += if (negExp) {
         0n - expNum
       } else {
@@ -658,7 +658,7 @@ provide let parseDecimal = (s: String) => {
       }
     d.decimalPoint = WasmI32.toGrain(newInt32(decimalPoint))
   }
-  let mut numDigits = WasmI32.load(WasmI32.fromGrain(d.numDigits), 8n)
+  let mut numDigits = WasmI32.load(WasmI32.fromGrain(d.numDigits), 4n)
   for (let mut i = numDigits; i < _MAX_DIGITS_WITHOUT_OVERFLOW; i += 1n) {
     WasmI32.store8(digits + i, 0n, 8n)
   }

--- a/stdlib/runtime/atof/parse.gr
+++ b/stdlib/runtime/atof/parse.gr
@@ -271,7 +271,7 @@ let parseFloatToParts = (string: String) => {
             Ok(exponentNumber) => {
               let exponentNumber = WasmI32.load(
                 WasmI32.fromGrain(exponentNumber),
-                8n
+                4n
               )
               exponent += exponentNumber
 
@@ -524,7 +524,7 @@ provide let parseFloat = (string: String) => {
 
   match (parseFloatToParts(string)) {
     Ok((exponent, mantissa, negative, manyDigits)) => {
-      let exponent = WasmI32.load(WasmI32.fromGrain(exponent), 8n)
+      let exponent = WasmI32.load(WasmI32.fromGrain(exponent), 4n)
       let mantissa = WasmI64.load(WasmI32.fromGrain(mantissa), 8n)
       let floatOpt = if (isFastPath(exponent, mantissa, negative, manyDigits)) {
         let (<=) = WasmI32.leS
@@ -586,14 +586,14 @@ provide let parseFloat = (string: String) => {
 
           let mut fp = computeFloat(WasmI64.extendI32S(exponent), mantissa)
           let f = WasmI64.load(WasmI32.fromGrain(fp.f), 8n)
-          let e = WasmI32.load(WasmI32.fromGrain(fp.e), 8n)
+          let e = WasmI32.load(WasmI32.fromGrain(fp.e), 4n)
           if (manyDigits && WasmI32.geS(e, 0n)) {
             let fp2 = computeFloat(
               WasmI64.extendI32S(exponent),
               WasmI64.add(mantissa, 1N)
             )
             let f2 = WasmI64.load(WasmI32.fromGrain(fp2.f), 8n)
-            let e2 = WasmI32.load(WasmI32.fromGrain(fp2.e), 8n)
+            let e2 = WasmI32.load(WasmI32.fromGrain(fp2.e), 4n)
             if (e != e2 || WasmI64.ne(f, f2)) {
               fp.e = -1l
             }
@@ -601,7 +601,7 @@ provide let parseFloat = (string: String) => {
 
           // Unable to correctly round the float using the Eisel-Lemire algorithm.
           // Fallback to a slower, but always correct algorithm.
-          let e = WasmI32.load(WasmI32.fromGrain(fp.e), 8n)
+          let e = WasmI32.load(WasmI32.fromGrain(fp.e), 4n)
           if (WasmI32.ltS(e, 0n)) {
             fp = parseLongMantissa(string)
           }

--- a/stdlib/runtime/atof/slow.gr
+++ b/stdlib/runtime/atof/slow.gr
@@ -130,8 +130,8 @@ provide let parseLongMantissa = (s: String) => {
 
   let mut d = parseDecimal(s)
   let digits = WasmI32.fromGrain(d.digits)
-  let mut numDigits = WasmI32.load(WasmI32.fromGrain(d.numDigits), 8n)
-  let mut decimalPoint = WasmI32.load(WasmI32.fromGrain(d.decimalPoint), 8n)
+  let mut numDigits = WasmI32.load(WasmI32.fromGrain(d.numDigits), 4n)
+  let mut decimalPoint = WasmI32.load(WasmI32.fromGrain(d.decimalPoint), 4n)
 
   // Short-circuit if the value can only be a literal 0 or infinity.
   if (numDigits == 0n || decimalPoint < -324n) {
@@ -146,7 +146,7 @@ provide let parseLongMantissa = (s: String) => {
       let n = decimalPoint
       let shift = getShift(n)
       Decimal.rightShift(d, shift)
-      decimalPoint = WasmI32.load(WasmI32.fromGrain(d.decimalPoint), 8n)
+      decimalPoint = WasmI32.load(WasmI32.fromGrain(d.decimalPoint), 4n)
       if (decimalPoint < 0n - _DECIMAL_POINT_RANGE) {
         done = true
         break
@@ -173,7 +173,7 @@ provide let parseLongMantissa = (s: String) => {
           getShift(0n - decimalPoint)
         }
         Decimal.leftShift(d, shift)
-        decimalPoint = WasmI32.load(WasmI32.fromGrain(d.decimalPoint), 8n)
+        decimalPoint = WasmI32.load(WasmI32.fromGrain(d.decimalPoint), 4n)
         if (decimalPoint > _DECIMAL_POINT_RANGE) {
           done = true
           break

--- a/stdlib/runtime/compare.gr
+++ b/stdlib/runtime/compare.gr
@@ -18,6 +18,7 @@ from WasmI32 use {
   shrU as (>>>),
 }
 include "runtime/unsafe/wasmi64" as WasmI64
+include "runtime/unsafe/wasmf32" as WasmF32
 include "runtime/unsafe/memory" as Memory
 include "runtime/unsafe/tags" as Tags
 include "runtime/dataStructures" as DataStructures
@@ -132,6 +133,13 @@ let rec heapCompareHelp = (heapTag, xptr, yptr) => {
 
       return 0
     },
+    t when t == Tags._GRAIN_INT32_HEAP_TAG => {
+      let xval = WasmI32.load(xptr, 4n)
+      let yval = WasmI32.load(yptr, 4n)
+      return if (WasmI32.ltS(xval, yval)) -1 else if (WasmI32.gtS(xval, yval)) 1
+      else 0
+    },
+    // Float32 is handled by compareHelp directly
     t when t == Tags._GRAIN_UINT32_HEAP_TAG => {
       let xval = WasmI32.load(xptr, 4n)
       let yval = WasmI32.load(yptr, 4n)
@@ -175,6 +183,20 @@ compareHelp = (x, y) => {
   } else if (isNumber(x)) {
     // Numbers have special comparison rules, e.g. NaN == NaN
     tagSimpleNumber(numberCompare(x, y))
+  } else if (WasmI32.load(x, 0n) == Tags._GRAIN_FLOAT32_HEAP_TAG) {
+    // Short circuit for Float32 to correctly handle NaN comparisons
+    let xval = WasmF32.load(x, 4n)
+    let yval = WasmF32.load(y, 4n)
+    let xIsNaN = WasmF32.ne(xval, xval)
+    let yIsNaN = WasmF32.ne(yval, yval)
+    if (xIsNaN) {
+      if (yIsNaN) 0 else -1
+    } else if (yIsNaN) {
+      // x is confirmed to be not NaN at this point
+      1
+    } else {
+      if (WasmF32.lt(xval, yval)) -1 else if (WasmF32.gt(xval, yval)) 1 else 0
+    }
   } else {
     // Handle all other heap allocated things
     // Can short circuit if pointers are the same

--- a/stdlib/runtime/equal.gr
+++ b/stdlib/runtime/equal.gr
@@ -15,6 +15,7 @@ from WasmI32 use {
   shl as (<<),
 }
 include "runtime/unsafe/wasmi64" as WasmI64
+include "runtime/unsafe/wasmf32" as WasmF32
 include "runtime/unsafe/tags" as Tags
 include "runtime/numbers" as Numbers
 from Numbers use { isNumber, numberEqual }
@@ -187,11 +188,14 @@ let rec heapEqualHelp = (heapTag, xptr, yptr) => {
         result
       }
     },
-    t when t == Tags._GRAIN_UINT32_HEAP_TAG => {
+    t when (
+      t == Tags._GRAIN_UINT32_HEAP_TAG || t == Tags._GRAIN_INT32_HEAP_TAG
+    ) => {
       let xval = WasmI32.load(xptr, 4n)
       let yval = WasmI32.load(yptr, 4n)
       WasmI32.eq(xval, yval)
     },
+    // Float32 is handled by equalHelp directly
     t when t == Tags._GRAIN_UINT64_HEAP_TAG => {
       let xval = WasmI64.load(xptr, 8n)
       let yval = WasmI64.load(yptr, 8n)
@@ -213,6 +217,11 @@ equalHelp = (x, y) => {
   } else if (isNumber(x)) {
     // Numbers have special equality rules, e.g. NaN != NaN
     numberEqual(x, y)
+  } else if (WasmI32.load(x, 0n) == Tags._GRAIN_FLOAT32_HEAP_TAG) {
+    // Short circuit for Float32 to correctly handle NaN != NaN
+    let xval = WasmF32.load(x, 4n)
+    let yval = WasmF32.load(y, 4n)
+    WasmF32.eq(xval, yval)
   } else {
     // Handle all other heap allocated things
     // Can short circuit if pointers are the same

--- a/stdlib/runtime/numbers.gr
+++ b/stdlib/runtime/numbers.gr
@@ -105,8 +105,7 @@ provide let isBoxedNumber = x => {
 provide let isFloat = x => {
   if (isBoxedNumber(x)) {
     let tag = WasmI32.load(x, 4n)
-    WasmI32.eq(tag, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG) ||
-      WasmI32.eq(tag, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG)
+    WasmI32.eq(tag, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG)
   } else {
     false
   }
@@ -116,8 +115,7 @@ provide let isFloat = x => {
 provide let isInteger = x => {
   if (isBoxedNumber(x)) {
     let tag = WasmI32.load(x, 4n)
-    WasmI32.eq(tag, Tags._GRAIN_INT32_BOXED_NUM_TAG) ||
-      WasmI32.eq(tag, Tags._GRAIN_INT64_BOXED_NUM_TAG) ||
+    WasmI32.eq(tag, Tags._GRAIN_INT64_BOXED_NUM_TAG) ||
       WasmI32.eq(tag, Tags._GRAIN_BIGINT_BOXED_NUM_TAG)
   } else {
     true
@@ -137,15 +135,12 @@ provide let isRational = x => {
 @unsafe
 provide let isNaN = x => {
   if (isBoxedNumber(x)) {
-    // Boxed numbers can have multiple subtypes, of which float32 and float64 can be NaN.
+    // Boxed numbers can have multiple subtypes, of which float64 can be NaN.
     let tag = WasmI32.load(x, 4n)
     if (WasmI32.eq(tag, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG)) {
       // uses the fact that NaN is the only number not equal to itself
       let wf64 = WasmF64.load(x, 8n)
       WasmF64.ne(wf64, wf64)
-    } else if (WasmI32.eq(tag, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG)) {
-      let wf32 = WasmF32.load(x, 8n)
-      WasmF32.ne(wf32, wf32)
     } else {
       // Neither rational numbers nor boxed integers can be infinite or NaN.
       // Grain doesn't allow creating a rational with denominator of zero either.
@@ -239,13 +234,11 @@ let gcd32 = (x, y) => {
 
 @unsafe
 provide let reducedInteger = x => {
-  if (WasmI64.gtS(x, _I32_MAX) || WasmI64.ltS(x, _I32_MIN)) {
-    newInt64(x)
-  } else if (
+  if (
     WasmI64.gtS(x, WasmI64.shrS(_I32_MAX, 1N)) ||
     WasmI64.ltS(x, WasmI64.shrS(_I32_MIN, 1N))
   ) {
-    newInt32(WasmI32.wrapI64(x))
+    newInt64(x)
   } else {
     tagSimple(WasmI32.wrapI64(x))
   }
@@ -255,10 +248,8 @@ provide let reducedInteger = x => {
 provide let reducedUnsignedInteger = x => {
   if (WasmI64.gtU(x, _I64_MAX)) {
     BI.makeWrappedUint64(x)
-  } else if (WasmI64.gtU(x, _I32_MAX)) {
-    newInt64(x)
   } else if (WasmI64.gtU(x, WasmI64.shrU(_I32_MAX, 1N))) {
-    newInt32(WasmI32.wrapI64(x))
+    newInt64(x)
   } else {
     tagSimple(WasmI32.wrapI64(x))
   }
@@ -381,18 +372,8 @@ provide let boxedNumberTag = xptr => {
 }
 
 @unsafe
-provide let boxedInt32Number = xptr => {
-  WasmI32.load(xptr, 8n)
-}
-
-@unsafe
 provide let boxedInt64Number = xptr => {
   WasmI64.load(xptr, 8n)
-}
-
-@unsafe
-provide let boxedFloat32Number = xptr => {
-  WasmF32.load(xptr, 8n)
 }
 
 @unsafe
@@ -418,9 +399,6 @@ provide let coerceNumberToWasmF32 = (x: Number) => {
   } else {
     let xtag = boxedNumberTag(x)
     match (xtag) {
-      t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
-        WasmF32.convertI32S(boxedInt32Number(x))
-      },
       t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
         WasmF32.convertI64S(boxedInt64Number(x))
       },
@@ -432,9 +410,6 @@ provide let coerceNumberToWasmF32 = (x: Number) => {
           BI.toFloat32(boxedRationalNumerator(x)),
           BI.toFloat32(boxedRationalDenominator(x))
         )
-      },
-      t when WasmI32.eq(t, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG) => {
-        boxedFloat32Number(x)
       },
       t when WasmI32.eq(t, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG) => {
         let xval = boxedFloat64Number(x)
@@ -460,9 +435,6 @@ provide let coerceNumberToWasmF64 = (x: Number) => {
   } else {
     let xtag = boxedNumberTag(x)
     match (xtag) {
-      t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
-        WasmF64.convertI32S(boxedInt32Number(x))
-      },
       t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
         WasmF64.convertI64S(boxedInt64Number(x))
       },
@@ -474,9 +446,6 @@ provide let coerceNumberToWasmF64 = (x: Number) => {
           BI.toFloat64(boxedRationalNumerator(x)),
           BI.toFloat64(boxedRationalDenominator(x))
         )
-      },
-      t when WasmI32.eq(t, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG) => {
-        WasmF64.promoteF32(boxedFloat32Number(x))
       },
       t when WasmI32.eq(t, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG) => {
         boxedFloat64Number(x)
@@ -496,9 +465,6 @@ provide let coerceNumberToWasmI64 = (x: Number) => {
   } else {
     let xtag = boxedNumberTag(x)
     match (xtag) {
-      t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
-        WasmI64.extendI32S(boxedInt32Number(x))
-      },
       t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
         boxedInt64Number(x)
       },
@@ -521,9 +487,6 @@ provide let coerceNumberToWasmI32 = (x: Number) => {
   } else {
     let xtag = boxedNumberTag(x)
     match (xtag) {
-      t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
-        boxedInt32Number(x)
-      },
       t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
         let int64 = boxedInt64Number(x)
         if (WasmI64.gtS(int64, _I32_MAX) || WasmI64.ltS(int64, _I32_MIN)) {
@@ -554,13 +517,6 @@ provide let coerceNumberToUnsignedWasmI64 = (x: Number) => {
   } else {
     let xtag = boxedNumberTag(x)
     match (xtag) {
-      t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
-        let int32 = boxedInt32Number(x)
-        if (WasmI32.ltS(int32, 0n)) {
-          throw Exception.Overflow
-        }
-        WasmI64.extendI32U(int32)
-      },
       t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
         let int64 = boxedInt64Number(x)
         if (WasmI64.ltS(int64, 0N)) {
@@ -591,13 +547,6 @@ provide let coerceNumberToUnsignedWasmI32 = (x: Number) => {
   } else {
     let xtag = boxedNumberTag(x)
     match (xtag) {
-      t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
-        let int32 = boxedInt32Number(x)
-        if (WasmI32.ltS(int32, 0n)) {
-          throw Exception.Overflow
-        }
-        int32
-      },
       t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
         let int64 = boxedInt64Number(x)
         if (WasmI64.gtS(int64, _U32_MAX) || WasmI64.ltS(int64, _U32_MIN)) {
@@ -624,9 +573,6 @@ let coerceNumberToBigInt = (x: Number) => {
   } else {
     let xtag = boxedNumberTag(x)
     match (xtag) {
-      t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
-        BI.makeWrappedInt32(boxedInt32Number(x))
-      },
       t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
         BI.makeWrappedInt64(boxedInt64Number(x))
       },
@@ -683,10 +629,6 @@ let numberEqualSimpleHelp = (x, y) => {
     let xval = untagSimple(x) // <- actual int value of x
     let yBoxedNumberTag = boxedNumberTag(y)
     match (yBoxedNumberTag) {
-      t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
-        let yBoxedVal = boxedInt32Number(y)
-        WasmI32.eq(xval, yBoxedVal)
-      },
       t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
         let yBoxedVal = boxedInt64Number(y)
         WasmI64.eq(WasmI64.extendI32S(xval), yBoxedVal)
@@ -697,11 +639,6 @@ let numberEqualSimpleHelp = (x, y) => {
       t when WasmI32.eq(t, Tags._GRAIN_RATIONAL_BOXED_NUM_TAG) => {
         // NOTE: we always store in most reduced form, so a rational and an int are never equal
         false
-      },
-      t when WasmI32.eq(t, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG) => {
-        let yBoxedVal = boxedFloat32Number(y)
-        isSafeIntegerF32(yBoxedVal) &&
-          WasmF32.eq(WasmF32.convertI32S(xval), yBoxedVal)
       },
       t when WasmI32.eq(t, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG) => {
         let yBoxedVal = boxedFloat64Number(y)
@@ -725,10 +662,6 @@ let numberEqualInt64Help = (xBoxedVal, y) => {
     // Boxed number:
     let yBoxedNumberTag = boxedNumberTag(y)
     match (yBoxedNumberTag) {
-      t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
-        let yBoxedVal = boxedInt32Number(y)
-        WasmI64.eq(xBoxedVal, WasmI64.extendI32S(yBoxedVal))
-      },
       t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
         let yBoxedVal = boxedInt64Number(y)
         WasmI64.eq(xBoxedVal, yBoxedVal)
@@ -739,11 +672,6 @@ let numberEqualInt64Help = (xBoxedVal, y) => {
       t when WasmI32.eq(t, Tags._GRAIN_RATIONAL_BOXED_NUM_TAG) => {
         // NOTE: we always store in most reduced form, so a rational and an int are never equal
         false
-      },
-      t when WasmI32.eq(t, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG) => {
-        let yBoxedVal = boxedFloat32Number(y)
-        isSafeIntegerF32(yBoxedVal) &&
-          WasmI64.eq(xBoxedVal, WasmI64.truncF32S(yBoxedVal))
       },
       t when WasmI32.eq(t, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG) => {
         let yBoxedVal = boxedFloat64Number(y)
@@ -758,12 +686,6 @@ let numberEqualInt64Help = (xBoxedVal, y) => {
 }
 
 @unsafe
-let numberEqualInt32Help = (xBoxedVal, y) => {
-  // We can just pretend it's 64-bit for the equality check
-  numberEqualInt64Help(WasmI64.extendI32S(xBoxedVal), y)
-}
-
-@unsafe
 let numberEqualRationalHelp = (xptr, y) => {
   // PRECONDITION: x is rational and x !== y and isNumber(y)
   // Basic number: (we know it's not equal, since we never store ints as rationals)
@@ -775,9 +697,6 @@ let numberEqualRationalHelp = (xptr, y) => {
     // Boxed number:
     let yBoxedNumberTag = boxedNumberTag(y)
     match (yBoxedNumberTag) {
-      t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
-        false
-      },
       t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
         false
       },
@@ -788,15 +707,6 @@ let numberEqualRationalHelp = (xptr, y) => {
         let yNumerator = boxedRationalNumerator(y)
         let yDenominator = boxedRationalDenominator(y)
         BI.eq(xNumerator, yNumerator) && BI.eq(xDenominator, yDenominator)
-      },
-      t when WasmI32.eq(t, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG) => {
-        let yBoxedVal = boxedFloat32Number(y)
-        let xAsFloat = WasmF32.div(
-          BI.toFloat32(xNumerator),
-          BI.toFloat32(xDenominator)
-        )
-        // TODO(#303): maybe we should have some sort of tolerance?
-        WasmF32.eq(xAsFloat, yBoxedVal)
       },
       t when WasmI32.eq(t, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG) => {
         let yBoxedVal = boxedFloat64Number(y)
@@ -824,10 +734,6 @@ let numberEqualFloat64Help = (x, y) => {
     // Boxed number
     let yBoxedNumberTag = boxedNumberTag(y)
     match (yBoxedNumberTag) {
-      t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
-        let yBoxedVal = boxedInt32Number(y)
-        isSafeIntegerF64(x) && WasmF64.eq(x, WasmF64.convertI32S(yBoxedVal))
-      },
       t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
         let yBoxedVal = boxedInt64Number(y)
         isSafeIntegerF64(x) && WasmF64.eq(x, WasmF64.convertI64S(yBoxedVal))
@@ -844,11 +750,6 @@ let numberEqualFloat64Help = (x, y) => {
         )
         WasmF64.eq(x, yAsFloat)
       },
-      t when WasmI32.eq(t, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG) => {
-        let yBoxedVal = boxedFloat32Number(y)
-        // TODO(#303): maybe we should have some sort of tolerance?
-        WasmF64.eq(x, WasmF64.promoteF32(yBoxedVal))
-      },
       t when WasmI32.eq(t, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG) => {
         let yBoxedVal = boxedFloat64Number(y)
         // TODO(#303): maybe we should have some sort of tolerance?
@@ -862,27 +763,6 @@ let numberEqualFloat64Help = (x, y) => {
 }
 
 @unsafe
-let numberEqualFloat32Help = (x, y) => {
-  let xIsInteger = isIntegerF32(x)
-  // Basic number:
-  if (isSimpleNumber(y)) {
-    xIsInteger && WasmF32.eq(x, WasmF32.convertI32S(untagSimple(y)))
-  } else {
-    // Boxed number
-    let yBoxedNumberTag = boxedNumberTag(y)
-    match (yBoxedNumberTag) {
-      t when WasmI32.eq(t, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG) => {
-        // Special case: f32/f32 equality (need to handle here without promotion)
-        WasmF32.eq(x, boxedFloat32Number(y))
-      },
-      _ => {
-        numberEqualFloat64Help(WasmF64.promoteF32(x), y)
-      },
-    }
-  }
-}
-
-@unsafe
 let numberEqualBigIntHelp = (x, y) => {
   if (isSimpleNumber(y)) {
     WasmI32.eqz(BI.cmpI64(x, WasmI64.extendI32S(untagSimple(y))))
@@ -890,10 +770,6 @@ let numberEqualBigIntHelp = (x, y) => {
     // Boxed number
     let yBoxedNumberTag = boxedNumberTag(y)
     match (yBoxedNumberTag) {
-      t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
-        let yBoxedVal = boxedInt32Number(y)
-        WasmI32.eqz(BI.cmpI64(x, WasmI64.extendI32S(yBoxedVal)))
-      },
       t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
         let yBoxedVal = boxedInt64Number(y)
         WasmI32.eqz(BI.cmpI64(x, yBoxedVal))
@@ -904,10 +780,6 @@ let numberEqualBigIntHelp = (x, y) => {
       t when WasmI32.eq(t, Tags._GRAIN_RATIONAL_BOXED_NUM_TAG) => {
         // Rationals are reduced, so it must be unequal
         false
-      },
-      t when WasmI32.eq(t, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG) => {
-        let yBoxedVal = boxedFloat32Number(y)
-        WasmI32.eqz(BI.cmpF32(x, yBoxedVal))
       },
       t when WasmI32.eq(t, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG) => {
         let yBoxedVal = boxedFloat64Number(y)
@@ -929,19 +801,12 @@ provide let numberEqual = (x, y) => {
     // Boxed number
     let xBoxedNumberTag = boxedNumberTag(x)
     match (xBoxedNumberTag) {
-      t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
-        let xBoxedVal = boxedInt32Number(x)
-        numberEqualInt32Help(xBoxedVal, y)
-      },
       t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
         let xBoxedVal = boxedInt64Number(x)
         numberEqualInt64Help(xBoxedVal, y)
       },
       t when WasmI32.eq(t, Tags._GRAIN_RATIONAL_BOXED_NUM_TAG) => {
         numberEqualRationalHelp(x, y)
-      },
-      t when WasmI32.eq(t, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG) => {
-        numberEqualFloat32Help(boxedFloat32Number(x), y)
       },
       t when WasmI32.eq(t, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG) => {
         numberEqualFloat64Help(boxedFloat64Number(x), y)
@@ -977,14 +842,6 @@ let numberAddSubSimpleHelp = (x, y, isSub) => {
     let xval = untagSimple(x) // <- actual int value of x
     let yBoxedNumberTag = boxedNumberTag(y)
     match (yBoxedNumberTag) {
-      t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
-        let xval = WasmI64.extendI32S(xval)
-        let yBoxedVal = WasmI64.extendI32S(boxedInt32Number(y))
-        let result =
-          if (isSub) WasmI64.sub(xval, yBoxedVal)
-          else WasmI64.add(xval, yBoxedVal)
-        reducedInteger(result)
-      },
       t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
         let yBoxedVal = boxedInt64Number(y)
         let xval64 = WasmI64.extendI32S(xval)
@@ -1031,14 +888,6 @@ let numberAddSubSimpleHelp = (x, y, isSub) => {
         Memory.decRef(result)
         ret
       },
-      t when WasmI32.eq(t, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG) => {
-        let yBoxedVal = boxedFloat32Number(y)
-        let xval = WasmF32.convertI32S(xval)
-        let result =
-          if (isSub) WasmF32.sub(xval, yBoxedVal)
-          else WasmF32.add(xval, yBoxedVal)
-        newFloat32(result)
-      },
       t when WasmI32.eq(t, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG) => {
         let yBoxedVal = boxedFloat64Number(y)
         let xval = WasmF64.convertI32S(xval)
@@ -1080,13 +929,6 @@ let numberAddSubInt64Help = (xval, y, isSub) => {
   } else {
     let yBoxedNumberTag = boxedNumberTag(y)
     match (yBoxedNumberTag) {
-      t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
-        let yBoxedVal = WasmI64.extendI32S(boxedInt32Number(y))
-        let result =
-          if (isSub) WasmI64.sub(xval, yBoxedVal)
-          else WasmI64.add(xval, yBoxedVal)
-        reducedInteger(result)
-      },
       t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
         let yBoxedVal = boxedInt64Number(y)
         let xval64 = xval
@@ -1133,14 +975,6 @@ let numberAddSubInt64Help = (xval, y, isSub) => {
         Memory.decRef(result)
         ret
       },
-      t when WasmI32.eq(t, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG) => {
-        let xval = WasmF32.convertI64S(xval)
-        let yBoxedVal = boxedFloat32Number(y)
-        let result =
-          if (isSub) WasmF32.sub(xval, yBoxedVal)
-          else WasmF32.add(xval, yBoxedVal)
-        newFloat32(result)
-      },
       t when WasmI32.eq(t, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG) => {
         let xval = WasmF64.convertI64S(xval)
         let yBoxedVal = boxedFloat64Number(y)
@@ -1157,37 +991,12 @@ let numberAddSubInt64Help = (xval, y, isSub) => {
 }
 
 @unsafe
-let numberAddSubFloat32Help = (xval, y, isSub) => {
-  if (
-    !isSimpleNumber(y) &&
-    WasmI32.eq(boxedNumberTag(y), Tags._GRAIN_FLOAT64_BOXED_NUM_TAG)
-  ) {
-    // Special case: promote to f64 if RHS is f64
-    let xval = WasmF64.promoteF32(xval)
-    let yval = boxedFloat64Number(y)
-    let result = if (isSub) WasmF64.sub(xval, yval) else WasmF64.add(xval, yval)
-    newFloat64(result)
-  } else {
-    // incRef y to reuse it via WasmI32.toGrain
-    Memory.incRef(y)
-    let yval = coerceNumberToWasmF32(WasmI32.toGrain(y): Number)
-    let result = if (isSub) WasmF32.sub(xval, yval) else WasmF32.add(xval, yval)
-    newFloat32(result)
-  }
-}
-
-@unsafe
 let numberAddSubFloat64Help = (xval, y, isSub) => {
   // incRef y to reuse it via WasmI32.toGrain
   Memory.incRef(y)
   let yval = coerceNumberToWasmF64(WasmI32.toGrain(y): Number)
   let result = if (isSub) WasmF64.sub(xval, yval) else WasmF64.add(xval, yval)
   newFloat64(result)
-}
-
-@unsafe
-let numberAddSubInt32Help = (xval, y, isSub) => {
-  numberAddSubInt64Help(WasmI64.extendI32S(xval), y, isSub)
 }
 
 @unsafe
@@ -1205,17 +1014,6 @@ let numberAddSubBigIntHelp = (x, y, isSub) => {
   } else {
     let yBoxedNumberTag = boxedNumberTag(y)
     match (yBoxedNumberTag) {
-      t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
-        let yBoxedVal = WasmI64.extendI32S(boxedInt32Number(y))
-        let yBig = BI.makeWrappedInt64(yBoxedVal)
-        let res = if (isSub) {
-          BI.sub(x, yBig)
-        } else {
-          BI.add(x, yBig)
-        }
-        Memory.decRef(yBig)
-        reducedBigInteger(res)
-      },
       t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
         let yBoxedVal = boxedInt64Number(y)
         let yBig = BI.makeWrappedInt64(yBoxedVal)
@@ -1246,14 +1044,6 @@ let numberAddSubBigIntHelp = (x, y, isSub) => {
         let ret = reducedFractionBigInt(result, yDenominator, false)
         Memory.decRef(result)
         ret
-      },
-      t when WasmI32.eq(t, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG) => {
-        let xval = BI.toFloat32(x)
-        let yBoxedVal = boxedFloat32Number(y)
-        let result =
-          if (isSub) WasmF32.sub(xval, yBoxedVal)
-          else WasmF32.add(xval, yBoxedVal)
-        newFloat32(result)
       },
       t when WasmI32.eq(t, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG) => {
         let xval = BI.toFloat64(x)
@@ -1402,18 +1192,6 @@ let numberAddSubRationalHelp = (x, y, isSub) => {
         // The one case we don't delegate is rational +/- rational
         addSubRational(x, y, isSub, false)
       },
-      t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
-        let yBig = BI.makeWrappedInt32(boxedInt32Number(y))
-        let expandedYNumerator = BI.mul(yBig, xDenominator)
-        Memory.decRef(yBig)
-        let result =
-          if (isSub) BI.sub(xNumerator, expandedYNumerator)
-          else BI.add(xNumerator, expandedYNumerator)
-        let ret = reducedFractionBigInt(result, xDenominator, false)
-        Memory.decRef(expandedYNumerator)
-        Memory.decRef(result)
-        ret
-      },
       t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
         let yBig = BI.makeWrappedInt64(boxedInt64Number(y))
         let expandedYNumerator = BI.mul(yBig, xDenominator)
@@ -1435,16 +1213,6 @@ let numberAddSubRationalHelp = (x, y, isSub) => {
         let ret = reducedFractionBigInt(result, xDenominator, false)
         Memory.decRef(result)
         ret
-      },
-      t when WasmI32.eq(t, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG) => {
-        let xval = WasmF32.div(
-          BI.toFloat32(xNumerator),
-          BI.toFloat32(xDenominator)
-        )
-        let result =
-          if (isSub) WasmF32.sub(xval, boxedFloat32Number(y))
-          else WasmF32.add(xval, boxedFloat32Number(y))
-        newFloat32(result)
       },
       t when WasmI32.eq(t, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG) => {
         let xnumfloat = BI.toFloat64(xNumerator)
@@ -1470,9 +1238,6 @@ let numberAddSubHelp = (x, y, isSub) => {
   } else {
     let xtag = boxedNumberTag(x)
     match (xtag) {
-      t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
-        numberAddSubInt32Help(boxedInt32Number(x), y, isSub)
-      },
       t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
         numberAddSubInt64Help(boxedInt64Number(x), y, isSub)
       },
@@ -1481,9 +1246,6 @@ let numberAddSubHelp = (x, y, isSub) => {
       },
       t when WasmI32.eq(t, Tags._GRAIN_RATIONAL_BOXED_NUM_TAG) => {
         numberAddSubRationalHelp(x, y, isSub)
-      },
-      t when WasmI32.eq(t, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG) => {
-        numberAddSubFloat32Help(boxedFloat32Number(x), y, isSub)
       },
       t when WasmI32.eq(t, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG) => {
         numberAddSubFloat64Help(boxedFloat64Number(x), y, isSub)
@@ -1540,14 +1302,6 @@ let numberTimesDivideInt64Help = (xval, y, isDivide) => {
   } else {
     let yBoxedNumberTag = boxedNumberTag(y)
     match (yBoxedNumberTag) {
-      t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
-        let yBoxedVal = WasmI64.extendI32S(boxedInt32Number(y))
-        if (isDivide) {
-          reducedFraction64(xval, yBoxedVal)
-        } else {
-          safeI64Multiply(xval, yBoxedVal)
-        }
-      },
       t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
         let yBoxedVal = boxedInt64Number(y)
         if (isDivide) {
@@ -1586,15 +1340,6 @@ let numberTimesDivideInt64Help = (xval, y, isDivide) => {
         Memory.decRef(xBig)
         ret
       },
-      t when WasmI32.eq(t, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG) => {
-        let xval = WasmF32.convertI64S(xval)
-        let yBoxedVal = boxedFloat32Number(y)
-        if (isDivide) {
-          newFloat32(WasmF32.div(xval, yBoxedVal))
-        } else {
-          newFloat32(WasmF32.mul(xval, yBoxedVal))
-        }
-      },
       t when WasmI32.eq(t, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG) => {
         let xval = WasmF64.convertI64S(xval)
         let yBoxedVal = boxedFloat64Number(y)
@@ -1625,17 +1370,6 @@ let numberTimesDivideBigIntHelp = (x, y, isDivide) => {
   } else {
     let yBoxedNumberTag = boxedNumberTag(y)
     match (yBoxedNumberTag) {
-      t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
-        let yBoxedVal = WasmI64.extendI32S(boxedInt32Number(y))
-        let yBig = BI.makeWrappedInt64(yBoxedVal)
-        let ret = if (isDivide) {
-          reducedFractionBigInt(x, yBig, false)
-        } else {
-          reducedBigInteger(BI.mul(x, yBig))
-        }
-        Memory.decRef(yBig)
-        ret
-      },
       t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
         let yBoxedVal = boxedInt64Number(y)
         let yBig = BI.makeWrappedInt64(yBoxedVal)
@@ -1671,17 +1405,6 @@ let numberTimesDivideBigIntHelp = (x, y, isDivide) => {
           ret
         }
       },
-      t when WasmI32.eq(t, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG) => {
-        // We make the decision to always promote to f64 here, since
-        // we can only fit rather small bigints (<4 limbs) into an F32
-        let xval = BI.toFloat64(x)
-        let yBoxedVal = WasmF64.promoteF32(boxedFloat32Number(y))
-        if (isDivide) {
-          newFloat64(WasmF64.div(xval, yBoxedVal))
-        } else {
-          newFloat64(WasmF64.mul(xval, yBoxedVal))
-        }
-      },
       t when WasmI32.eq(t, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG) => {
         let xval = BI.toFloat64(x)
         let yBoxedVal = boxedFloat64Number(y)
@@ -1702,11 +1425,6 @@ let numberTimesDivideBigIntHelp = (x, y, isDivide) => {
 let numberTimesDivideSimpleHelp = (x, y, isDivide) => {
   // PRECONDITION: x is a "simple" number (value tag is 0) and isNumber(y)
   let xval = untagSimple(x) // <- actual int value of x
-  numberTimesDivideInt64Help(WasmI64.extendI32S(xval), y, isDivide)
-}
-
-@unsafe
-let numberTimesDivideInt32Help = (xval, y, isDivide) => {
   numberTimesDivideInt64Help(WasmI64.extendI32S(xval), y, isDivide)
 }
 
@@ -1738,25 +1456,6 @@ let numberTimesDivideRationalHelp = (x, y, isDivide) => {
   } else {
     let ytag = boxedNumberTag(y)
     match (ytag) {
-      t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
-        // Same idea as above
-        let yBig = BI.makeWrappedInt32(boxedInt32Number(y))
-        let ret = if (isDivide) {
-          // (a / b) / y == a / (b * y)
-          let denominator = BI.mul(xDenominator, yBig)
-          let ret = reducedFractionBigInt(xNumerator, denominator, false)
-          Memory.decRef(denominator)
-          ret
-        } else {
-          // (a / b) * y == (a * y) / b
-          let numerator = BI.mul(xNumerator, yBig)
-          let ret = reducedFractionBigInt(numerator, xDenominator, false)
-          Memory.decRef(numerator)
-          ret
-        }
-        Memory.decRef(yBig)
-        ret
-      },
       t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
         // Same idea as above
         let yBig = BI.makeWrappedInt64(boxedInt64Number(y))
@@ -1794,17 +1493,6 @@ let numberTimesDivideRationalHelp = (x, y, isDivide) => {
       t when WasmI32.eq(t, Tags._GRAIN_RATIONAL_BOXED_NUM_TAG) => {
         timesDivideRational(x, y, isDivide, false)
       },
-      t when WasmI32.eq(t, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG) => {
-        // TODO(#1190): We should probably use something more accurate if possible here
-        let asFloat = WasmF32.demoteF64(
-          WasmF64.div(BI.toFloat64(xNumerator), BI.toFloat64(xDenominator))
-        )
-        if (isDivide) {
-          newFloat32(WasmF32.div(asFloat, boxedFloat32Number(y)))
-        } else {
-          newFloat32(WasmF32.mul(asFloat, boxedFloat32Number(y)))
-        }
-      },
       t when WasmI32.eq(t, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG) => {
         // TODO(#1190): We should probably use something more accurate if possible here
         let asFloat = WasmF64.div(
@@ -1837,39 +1525,12 @@ let numberTimesDivideFloat64Help = (x, y, isDivide) => {
 }
 
 @unsafe
-let numberTimesDivideFloat32Help = (x, y, isDivide) => {
-  if (
-    isBoxedNumber(y) &&
-    WasmI32.eq(boxedNumberTag(y), Tags._GRAIN_INT64_BOXED_NUM_TAG)
-  ) {
-    // Special case: f32->f64 promotion
-    if (isDivide) {
-      newFloat64(WasmF64.div(WasmF64.promoteF32(x), boxedFloat64Number(y)))
-    } else {
-      newFloat64(WasmF64.mul(WasmF64.promoteF32(x), boxedFloat64Number(y)))
-    }
-  } else {
-    // incRef y to reuse it via WasmI32.toGrain
-    Memory.incRef(y)
-    let yAsFloat = coerceNumberToWasmF32(WasmI32.toGrain(y): Number)
-    if (isDivide) {
-      newFloat32(WasmF32.div(x, yAsFloat))
-    } else {
-      newFloat32(WasmF32.mul(x, yAsFloat))
-    }
-  }
-}
-
-@unsafe
 let numberTimesDivideHelp = (x, y, isDivide) => {
   if (isSimpleNumber(x)) {
     numberTimesDivideSimpleHelp(x, y, isDivide)
   } else {
     let xtag = boxedNumberTag(x)
     match (xtag) {
-      t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
-        numberTimesDivideInt32Help(boxedInt32Number(x), y, isDivide)
-      },
       t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
         numberTimesDivideInt64Help(boxedInt64Number(x), y, isDivide)
       },
@@ -1878,9 +1539,6 @@ let numberTimesDivideHelp = (x, y, isDivide) => {
       },
       t when WasmI32.eq(t, Tags._GRAIN_RATIONAL_BOXED_NUM_TAG) => {
         numberTimesDivideRationalHelp(x, y, isDivide)
-      },
-      t when WasmI32.eq(t, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG) => {
-        numberTimesDivideFloat32Help(boxedFloat32Number(x), y, isDivide)
       },
       t when WasmI32.eq(t, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG) => {
         numberTimesDivideFloat64Help(boxedFloat64Number(x), y, isDivide)
@@ -1960,9 +1618,6 @@ let cmpBigInt = (x: WasmI32, y: WasmI32) => {
   } else {
     let yBoxedNumberTag = boxedNumberTag(y)
     match (yBoxedNumberTag) {
-      t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
-        BI.cmpI64(x, WasmI64.extendI32S(boxedInt32Number(y)))
-      },
       t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
         BI.cmpI64(x, boxedInt64Number(y))
       },
@@ -1974,9 +1629,6 @@ let cmpBigInt = (x: WasmI32, y: WasmI32) => {
         let ret = BI.cmp(tmp, boxedRationalNumerator(y))
         Memory.decRef(tmp)
         ret
-      },
-      t when WasmI32.eq(t, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG) => {
-        BI.cmpF32(x, boxedFloat32Number(y))
       },
       t when WasmI32.eq(t, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG) => {
         BI.cmpF64(x, boxedFloat64Number(y))
@@ -1992,12 +1644,8 @@ let cmpBigInt = (x: WasmI32, y: WasmI32) => {
 // unlike regular float logic, NaN is considered equal to itself and
 // smaller than any other number
 @unsafe
-let cmpFloat = (x: WasmI32, y: WasmI32, is64: Bool) => {
-  let xf = if (is64) {
-    boxedFloat64Number(x)
-  } else {
-    WasmF64.promoteF32(boxedFloat32Number(x))
-  }
+let cmpFloat = (x: WasmI32, y: WasmI32) => {
+  let xf = boxedFloat64Number(x)
   if (isSimpleNumber(y)) {
     let yf = WasmF64.convertI32S(untagSimple(y))
     // special NaN cases
@@ -2022,9 +1670,6 @@ let cmpFloat = (x: WasmI32, y: WasmI32, is64: Bool) => {
       WasmI32.sub(0n, cmpBigInt(y, x))
     } else {
       let yf = match (yBoxedNumberTag) {
-        t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
-          WasmF64.convertI32S(boxedInt32Number(y))
-        },
         t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
           WasmF64.convertI64S(boxedInt64Number(y))
         },
@@ -2036,9 +1681,6 @@ let cmpFloat = (x: WasmI32, y: WasmI32, is64: Bool) => {
             BI.toFloat64(boxedRationalNumerator(y)),
             BI.toFloat64(boxedRationalDenominator(y))
           )
-        },
-        t when WasmI32.eq(t, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG) => {
-          WasmF64.promoteF32(boxedFloat32Number(y))
         },
         t when WasmI32.eq(t, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG) => {
           boxedFloat64Number(y)
@@ -2068,22 +1710,14 @@ let cmpFloat = (x: WasmI32, y: WasmI32, is64: Bool) => {
 }
 
 @unsafe
-let cmpSmallInt = (x: WasmI32, y: WasmI32, is64: Bool) => {
-  let xi = if (is64) {
-    boxedInt64Number(x)
-  } else {
-    WasmI64.extendI32S(boxedInt32Number(x))
-  }
+let cmpSmallInt = (x: WasmI32, y: WasmI32) => {
+  let xi = boxedInt64Number(x)
   if (isSimpleNumber(y)) {
     let yi = WasmI64.extendI32S(untagSimple(y))
     if (WasmI64.ltS(xi, yi)) -1n else if (WasmI64.gtS(xi, yi)) 1n else 0n
   } else {
     let yBoxedNumberTag = boxedNumberTag(y)
     match (yBoxedNumberTag) {
-      t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
-        let yi = WasmI64.extendI32S(boxedInt32Number(y))
-        if (WasmI64.ltS(xi, yi)) -1n else if (WasmI64.gtS(xi, yi)) 1n else 0n
-      },
       t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
         let yi = boxedInt64Number(y)
         if (WasmI64.ltS(xi, yi)) -1n else if (WasmI64.gtS(xi, yi)) 1n else 0n
@@ -2103,11 +1737,8 @@ let cmpSmallInt = (x: WasmI32, y: WasmI32, is64: Bool) => {
           )
         ) -1n else 1n
       },
-      t when WasmI32.eq(t, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG) => {
-        WasmI32.sub(0n, cmpFloat(y, x, false))
-      },
       t when WasmI32.eq(t, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG) => {
-        WasmI32.sub(0n, cmpFloat(y, x, true))
+        WasmI32.sub(0n, cmpFloat(y, x))
       },
       _ => {
         throw UnknownNumberTag
@@ -2128,11 +1759,8 @@ let cmpRational = (x: WasmI32, y: WasmI32) => {
   } else {
     let yBoxedNumberTag = boxedNumberTag(y)
     match (yBoxedNumberTag) {
-      t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
-        WasmI32.sub(0n, cmpSmallInt(y, x, false))
-      },
       t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
-        WasmI32.sub(0n, cmpSmallInt(y, x, true))
+        WasmI32.sub(0n, cmpSmallInt(y, x))
       },
       t when WasmI32.eq(t, Tags._GRAIN_BIGINT_BOXED_NUM_TAG) => {
         WasmI32.sub(0n, cmpBigInt(y, x))
@@ -2140,11 +1768,8 @@ let cmpRational = (x: WasmI32, y: WasmI32) => {
       t when WasmI32.eq(t, Tags._GRAIN_RATIONAL_BOXED_NUM_TAG) => {
         cmpRationals(x, y)
       },
-      t when WasmI32.eq(t, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG) => {
-        WasmI32.sub(0n, cmpFloat(y, x, false))
-      },
       t when WasmI32.eq(t, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG) => {
-        WasmI32.sub(0n, cmpFloat(y, x, true))
+        WasmI32.sub(0n, cmpFloat(y, x))
       },
       _ => {
         throw UnknownNumberTag
@@ -2162,11 +1787,8 @@ provide let cmp = (x: WasmI32, y: WasmI32) => {
     } else {
       let yBoxedNumberTag = boxedNumberTag(y)
       match (yBoxedNumberTag) {
-        t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
-          WasmI32.sub(0n, cmpSmallInt(y, x, false))
-        },
         t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
-          WasmI32.sub(0n, cmpSmallInt(y, x, true))
+          WasmI32.sub(0n, cmpSmallInt(y, x))
         },
         t when WasmI32.eq(t, Tags._GRAIN_BIGINT_BOXED_NUM_TAG) => {
           WasmI32.sub(0n, cmpBigInt(y, x))
@@ -2174,11 +1796,8 @@ provide let cmp = (x: WasmI32, y: WasmI32) => {
         t when WasmI32.eq(t, Tags._GRAIN_RATIONAL_BOXED_NUM_TAG) => {
           WasmI32.sub(0n, cmpRational(y, x))
         },
-        t when WasmI32.eq(t, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG) => {
-          WasmI32.sub(0n, cmpFloat(y, x, false))
-        },
         t when WasmI32.eq(t, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG) => {
-          WasmI32.sub(0n, cmpFloat(y, x, true))
+          WasmI32.sub(0n, cmpFloat(y, x))
         },
         _ => {
           throw UnknownNumberTag
@@ -2188,11 +1807,8 @@ provide let cmp = (x: WasmI32, y: WasmI32) => {
   } else {
     let xBoxedNumberTag = boxedNumberTag(x)
     match (xBoxedNumberTag) {
-      t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
-        cmpSmallInt(x, y, false)
-      },
       t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
-        cmpSmallInt(x, y, true)
+        cmpSmallInt(x, y)
       },
       t when WasmI32.eq(t, Tags._GRAIN_BIGINT_BOXED_NUM_TAG) => {
         cmpBigInt(x, y)
@@ -2200,11 +1816,8 @@ provide let cmp = (x: WasmI32, y: WasmI32) => {
       t when WasmI32.eq(t, Tags._GRAIN_RATIONAL_BOXED_NUM_TAG) => {
         cmpRational(x, y)
       },
-      t when WasmI32.eq(t, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG) => {
-        cmpFloat(x, y, false)
-      },
       t when WasmI32.eq(t, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG) => {
-        cmpFloat(x, y, true)
+        cmpFloat(x, y)
       },
       _ => {
         throw UnknownNumberTag
@@ -2536,9 +2149,6 @@ let coerceNumberToShortUint = (x: Number, max32, max64, is8bit) => {
   } else {
     let xtag = boxedNumberTag(x)
     match (xtag) {
-      t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
-        boxedInt32Number(x)
-      },
       t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
         let int64 = boxedInt64Number(x)
         if (WasmI64.gtS(int64, max64) || WasmI64.ltS(int64, 0N)) {
@@ -2577,9 +2187,6 @@ let coerceNumberToShortInt =
   } else {
     let xtag = boxedNumberTag(x)
     match (xtag) {
-      t when WasmI32.eq(t, Tags._GRAIN_INT32_BOXED_NUM_TAG) => {
-        boxedInt32Number(x)
-      },
       t when WasmI32.eq(t, Tags._GRAIN_INT64_BOXED_NUM_TAG) => {
         let int64 = boxedInt64Number(x)
         if (WasmI64.gtS(int64, max64) || WasmI64.ltS(int64, min64)) {
@@ -2682,20 +2289,7 @@ provide let coerceNumberToUint16 = (number: Number) => {
  */
 @unsafe
 provide let coerceNumberToInt32 = (x: Number) => {
-  let x = WasmI32.fromGrain(x)
-  let result = if (
-    !isSimpleNumber(x) &&
-    WasmI32.eq(boxedNumberTag(x), Tags._GRAIN_INT32_BOXED_NUM_TAG)
-  ) {
-    // avoid extra malloc and prevent x from being freed
-    Memory.incRef(x)
-    x
-  } else {
-    // incRef x to reuse it via WasmI32.toGrain
-    Memory.incRef(x)
-    // can possibly fail
-    newInt32(coerceNumberToWasmI32(WasmI32.toGrain(x): Number))
-  }
+  let result = newInt32(coerceNumberToWasmI32(x))
   WasmI32.toGrain(result): Int32
 }
 
@@ -2757,11 +2351,6 @@ provide let coerceNumberToRational = (x: Number) => {
       // avoid extra malloc and prevent x from being freed
       Memory.incRef(x)
       x
-    } else if (WasmI32.eq(tag, Tags._GRAIN_INT32_BOXED_NUM_TAG)) {
-      newRational(
-        BI.makeWrappedInt32(boxedInt32Number(x)),
-        BI.makeWrappedInt32(1n)
-      )
     } else if (WasmI32.eq(tag, Tags._GRAIN_INT64_BOXED_NUM_TAG)) {
       // incRef x to reuse it via WasmI32.toGrain
       Memory.incRef(x)
@@ -2786,19 +2375,7 @@ provide let coerceNumberToRational = (x: Number) => {
  */
 @unsafe
 provide let coerceNumberToFloat32 = (x: Number) => {
-  let x = WasmI32.fromGrain(x)
-  let result = if (
-    !isSimpleNumber(x) &&
-    WasmI32.eq(boxedNumberTag(x), Tags._GRAIN_FLOAT32_BOXED_NUM_TAG)
-  ) {
-    // avoid extra malloc and prevent x from being freed
-    Memory.incRef(x)
-    x
-  } else {
-    // incRef x to reuse it via WasmI32.toGrain
-    Memory.incRef(x)
-    newFloat32(coerceNumberToWasmF32(WasmI32.toGrain(x): Number))
-  }
+  let result = newFloat32(coerceNumberToWasmF32(x))
   WasmI32.toGrain(result): Float32
 }
 
@@ -2894,9 +2471,9 @@ provide let coerceUint16ToNumber = (value: Uint16) => {
  */
 @unsafe
 provide let coerceInt32ToNumber = (x: Int32) => {
-  WasmI32.toGrain(
-    reducedInteger(WasmI64.extendI32S(boxedInt32Number(WasmI32.fromGrain(x))))
-  ): Number
+  let x = WasmI32.load(WasmI32.fromGrain(x), 4n)
+  let result = reducedInteger(WasmI64.extendI32S(x))
+  WasmI32.toGrain(result): Number
 }
 
 /**
@@ -2963,9 +2540,9 @@ provide let coerceRationalToNumber = (x: Rational) => {
  */
 @unsafe
 provide let coerceFloat32ToNumber = (x: Float32) => {
-  WasmI32.toGrain(
-    newFloat64(WasmF64.promoteF32(boxedFloat32Number(WasmI32.fromGrain(x))))
-  ): Number
+  let x = WasmF32.load(WasmI32.fromGrain(x), 4n)
+  let x64 = WasmF64.promoteF32(x)
+  WasmI32.toGrain(newFloat64(x64)): Number
 }
 
 /**
@@ -2998,7 +2575,6 @@ let convertInexactToExactHelp = x => {
   } else {
     let tag = boxedNumberTag(x)
     if (
-      WasmI32.eq(tag, Tags._GRAIN_INT32_BOXED_NUM_TAG) ||
       WasmI32.eq(tag, Tags._GRAIN_INT64_BOXED_NUM_TAG) ||
       WasmI32.eq(tag, Tags._GRAIN_BIGINT_BOXED_NUM_TAG) ||
       WasmI32.eq(tag, Tags._GRAIN_RATIONAL_BOXED_NUM_TAG)
@@ -3007,12 +2583,6 @@ let convertInexactToExactHelp = x => {
       x
     } else {
       match (tag) {
-        t when WasmI32.eq(t, Tags._GRAIN_FLOAT32_BOXED_NUM_TAG) => {
-          // TODO(#1191): Investigate if BigInt is more accurate
-          reducedInteger(
-            WasmI64.truncF32S(WasmF32.nearest(boxedFloat32Number(x)))
-          )
-        },
         t when WasmI32.eq(t, Tags._GRAIN_FLOAT64_BOXED_NUM_TAG) => {
           // TODO(#1191): Investigate if BigInt is more accurate
           reducedInteger(

--- a/stdlib/runtime/numbers.md
+++ b/stdlib/runtime/numbers.md
@@ -66,22 +66,10 @@ reducedUnsignedInteger : WasmI64 -> WasmI32
 boxedNumberTag : WasmI32 -> WasmI32
 ```
 
-### Numbers.**boxedInt32Number**
-
-```grain
-boxedInt32Number : WasmI32 -> WasmI32
-```
-
 ### Numbers.**boxedInt64Number**
 
 ```grain
 boxedInt64Number : WasmI32 -> WasmI64
-```
-
-### Numbers.**boxedFloat32Number**
-
-```grain
-boxedFloat32Number : WasmI32 -> WasmF32
 ```
 
 ### Numbers.**boxedFloat64Number**

--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -471,9 +471,6 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
     t when t == Tags._GRAIN_BOXED_NUM_HEAP_TAG => {
       let numberTag = WasmI32.load(ptr, 4n)
       match (numberTag) {
-        t when t == Tags._GRAIN_INT32_BOXED_NUM_TAG => {
-          NumberUtils.itoa32(WasmI32.load(ptr, 8n), 10n)
-        },
         t when t == Tags._GRAIN_INT64_BOXED_NUM_TAG => {
           NumberUtils.itoa64(WasmI64.load(ptr, 8n), 10n)
         },
@@ -487,9 +484,6 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
           let strings = [numerator, slash, denominator]
           join(strings)
         },
-        t when t == Tags._GRAIN_FLOAT32_BOXED_NUM_TAG => {
-          NumberUtils.dtoa(WasmF64.promoteF32(WasmF32.load(ptr, 8n)))
-        },
         t when t == Tags._GRAIN_FLOAT64_BOXED_NUM_TAG => {
           NumberUtils.dtoa(WasmF64.load(ptr, 8n))
         },
@@ -497,6 +491,12 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
           "<unknown boxed number>"
         },
       }
+    },
+    t when t == Tags._GRAIN_INT32_HEAP_TAG => {
+      NumberUtils.itoa32(WasmI32.load(ptr, 4n), 10n)
+    },
+    t when t == Tags._GRAIN_FLOAT32_HEAP_TAG => {
+      NumberUtils.dtoa(WasmF64.promoteF32(WasmF32.load(ptr, 4n)))
     },
     t when t == Tags._GRAIN_UINT32_HEAP_TAG => {
       NumberUtils.utoa32(WasmI32.load(ptr, 4n), 10n)

--- a/stdlib/runtime/unsafe/constants.gr
+++ b/stdlib/runtime/unsafe/constants.gr
@@ -2,7 +2,7 @@
 module Constants
 
 // Signed/Unsigned Min/Max Constants
-provide let _SMIN_I32 = 0xFFFFFFFFn
+provide let _SMIN_I32 = 0x80000000n
 provide let _SMAX_I32 = 0x7FFFFFFFn
 provide let _UMIN_I32 = 0x0n
 provide let _UMAX_I32 = 0xFFFFFFFFn
@@ -15,7 +15,7 @@ provide let _SMIN16_I32 = -0x7FFFn
 provide let _SMAX16_I32 = 0x7FFFn
 provide let _UMAX16_I32 = 0xFFFFn
 
-provide let _SMIN_I64 = 0xFFFFFFFFFFFFFFFFN
+provide let _SMIN_I64 = 0x8000000000000000N
 provide let _SMAX_I64 = 0x7FFFFFFFFFFFFFFFN
 provide let _UMIN_I64 = 0x0N
 provide let _UMAX_I64 = 0xFFFFFFFFFFFFFFFFN
@@ -28,7 +28,7 @@ provide let _SMIN16_I64 = -0x7FFFN
 provide let _SMAX16_I64 = 0x7FFFN
 provide let _UMAX16_I64 = 0xFFFFN
 
-provide let _SMIN32_I64 = -0x7FFFFFFFN
+provide let _SMIN32_I64 = 0xFFFFFFFF80000000N
 provide let _SMAX32_I64 = 0x7FFFFFFFN
 provide let _UMIN32_I64 = 0x0N
 provide let _UMAX32_I64 = 0xFFFFFFFFN

--- a/stdlib/runtime/unsafe/conv.gr
+++ b/stdlib/runtime/unsafe/conv.gr
@@ -15,7 +15,7 @@ provide let toInt32 = n => {
 @unsafe
 provide let fromInt32 = (n: Int32) => {
   let ptr = WasmI32.fromGrain(n)
-  WasmI32.load(ptr, 8n)
+  WasmI32.load(ptr, 4n)
 }
 
 @unsafe
@@ -37,7 +37,7 @@ provide let toFloat32 = n => {
 @unsafe
 provide let fromFloat32 = (n: Float32) => {
   let ptr = WasmI32.fromGrain(n)
-  WasmF32.load(ptr, 8n)
+  WasmF32.load(ptr, 4n)
 }
 
 @unsafe
@@ -84,7 +84,7 @@ provide let wasmI32ToNumber = (n: WasmI32) => {
   }
 
   // If it did overflow, then the value differs and we need to discard it and
-  // allocate the number on the heap. A boxed 32 bit number actually is the
-  // same thing as an Int32. It only needs to be cast into Number.
-  return WasmI32.toGrain(newInt32(n)): Number
+  // allocate the number on the heap. We can do this by extending the 32 bit
+  // number to an Int64.
+  return WasmI32.toGrain(newInt64(WasmI64.extendI32S(n))): Number
 }

--- a/stdlib/runtime/unsafe/tags.gr
+++ b/stdlib/runtime/unsafe/tags.gr
@@ -30,13 +30,13 @@ provide let _GRAIN_BOXED_NUM_HEAP_TAG = 5n
 provide let _GRAIN_LAMBDA_HEAP_TAG = 6n
 provide let _GRAIN_TUPLE_HEAP_TAG = 7n
 provide let _GRAIN_BYTES_HEAP_TAG = 8n
-provide let _GRAIN_UINT32_HEAP_TAG = 9n
-provide let _GRAIN_UINT64_HEAP_TAG = 10n
+provide let _GRAIN_INT32_HEAP_TAG = 9n
+provide let _GRAIN_FLOAT32_HEAP_TAG = 10n
+provide let _GRAIN_UINT32_HEAP_TAG = 11n
+provide let _GRAIN_UINT64_HEAP_TAG = 12n
 
 // Boxed number types
-provide let _GRAIN_FLOAT32_BOXED_NUM_TAG = 1n
-provide let _GRAIN_FLOAT64_BOXED_NUM_TAG = 2n
-provide let _GRAIN_INT32_BOXED_NUM_TAG = 3n
-provide let _GRAIN_INT64_BOXED_NUM_TAG = 4n
-provide let _GRAIN_RATIONAL_BOXED_NUM_TAG = 5n
-provide let _GRAIN_BIGINT_BOXED_NUM_TAG = 6n
+provide let _GRAIN_FLOAT64_BOXED_NUM_TAG = 1n
+provide let _GRAIN_INT64_BOXED_NUM_TAG = 2n
+provide let _GRAIN_RATIONAL_BOXED_NUM_TAG = 3n
+provide let _GRAIN_BIGINT_BOXED_NUM_TAG = 4n

--- a/stdlib/runtime/unsafe/tags.md
+++ b/stdlib/runtime/unsafe/tags.md
@@ -150,6 +150,18 @@ _GRAIN_TUPLE_HEAP_TAG : WasmI32
 _GRAIN_BYTES_HEAP_TAG : WasmI32
 ```
 
+### Tags.**_GRAIN_INT32_HEAP_TAG**
+
+```grain
+_GRAIN_INT32_HEAP_TAG : WasmI32
+```
+
+### Tags.**_GRAIN_FLOAT32_HEAP_TAG**
+
+```grain
+_GRAIN_FLOAT32_HEAP_TAG : WasmI32
+```
+
 ### Tags.**_GRAIN_UINT32_HEAP_TAG**
 
 ```grain
@@ -162,22 +174,10 @@ _GRAIN_UINT32_HEAP_TAG : WasmI32
 _GRAIN_UINT64_HEAP_TAG : WasmI32
 ```
 
-### Tags.**_GRAIN_FLOAT32_BOXED_NUM_TAG**
-
-```grain
-_GRAIN_FLOAT32_BOXED_NUM_TAG : WasmI32
-```
-
 ### Tags.**_GRAIN_FLOAT64_BOXED_NUM_TAG**
 
 ```grain
 _GRAIN_FLOAT64_BOXED_NUM_TAG : WasmI32
-```
-
-### Tags.**_GRAIN_INT32_BOXED_NUM_TAG**
-
-```grain
-_GRAIN_INT32_BOXED_NUM_TAG : WasmI32
 ```
 
 ### Tags.**_GRAIN_INT64_BOXED_NUM_TAG**

--- a/stdlib/uint32.gr
+++ b/stdlib/uint32.gr
@@ -60,7 +60,7 @@ provide let toNumber = (x: Uint32) => {
  */
 @unsafe
 provide let fromInt32 = (x: Int32) => {
-  let x = WasmI32.load(WasmI32.fromGrain(x), 8n)
+  let x = WasmI32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
   let result = newUint32(x)
   WasmI32.toGrain(result): Uint32
 }


### PR DESCRIPTION
Closes #1555, making `Int32` and `Float32` their own distinct types separate from `Number`. The most fragile part of these changes is making sure that all of the memory load offsets for these types were corrected, but I am fairly confident that I got them all after sweeping through every instance of `8n` in the stdlib/runtime several times and making corrections where necessary :crossed_fingers: .