### PR TITLE
fix(graindoc): Escape * chars that would close markdown bold incorrectly

### DIFF
--- a/compiler/src/utils/markdown.re
+++ b/compiler/src/utils/markdown.re
@@ -51,7 +51,16 @@ let frontmatter = rows => {
 };
 
 let bold = str => {
-  Format.sprintf("**%s**", str);
+  let escaped_str =
+    Str.global_substitute(
+      Str.regexp({|\(^\*+\)\|\(\*\*+\)\|\(\*+$\)|}),
+      str => {
+        let matched = Str.matched_string(str);
+        Str.global_replace(Str.regexp({|\*|}), {|\*|}, matched);
+      },
+      str,
+    );
+  Format.sprintf("**%s**", escaped_str);
 };
 
 let blockquote = str => {

--- a/compiler/test/utils/markdown.re
+++ b/compiler/test/utils/markdown.re
@@ -1,0 +1,42 @@
+open Grain_utils;
+
+open Grain_tests.TestFramework;
+open Grain_tests.Runner;
+
+describe("utils/markdown", ({test}) => {
+  test("bold_escape_leading_star", ({expect}) => {
+    expect.string(Markdown.bold("*")).toEqual({|**\***|})
+  });
+
+  test("bold_escape_many_leading_stars", ({expect}) => {
+    expect.string(Markdown.bold("*****")).toEqual({|**\*\*\*\*\***|})
+  });
+
+  // This is how an operator is passed
+  test("bold_no_escape_one_nonleading_star", ({expect}) => {
+    expect.string(Markdown.bold("(*)")).toEqual({|**(*)**|})
+  });
+
+  // This is the pow operator
+  test("bold_escape_two_nonleading_star", ({expect}) => {
+    expect.string(Markdown.bold("(**)")).toEqual({|**(\*\*)**|})
+  });
+
+  test("bold_escape_many_nonleading_star", ({expect}) => {
+    expect.string(Markdown.bold("(******)")).toEqual({|**(\*\*\*\*\*\*)**|})
+  });
+
+  test("bold_escape_trailing_star", ({expect}) => {
+    expect.string(Markdown.bold("foo*")).toEqual({|**foo\***|})
+  });
+
+  test("bold_escape_many_trailing_star", ({expect}) => {
+    expect.string(Markdown.bold("foo*****")).toEqual({|**foo\*\*\*\*\***|})
+  });
+
+  test("bold_escape_many_leading_and_trailing_star", ({expect}) => {
+    expect.string(Markdown.bold("*****foo*****")).toEqual(
+      {|**\*\*\*\*\*foo\*\*\*\*\***|},
+    )
+  });
+});


### PR DESCRIPTION
This escapes any `*+` characters at the beginning of a string passed to `Markdown.bold`, any `**+` anywhere in the string, and any `*+` at the end of string. These all would cause the bold to be rendered improperly.

I've also started adding tests for the markdown utils, to ensure this was working before applying to #1538

Closes #1550 - I know this said to escape `_` but those don't actually effect the `**` added by bold so I'm not going to escape them right now.