### PR TITLE
feat(graindoc)!: Support docblocks on submodules

### DIFF
--- a/compiler/graindoc/graindoc.re
+++ b/compiler/graindoc/graindoc.re
@@ -133,7 +133,10 @@ let generate_docs =
       |> Option.map((attr: Comment_attributes.t) => {
            switch (attr) {
            | Since({attr_version}) =>
-             Docblock.output_for_since(~current_version, attr_version)
+             Docblock.output_for_since(
+               ~current_version,
+               {since_version: attr_version},
+             )
            | _ =>
              failwith("Unreachable: Non-`since` attribute can't exist here.")
            }
@@ -146,8 +149,7 @@ let generate_docs =
            | History({attr_version, attr_desc}) =>
              Docblock.output_for_history(
                ~current_version,
-               attr_version,
-               attr_desc,
+               {history_version: attr_version, history_msg: attr_desc},
              )
            | _ =>
              failwith("Unreachable: Non-`since` attribute can't exist here.")
@@ -216,6 +218,7 @@ let generate_docs =
               ~comments,
               ~provides,
               ~module_name,
+              ~module_namespace="",
               ~ident,
               td,
             );
@@ -264,6 +267,7 @@ let generate_docs =
               ~comments,
               ~provides,
               ~module_name,
+              ~module_namespace="",
               ~ident,
               vd,
             );

--- a/compiler/src/diagnostics/comment_attributes.re
+++ b/compiler/src/diagnostics/comment_attributes.re
@@ -1,32 +1,22 @@
 exception InvalidAttribute(string);
 exception MalformedAttribute(string, string);
 
-type attr_name = string;
-type attr_desc = string;
-// The `attr_type` always starts as `None` and is applied later by something like Graindoc
-type attr_type = option(string);
-type attr_version = string;
-
 type t =
   | Param({
-      attr_name,
-      attr_type,
-      attr_desc,
+      attr_name: string,
+      attr_desc: string,
     })
-  | Returns({
-      attr_desc,
-      attr_type,
-    })
-  | Example({attr_desc})
-  | Deprecated({attr_desc})
-  | Since({attr_version})
+  | Returns({attr_desc: string})
+  | Example({attr_desc: string})
+  | Deprecated({attr_desc: string})
+  | Since({attr_version: string})
   | History({
-      attr_version,
-      attr_desc,
+      attr_version: string,
+      attr_desc: string,
     })
   | Throws({
-      attr_type,
-      attr_desc,
+      attr_type: string,
+      attr_desc: string,
     });
 
 type parsed_graindoc = (option(string), list(t));

--- a/compiler/src/diagnostics/graindoc_parser.mly
+++ b/compiler/src/diagnostics/graindoc_parser.mly
@@ -27,13 +27,13 @@ attribute_text:
   | ioption(eols) multiline_text ioption(eols) %prec EOL { $2 }
 
 attribute:
-  | PARAM IDENT COLON attribute_text { Param({ attr_name=$2; attr_type=None; attr_desc=$4 }) }
-  | RETURNS attribute_text { Returns({ attr_desc=$2; attr_type=None }) }
+  | PARAM IDENT COLON attribute_text { Param({ attr_name=$2; attr_desc=$4 }) }
+  | RETURNS attribute_text { Returns({attr_desc=$2}) }
   | EXAMPLE attribute_text { Example({attr_desc=$2}) }
   | DEPRECATED attribute_text { Deprecated({attr_desc=$2}) }
   | SINCE SEMVER { Since({attr_version=$2}) }
   | HISTORY SEMVER COLON attribute_text { History({ attr_version=$2; attr_desc=$4; }) }
-  | THROWS CONSTRUCTOR COLON attribute_text { Throws({ attr_type=Some $2; attr_desc=$4; }); }
+  | THROWS CONSTRUCTOR COLON attribute_text { Throws({ attr_type=$2; attr_desc=$4; }); }
 
 attributes_help:
   | attribute { [$1] }

--- a/stdlib/regex.md
+++ b/stdlib/regex.md
@@ -25,6 +25,11 @@ type RegularExpression
 
 ### Regex.**MatchResult**
 
+<details disabled>
+<summary tabindex="-1">Added in <code>0.4.3</code></summary>
+No other changes yet.
+</details>
+
 ```grain
 record MatchResult {
   group: Number -> Option<String>,


### PR DESCRIPTION
This updates graindoc to support submodules. Since modules need to be processed recursively, I needed to refactor most of the graindoc internals. This was a really good refactor because it makes a clear separation between the attribute parsing, the docblock data types, and the markdown generation phase. Both the docblock collection and markdown generation are recursive so we can start at the top of the program tree and call `Docblock.for_signature_items` and the `Docblock.to_markdown` on the results and everything gets printed.

Since we don't have any submodules in the stdlib at the moment, I've run this against #1479 and pushed the updated docs as https://github.com/grain-lang/grain/pull/1479/commits/4dfc7c56074cc929f3becad5db7a98e0d3e7174c

Closes #1621