### PR TITLE
feat(graindoc)!: Only use original doc blocks when re-providing

### DIFF
--- a/compiler/graindoc/graindoc.re
+++ b/compiler/graindoc/graindoc.re
@@ -80,10 +80,6 @@ let compile_typed = (input: Fp.t(Fp.absolute)) => {
 
 let generate_docs =
     (~current_version, ~output=?, program: Typedtree.typed_program) => {
-  let comments = Comments.to_ordered(program.comments);
-
-  let provides = Docblock.enumerate_provides(program);
-
   let signature_items = program.signature.cmi_sign;
 
   let buf = Buffer.create(0);
@@ -93,8 +89,6 @@ let generate_docs =
 
   let docblock =
     Docblock.for_signature_items(
-      ~comments,
-      ~provides,
       ~module_namespace=None,
       ~name=module_name,
       ~loc=program.module_name.loc,

--- a/stdlib/bigint.gr
+++ b/stdlib/bigint.gr
@@ -19,24 +19,7 @@ from Numbers use {
   coerceBigIntToNumber as toNumber,
 }
 
-/**
- * Converts a Number to a BigInt.
- *
- * @param number: The value to convert
- * @returns The Number represented as a BigInt
- *
- * @since v0.5.0
- */
-provide { fromNumber }
-/**
- * Converts a BigInt to a Number.
- *
- * @param num: The value to convert
- * @returns The BigInt represented as a Number
- *
- * @since v0.5.0
- */
-provide { toNumber }
+provide { fromNumber, toNumber }
 
 /**
  * Increments the value by one.

--- a/stdlib/float32.gr
+++ b/stdlib/float32.gr
@@ -66,25 +66,7 @@ provide let tau = 6.2831853f
  */
 provide let e = 2.7182817f
 
-/**
- * Converts a Number to a Float32.
- *
- * @param number: The value to convert
- * @returns The Number represented as a Float32
- *
- * @since v0.2.0
- */
-provide { fromNumber }
-
-/**
- * Converts a Float32 to a Number.
- *
- * @param float: The value to convert
- * @returns The Float32 represented as a Number
- *
- * @since v0.2.0
- */
-provide { toNumber }
+provide { fromNumber, toNumber }
 
 /**
  * Computes the sum of its operands.

--- a/stdlib/float64.gr
+++ b/stdlib/float64.gr
@@ -70,25 +70,7 @@ provide let tau = 6.283185307179586d
  */
 provide let e = 2.718281828459045d
 
-/**
- * Converts a Number to a Float64.
- *
- * @param number: The value to convert
- * @returns The Number represented as a Float64
- *
- * @since v0.2.0
- */
-provide { fromNumber }
-
-/**
- * Converts a Float64 to a Number.
- *
- * @param float: The value to convert
- * @returns The Float64 represented as a Number
- *
- * @since v0.2.0
- */
-provide { toNumber }
+provide { fromNumber, toNumber }
 
 /**
  * Computes the sum of its operands.

--- a/stdlib/int32.gr
+++ b/stdlib/int32.gr
@@ -20,25 +20,7 @@ from Numbers use {
   coerceInt32ToNumber as toNumber,
 }
 
-/**
- * Converts a Number to an Int32.
- *
- * @param number: The value to convert
- * @returns The Number represented as an Int32
- *
- * @since v0.2.0
- */
-provide { fromNumber }
-
-/**
- * Converts an Int32 to a Number.
- *
- * @param value: The value to convert
- * @returns The Int32 represented as a Number
- *
- * @since v0.2.0
- */
-provide { toNumber }
+provide { fromNumber, toNumber }
 
 /**
  * Converts a Uint32 to an Int32.

--- a/stdlib/int64.gr
+++ b/stdlib/int64.gr
@@ -21,25 +21,7 @@ from Numbers use {
   coerceInt64ToNumber as toNumber,
 }
 
-/**
- * Converts a Number to an Int64.
- *
- * @param number: The value to convert
- * @returns The Number represented as an Int64
- *
- * @since v0.2.0
- */
-provide { fromNumber }
-
-/**
- * Converts an Int64 to a Number.
- *
- * @param value: The value to convert
- * @returns The Int64 represented as a Number
- *
- * @since v0.2.0
- */
-provide { toNumber }
+provide { fromNumber, toNumber }
 
 /**
  * Converts a Uint64 to an Int64.

--- a/stdlib/pervasives.gr
+++ b/stdlib/pervasives.gr
@@ -85,16 +85,6 @@ provide primitive (&&): (Bool, Bool) -> Bool = "@and"
  */
 provide primitive (||): (Bool, Bool) -> Bool = "@or"
 
-/**
- * Check that two values are equal. This checks for structural equality,
- * so it also works for comparing things like tuples and lists.
- *
- * @param value1: The first operand
- * @param value2: The second operand
- * @returns `true` if the values are structurally equal or `false` otherwise
- *
- * @since v0.1.0
- */
 provide { (==) }
 
 /**
@@ -133,240 +123,28 @@ provide primitive (is): (a, a) -> Bool = "@is"
  */
 provide let (isnt): (a, a) -> Bool = (x, y) => !(x is y)
 
-/**
- * Checks if the first operand is less than the second operand.
- *
- * @param num1: The first operand
- * @param num2: The second operand
- * @returns `true` if the first operand is less than the second operand or `false` otherwise
- *
- * @since v0.1.0
- */
-provide { (<) }
-
-/**
- * Checks if the first operand is greater than the second operand.
- *
- * @param num1: The first operand
- * @param num2: The second operand
- * @returns `true` if the first operand is greater than the second operand or `false` otherwise
- *
- * @since v0.1.0
- */
-provide { (>) }
-
-/**
- * Checks if the first operand is less than or equal to the second operand.
- *
- * @param num1: The first operand
- * @param num2: The second operand
- * @returns `true` if the first operand is less than or equal to the second operand or `false` otherwise
- *
- * @since v0.1.0
- */
-provide { (<=) }
-
-/**
- * Checks if the first operand is greater than or equal to the second operand.
- *
- * @param num1: The first operand
- * @param num2: The second operand
- * @returns `true` if the first operand is greater than or equal to the second operand or `false` otherwise
- *
- * @since v0.1.0
- */
-provide { (>=) }
-
-/**
- * Compares the first argument to the second argument and produces an integer result.
- * Provides a consistent ordering over all types and is suitable for sorting and other kinds of ordering.
- * `compare` treats `NaN` differently than the other comparison operators in that it considers `NaN` equal to itself and smaller than any other number.
- *
- * @param num1: The first operand
- * @param num2: The second operand
- * @returns A negative integer if the first operand is less than the second operand, `0` if they are equal, or a positive integer otherwise
- *
- * @since v0.5.3
- */
-provide { compare }
-
-/**
- * Computes the sum of its operands.
- *
- * @param num1: The first operand
- * @param num2: The second operand
- * @returns The sum of the two operands
- *
- * @since v0.1.0
- */
-provide { (+) }
-
-/**
- * Computes the difference of its operands.
- *
- * @param num1: The first operand
- * @param num2: The second operand
- * @returns The difference of the two operands
- *
- * @since v0.1.0
- */
-provide { (-) }
-
-/**
- * Computes the product of its operands.
- *
- * @param num1: The first operand
- * @param num2: The second operand
- * @returns The product of the two operands
- *
- * @since v0.1.0
- */
-provide { (*) }
-
-/**
- * Computes the quotient of its operands.
- *
- * @param num1: The first operand
- * @param num2: The second operand
- * @returns The quotient of the two operands
- *
- * @since v0.1.0
- */
-provide { (/) }
-
-/**
- * Computes the remainder of the division of the first operand by the second.
- * The result will have the sign of the second operand.
- *
- * @param num1: The first operand
- * @param num2: The second operand
- * @returns The modulus of its operands
- *
- * @since v0.1.0
- */
-provide { (%) }
-
-/**
- * Increments the value by one.
- *
- * @param value: The value to increment
- * @returns The incremented value
- *
- * @since v0.1.0
- */
-provide { incr }
-
-/**
- * Decrements the value by one.
- *
- * @param value: The value to decrement
- * @returns The decremented value
- *
- * @since v0.1.0
- */
-provide { decr }
-
-/**
- * Concatenate two strings.
- *
- * @param str1: The beginning string
- * @param str2: The ending string
- * @returns The combined string
- *
- * @example "Foo" ++ "Bar" == "FooBar"
- *
- * @since v0.2.0
- */
-provide { (++) }
-
-/**
- * Computes the bitwise NOT of the operand.
- *
- * @param value: The operand
- * @returns Containing the inverted bits of the operand
- *
- * @since v0.2.0
- */
-provide { lnot }
-
-/**
- * Computes the bitwise AND (`&`) on the given operands.
- *
- * @param value1: The first operand
- * @param value2: The second operand
- * @returns Containing a `1` in each bit position for which the corresponding bits of both operands are `1`
- *
- * @since v0.3.0
- * @history v0.2.0: Originally named `land`
- * @history v0.3.0: Renamed to `&`
- */
-provide { (&) }
-
-/**
- * Computes the bitwise OR (`|`) on the given operands.
- *
- * @param value1: The first operand
- * @param value2: The second operand
- * @returns Containing a `1` in each bit position for which the corresponding bits of either or both operands are `1`
- *
- * @since v0.3.0
- * @history v0.2.0: Originally named `lor`
- * @history v0.3.0: Renamed to `|`
- */
-provide { (|) }
-
-/**
- * Computes the bitwise XOR (`^`) on the given operands.
- *
- * @param value1: The first operand
- * @param value2: The second operand
- * @returns Containing a `1` in each bit position for which the corresponding bits of either but not both operands are `1`
- *
- * @since v0.3.0
- * @history v0.1.0: The `^` operator was originally an alias of `unbox`
- * @history v0.2.0: Originally named `lxor`
- * @history v0.3.0: Renamed to `^`
- */
-provide { (^) }
-
-/**
- * Shifts the bits of the value left by the given number of bits.
- *
- * @param value: The value to shift
- * @param amount: The number of bits to shift by
- * @returns The shifted value
- *
- * @since v0.3.0
- * @history v0.2.0: Originally named `lsl`
- * @history v0.3.0: Renamed to `<<`
- */
-provide { (<<) }
-
-/**
- * Shifts the bits of the value right by the given number of bits, preserving the sign bit.
- *
- * @param value: The value to shift
- * @param amount: The amount to shift by
- * @returns The shifted value
- *
- * @since v0.3.0
- * @history v0.2.0: Originally named `lsr`
- * @history v0.3.0: Renamed to `>>>`
- */
-provide { (>>>) }
-
-/**
- * Shifts the bits of the value right by the given number of bits.
- *
- * @param value: The value to shift
- * @param amount: The amount to shift by
- * @returns The shifted value
- *
- * @since v0.3.0
- * @history v0.2.0: Originally named `asr`
- * @history v0.3.0: Renamed to `>>`
- */
-provide { (>>) }
+provide {
+  (<),
+  (>),
+  (<=),
+  (>=),
+  compare,
+  (+),
+  (-),
+  (*),
+  (/),
+  (%),
+  incr,
+  decr,
+  (++),
+  lnot,
+  (&),
+  (|),
+  (^),
+  (<<),
+  (>>>),
+  (>>),
+}
 
 // Number coercions & conversions
 
@@ -374,27 +152,7 @@ provide { (>>) }
 // foreign wasm convertExactToInexact : Number -> Number as inexact from "stdlib-external/runtime"
 // foreign wasm convertInexactToExact : Number -> Number as exact from "stdlib-external/runtime"
 
-/**
- * Converts the given operand to a string.
- * Provides a better representation of data types if those types are provided from the module.
- *
- * @param value: The operand
- * @returns The operand, as a string
- *
- * @since v0.1.0
- */
-provide { toString }
-
-/**
- * Prints the given operand to the console. Works for any type. Internally, calls `toString`
- * on the operand, so a better representation of data type will be printed if those types
- * are provided from the module.
- *
- * @param value: The operand
- *
- * @since v0.1.0
- */
-provide { print }
+provide { toString, print }
 
 /**
  * Accepts any value and always returns `void`.

--- a/stdlib/runtime/compare.gr
+++ b/stdlib/runtime/compare.gr
@@ -176,6 +176,17 @@ compareHelp = (x, y) => {
   }
 }
 
+/**
+ * Compares the first argument to the second argument and produces an integer result.
+ * Provides a consistent ordering over all types and is suitable for sorting and other kinds of ordering.
+ * `compare` treats `NaN` differently than the other comparison operators in that it considers `NaN` equal to itself and smaller than any other number.
+ *
+ * @param num1: The first operand
+ * @param num2: The second operand
+ * @returns A negative integer if the first operand is less than the second operand, `0` if they are equal, or a positive integer otherwise
+ *
+ * @since v0.5.3
+ */
 @unsafe
 provide let compare = (x: a, y: a) => {
   compareHelp(WasmI32.fromGrain(x), WasmI32.fromGrain(y))

--- a/stdlib/runtime/compare.md
+++ b/stdlib/runtime/compare.md
@@ -8,7 +8,29 @@ Functions and constants included in the Compare module.
 
 ### Compare.**compare**
 
+<details disabled>
+<summary tabindex="-1">Added in <code>0.5.3</code></summary>
+No other changes yet.
+</details>
+
 ```grain
 compare : (a, a) -> Number
 ```
+
+Compares the first argument to the second argument and produces an integer result.
+Provides a consistent ordering over all types and is suitable for sorting and other kinds of ordering.
+`compare` treats `NaN` differently than the other comparison operators in that it considers `NaN` equal to itself and smaller than any other number.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`num1`|`a`|The first operand|
+|`num2`|`a`|The second operand|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|A negative integer if the first operand is less than the second operand, `0` if they are equal, or a positive integer otherwise|
 

--- a/stdlib/runtime/equal.gr
+++ b/stdlib/runtime/equal.gr
@@ -220,6 +220,16 @@ equalHelp = (x, y) => {
   }
 }
 
+/**
+ * Check that two values are equal. This checks for structural equality,
+ * so it also works for comparing things like tuples and lists.
+ *
+ * @param value1: The first operand
+ * @param value2: The second operand
+ * @returns `true` if the values are structurally equal or `false` otherwise
+ *
+ * @since v0.1.0
+ */
 @unsafe
 provide let equal = (x: a, y: a) => {
   equalHelp(WasmI32.fromGrain(x), WasmI32.fromGrain(y))

--- a/stdlib/runtime/equal.md
+++ b/stdlib/runtime/equal.md
@@ -8,7 +8,28 @@ Functions and constants included in the Equal module.
 
 ### Equal.**equal**
 
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
+
 ```grain
 equal : (a, a) -> Bool
 ```
+
+Check that two values are equal. This checks for structural equality,
+so it also works for comparing things like tuples and lists.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`value1`|`a`|The first operand|
+|`value2`|`a`|The second operand|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Bool`|`true` if the values are structurally equal or `false` otherwise|
 

--- a/stdlib/runtime/numbers.gr
+++ b/stdlib/runtime/numbers.gr
@@ -2150,6 +2150,15 @@ provide let cmp = (x: WasmI32, y: WasmI32) => {
 // NaN being considered equal to itself and less than all other numbers in
 // this case).
 
+/**
+ * Checks if the first operand is less than the second operand.
+ *
+ * @param num1: The first operand
+ * @param num2: The second operand
+ * @returns `true` if the first operand is less than the second operand or `false` otherwise
+ *
+ * @since v0.1.0
+ */
 @unsafe
 provide let (<) = (x: Number, y: Number) => {
   let x = WasmI32.fromGrain(x)
@@ -2157,6 +2166,15 @@ provide let (<) = (x: Number, y: Number) => {
   !isNaN(x) && !isNaN(y) && WasmI32.ltS(cmp(x, y), 0n)
 }
 
+/**
+ * Checks if the first operand is greater than the second operand.
+ *
+ * @param num1: The first operand
+ * @param num2: The second operand
+ * @returns `true` if the first operand is greater than the second operand or `false` otherwise
+ *
+ * @since v0.1.0
+ */
 @unsafe
 provide let (>) = (x: Number, y: Number) => {
   let x = WasmI32.fromGrain(x)
@@ -2164,6 +2182,15 @@ provide let (>) = (x: Number, y: Number) => {
   !isNaN(x) && !isNaN(y) && WasmI32.gtS(cmp(x, y), 0n)
 }
 
+/**
+ * Checks if the first operand is less than or equal to the second operand.
+ *
+ * @param num1: The first operand
+ * @param num2: The second operand
+ * @returns `true` if the first operand is less than or equal to the second operand or `false` otherwise
+ *
+ * @since v0.1.0
+ */
 @unsafe
 provide let (<=) = (x: Number, y: Number) => {
   let x = WasmI32.fromGrain(x)
@@ -2171,6 +2198,15 @@ provide let (<=) = (x: Number, y: Number) => {
   !isNaN(x) && !isNaN(y) && WasmI32.leS(cmp(x, y), 0n)
 }
 
+/**
+ * Checks if the first operand is greater than or equal to the second operand.
+ *
+ * @param num1: The first operand
+ * @param num2: The second operand
+ * @returns `true` if the first operand is greater than or equal to the second operand or `false` otherwise
+ *
+ * @since v0.1.0
+ */
 @unsafe
 provide let (>=) = (x: Number, y: Number) => {
   let x = WasmI32.fromGrain(x)
@@ -2202,6 +2238,14 @@ provide let numberEq = (x: Number, y: Number) => {
  */
 // TODO(#306): Semantics around when things should stay i32/i64
 
+/**
+ * Computes the bitwise NOT of the operand.
+ *
+ * @param value: The operand
+ * @returns Containing the inverted bits of the operand
+ *
+ * @since v0.2.0
+ */
 @unsafe
 provide let lnot = (x: Number) => {
   let xw32 = WasmI32.fromGrain(x)
@@ -2213,6 +2257,17 @@ provide let lnot = (x: Number) => {
   }
 }
 
+/**
+ * Shifts the bits of the value left by the given number of bits.
+ *
+ * @param value: The value to shift
+ * @param amount: The number of bits to shift by
+ * @returns The shifted value
+ *
+ * @since v0.3.0
+ * @history v0.2.0: Originally named `lsl`
+ * @history v0.3.0: Renamed to `<<`
+ */
 @unsafe
 provide let (<<) = (x: Number, y: Number) => {
   let xw32 = WasmI32.fromGrain(x)
@@ -2234,6 +2289,17 @@ provide let (<<) = (x: Number, y: Number) => {
   }
 }
 
+/**
+ * Shifts the bits of the value right by the given number of bits, preserving the sign bit.
+ *
+ * @param value: The value to shift
+ * @param amount: The amount to shift by
+ * @returns The shifted value
+ *
+ * @since v0.3.0
+ * @history v0.2.0: Originally named `lsr`
+ * @history v0.3.0: Renamed to `>>>`
+ */
 @unsafe
 provide let (>>>) = (x: Number, y: Number) => {
   let xw32 = WasmI32.fromGrain(x)
@@ -2249,6 +2315,17 @@ provide let (>>>) = (x: Number, y: Number) => {
   }
 }
 
+/**
+ * Computes the bitwise AND (`&`) on the given operands.
+ *
+ * @param value1: The first operand
+ * @param value2: The second operand
+ * @returns Containing a `1` in each bit position for which the corresponding bits of both operands are `1`
+ *
+ * @since v0.3.0
+ * @history v0.2.0: Originally named `land`
+ * @history v0.3.0: Renamed to `&`
+ */
 @unsafe
 provide let (&) = (x: Number, y: Number) => {
   let xw32 = WasmI32.fromGrain(x)
@@ -2275,6 +2352,17 @@ provide let (&) = (x: Number, y: Number) => {
   }
 }
 
+/**
+ * Computes the bitwise OR (`|`) on the given operands.
+ *
+ * @param value1: The first operand
+ * @param value2: The second operand
+ * @returns Containing a `1` in each bit position for which the corresponding bits of either or both operands are `1`
+ *
+ * @since v0.3.0
+ * @history v0.2.0: Originally named `lor`
+ * @history v0.3.0: Renamed to `|`
+ */
 @unsafe
 provide let (|) = (x: Number, y: Number) => {
   let xw32 = WasmI32.fromGrain(x)
@@ -2301,6 +2389,18 @@ provide let (|) = (x: Number, y: Number) => {
   }
 }
 
+/**
+ * Computes the bitwise XOR (`^`) on the given operands.
+ *
+ * @param value1: The first operand
+ * @param value2: The second operand
+ * @returns Containing a `1` in each bit position for which the corresponding bits of either but not both operands are `1`
+ *
+ * @since v0.3.0
+ * @history v0.1.0: The `^` operator was originally an alias of `unbox`
+ * @history v0.2.0: Originally named `lxor`
+ * @history v0.3.0: Renamed to `^`
+ */
 @unsafe
 provide let (^) = (x: Number, y: Number) => {
   let xw32 = WasmI32.fromGrain(x)
@@ -2327,6 +2427,17 @@ provide let (^) = (x: Number, y: Number) => {
   }
 }
 
+/**
+ * Shifts the bits of the value right by the given number of bits.
+ *
+ * @param value: The value to shift
+ * @param amount: The amount to shift by
+ * @returns The shifted value
+ *
+ * @since v0.3.0
+ * @history v0.2.0: Originally named `asr`
+ * @history v0.3.0: Renamed to `>>`
+ */
 @unsafe
 provide let (>>) = (x: Number, y: Number) => {
   let xw32 = WasmI32.fromGrain(x)
@@ -2347,6 +2458,14 @@ provide let (>>) = (x: Number, y: Number) => {
 // [NOTE]: Coercion is a *conservative* process! For example, even if a float is 1.0,
 //         we will fail if attempting to coerce to an int!
 
+/**
+ * Converts a Number to an Int32.
+ *
+ * @param number: The value to convert
+ * @returns The Number represented as an Int32
+ *
+ * @since v0.2.0
+ */
 @unsafe
 provide let coerceNumberToInt32 = (x: Number) => {
   let x = WasmI32.fromGrain(x)
@@ -2366,6 +2485,14 @@ provide let coerceNumberToInt32 = (x: Number) => {
   WasmI32.toGrain(result): Int32
 }
 
+/**
+ * Converts a Number to an Int64.
+ *
+ * @param number: The value to convert
+ * @returns The Number represented as an Int64
+ *
+ * @since v0.2.0
+ */
 @unsafe
 provide let coerceNumberToInt64 = (x: Number) => {
   let x = WasmI32.fromGrain(x)
@@ -2384,6 +2511,14 @@ provide let coerceNumberToInt64 = (x: Number) => {
   WasmI32.toGrain(result): Int64
 }
 
+/**
+ * Converts a Number to a BigInt.
+ *
+ * @param number: The value to convert
+ * @returns The Number represented as a BigInt
+ *
+ * @since v0.5.0
+ */
 @unsafe
 provide let coerceNumberToBigInt = (x: Number) => {
   let x = WasmI32.fromGrain(x)
@@ -2429,6 +2564,14 @@ provide let coerceNumberToRational = (x: Number) => {
   WasmI32.toGrain(result): Rational
 }
 
+/**
+ * Converts a Number to a Float32.
+ *
+ * @param number: The value to convert
+ * @returns The Number represented as a Float32
+ *
+ * @since v0.2.0
+ */
 @unsafe
 provide let coerceNumberToFloat32 = (x: Number) => {
   let x = WasmI32.fromGrain(x)
@@ -2447,6 +2590,14 @@ provide let coerceNumberToFloat32 = (x: Number) => {
   WasmI32.toGrain(result): Float32
 }
 
+/**
+ * Converts a Number to a Float64.
+ *
+ * @param number: The value to convert
+ * @returns The Number represented as a Float64
+ *
+ * @since v0.2.0
+ */
 @unsafe
 provide let coerceNumberToFloat64 = (x: Number) => {
   let x = WasmI32.fromGrain(x)
@@ -2465,6 +2616,14 @@ provide let coerceNumberToFloat64 = (x: Number) => {
   WasmI32.toGrain(result): Float64
 }
 
+/**
+ * Converts an Int32 to a Number.
+ *
+ * @param value: The value to convert
+ * @returns The Int32 represented as a Number
+ *
+ * @since v0.2.0
+ */
 @unsafe
 provide let coerceInt32ToNumber = (x: Int32) => {
   WasmI32.toGrain(
@@ -2472,6 +2631,14 @@ provide let coerceInt32ToNumber = (x: Int32) => {
   ): Number
 }
 
+/**
+ * Converts an Int64 to a Number.
+ *
+ * @param value: The value to convert
+ * @returns The Int64 represented as a Number
+ *
+ * @since v0.2.0
+ */
 @unsafe
 provide let coerceInt64ToNumber = (x: Int64) => {
   WasmI32.toGrain(
@@ -2479,6 +2646,14 @@ provide let coerceInt64ToNumber = (x: Int64) => {
   ): Number
 }
 
+/**
+ * Converts a BigInt to a Number.
+ *
+ * @param num: The value to convert
+ * @returns The BigInt represented as a Number
+ *
+ * @since v0.5.0
+ */
 @unsafe
 provide let coerceBigIntToNumber = (x: BigInt) => {
   let x = WasmI32.fromGrain(x)
@@ -2504,6 +2679,14 @@ provide let coerceRationalToNumber = (x: Rational) => {
   }
 }
 
+/**
+ * Converts a Float32 to a Number.
+ *
+ * @param float: The value to convert
+ * @returns The Float32 represented as a Number
+ *
+ * @since v0.2.0
+ */
 @unsafe
 provide let coerceFloat32ToNumber = (x: Float32) => {
   WasmI32.toGrain(
@@ -2511,6 +2694,14 @@ provide let coerceFloat32ToNumber = (x: Float32) => {
   ): Number
 }
 
+/**
+ * Converts a Float64 to a Number.
+ *
+ * @param float: The value to convert
+ * @returns The Float64 represented as a Number
+ *
+ * @since v0.2.0
+ */
 @unsafe
 provide let coerceFloat64ToNumber = (x: Float64) => {
   let x = WasmI32.fromGrain(x)
@@ -2567,6 +2758,15 @@ provide let convertInexactToExact = (x: Number) => {
   WasmI32.toGrain(convertInexactToExactHelp(WasmI32.fromGrain(x))): Number
 }
 
+/**
+ * Computes the sum of its operands.
+ *
+ * @param num1: The first operand
+ * @param num2: The second operand
+ * @returns The sum of the two operands
+ *
+ * @since v0.1.0
+ */
 @unsafe
 provide let (+) = (x: Number, y: Number) => {
   let x = WasmI32.fromGrain(x)
@@ -2574,6 +2774,15 @@ provide let (+) = (x: Number, y: Number) => {
   numberAdd(x, y)
 }
 
+/**
+ * Computes the difference of its operands.
+ *
+ * @param num1: The first operand
+ * @param num2: The second operand
+ * @returns The difference of the two operands
+ *
+ * @since v0.1.0
+ */
 @unsafe
 provide let (-) = (x: Number, y: Number) => {
   let x = WasmI32.fromGrain(x)
@@ -2581,6 +2790,15 @@ provide let (-) = (x: Number, y: Number) => {
   numberSub(x, y)
 }
 
+/**
+ * Computes the product of its operands.
+ *
+ * @param num1: The first operand
+ * @param num2: The second operand
+ * @returns The product of the two operands
+ *
+ * @since v0.1.0
+ */
 @unsafe
 provide let (*) = (x: Number, y: Number) => {
   let x = WasmI32.fromGrain(x)
@@ -2588,6 +2806,15 @@ provide let (*) = (x: Number, y: Number) => {
   numberTimes(x, y)
 }
 
+/**
+ * Computes the quotient of its operands.
+ *
+ * @param num1: The first operand
+ * @param num2: The second operand
+ * @returns The quotient of the two operands
+ *
+ * @since v0.1.0
+ */
 @unsafe
 provide let (/) = (x: Number, y: Number) => {
   let x = WasmI32.fromGrain(x)
@@ -2595,6 +2822,16 @@ provide let (/) = (x: Number, y: Number) => {
   numberDivide(x, y)
 }
 
+/**
+ * Computes the remainder of the division of the first operand by the second.
+ * The result will have the sign of the second operand.
+ *
+ * @param num1: The first operand
+ * @param num2: The second operand
+ * @returns The modulus of its operands
+ *
+ * @since v0.1.0
+ */
 @unsafe
 provide let (%) = (x: Number, y: Number) => {
   let x = WasmI32.fromGrain(x)
@@ -2604,10 +2841,26 @@ provide let (%) = (x: Number, y: Number) => {
 
 // inc/dec
 
+/**
+ * Increments the value by one.
+ *
+ * @param value: The value to increment
+ * @returns The incremented value
+ *
+ * @since v0.1.0
+ */
 provide let incr = x => {
   x + 1
 }
 
+/**
+ * Decrements the value by one.
+ *
+ * @param value: The value to decrement
+ * @returns The decremented value
+ *
+ * @since v0.1.0
+ */
 provide let decr = x => {
   x - 1
 }

--- a/stdlib/runtime/numbers.md
+++ b/stdlib/runtime/numbers.md
@@ -146,27 +146,107 @@ cmp : (WasmI32, WasmI32) -> WasmI32
 
 ### Numbers.**(<)**
 
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
+
 ```grain
 (<) : (Number, Number) -> Bool
 ```
 
+Checks if the first operand is less than the second operand.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`num1`|`Number`|The first operand|
+|`num2`|`Number`|The second operand|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Bool`|`true` if the first operand is less than the second operand or `false` otherwise|
+
 ### Numbers.**(>)**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 (>) : (Number, Number) -> Bool
 ```
 
+Checks if the first operand is greater than the second operand.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`num1`|`Number`|The first operand|
+|`num2`|`Number`|The second operand|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Bool`|`true` if the first operand is greater than the second operand or `false` otherwise|
+
 ### Numbers.**(<=)**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 (<=) : (Number, Number) -> Bool
 ```
 
+Checks if the first operand is less than or equal to the second operand.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`num1`|`Number`|The first operand|
+|`num2`|`Number`|The second operand|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Bool`|`true` if the first operand is less than or equal to the second operand or `false` otherwise|
+
 ### Numbers.**(>=)**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 (>=) : (Number, Number) -> Bool
 ```
+
+Checks if the first operand is greater than or equal to the second operand.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`num1`|`Number`|The first operand|
+|`num2`|`Number`|The second operand|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Bool`|`true` if the first operand is greater than or equal to the second operand or `false` otherwise|
 
 ### Numbers.**compare**
 
@@ -182,63 +262,308 @@ numberEq : (Number, Number) -> Bool
 
 ### Numbers.**lnot**
 
+<details disabled>
+<summary tabindex="-1">Added in <code>0.2.0</code></summary>
+No other changes yet.
+</details>
+
 ```grain
 lnot : Number -> Number
 ```
 
+Computes the bitwise NOT of the operand.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`value`|`Number`|The operand|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|Containing the inverted bits of the operand|
+
 ### Numbers.**(<<)**
+
+<details>
+<summary>Added in <code>0.3.0</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally named `lsl`</td></tr>
+<tr><td><code>0.3.0</code></td><td>Renamed to `<<`</td></tr>
+</tbody>
+</table>
+</details>
 
 ```grain
 (<<) : (Number, Number) -> Number
 ```
 
+Shifts the bits of the value left by the given number of bits.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`value`|`Number`|The value to shift|
+|`amount`|`Number`|The number of bits to shift by|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The shifted value|
+
 ### Numbers.**(>>>)**
+
+<details>
+<summary>Added in <code>0.3.0</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally named `lsr`</td></tr>
+<tr><td><code>0.3.0</code></td><td>Renamed to `>>>`</td></tr>
+</tbody>
+</table>
+</details>
 
 ```grain
 (>>>) : (Number, Number) -> Number
 ```
 
+Shifts the bits of the value right by the given number of bits, preserving the sign bit.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`value`|`Number`|The value to shift|
+|`amount`|`Number`|The amount to shift by|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The shifted value|
+
 ### Numbers.**(&)**
+
+<details>
+<summary>Added in <code>0.3.0</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally named `land`</td></tr>
+<tr><td><code>0.3.0</code></td><td>Renamed to `&`</td></tr>
+</tbody>
+</table>
+</details>
 
 ```grain
 (&) : (Number, Number) -> Number
 ```
 
+Computes the bitwise AND (`&`) on the given operands.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`value1`|`Number`|The first operand|
+|`value2`|`Number`|The second operand|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|Containing a `1` in each bit position for which the corresponding bits of both operands are `1`|
+
 ### Numbers.**(|)**
+
+<details>
+<summary>Added in <code>0.3.0</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally named `lor`</td></tr>
+<tr><td><code>0.3.0</code></td><td>Renamed to `|`</td></tr>
+</tbody>
+</table>
+</details>
 
 ```grain
 (|) : (Number, Number) -> Number
 ```
 
+Computes the bitwise OR (`|`) on the given operands.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`value1`|`Number`|The first operand|
+|`value2`|`Number`|The second operand|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|Containing a `1` in each bit position for which the corresponding bits of either or both operands are `1`|
+
 ### Numbers.**(^)**
+
+<details>
+<summary>Added in <code>0.3.0</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.1.0</code></td><td>The `^` operator was originally an alias of `unbox`</td></tr>
+<tr><td><code>0.2.0</code></td><td>Originally named `lxor`</td></tr>
+<tr><td><code>0.3.0</code></td><td>Renamed to `^`</td></tr>
+</tbody>
+</table>
+</details>
 
 ```grain
 (^) : (Number, Number) -> Number
 ```
 
+Computes the bitwise XOR (`^`) on the given operands.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`value1`|`Number`|The first operand|
+|`value2`|`Number`|The second operand|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|Containing a `1` in each bit position for which the corresponding bits of either but not both operands are `1`|
+
 ### Numbers.**(>>)**
+
+<details>
+<summary>Added in <code>0.3.0</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally named `asr`</td></tr>
+<tr><td><code>0.3.0</code></td><td>Renamed to `>>`</td></tr>
+</tbody>
+</table>
+</details>
 
 ```grain
 (>>) : (Number, Number) -> Number
 ```
 
+Shifts the bits of the value right by the given number of bits.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`value`|`Number`|The value to shift|
+|`amount`|`Number`|The amount to shift by|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The shifted value|
+
 ### Numbers.**coerceNumberToInt32**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.2.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 coerceNumberToInt32 : Number -> Int32
 ```
 
+Converts a Number to an Int32.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`number`|`Number`|The value to convert|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Int32`|The Number represented as an Int32|
+
 ### Numbers.**coerceNumberToInt64**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.2.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 coerceNumberToInt64 : Number -> Int64
 ```
 
+Converts a Number to an Int64.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`number`|`Number`|The value to convert|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Int64`|The Number represented as an Int64|
+
 ### Numbers.**coerceNumberToBigInt**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 coerceNumberToBigInt : Number -> BigInt
 ```
+
+Converts a Number to a BigInt.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`number`|`Number`|The value to convert|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`BigInt`|The Number represented as a BigInt|
 
 ### Numbers.**coerceNumberToRational**
 
@@ -248,33 +573,128 @@ coerceNumberToRational : Number -> Rational
 
 ### Numbers.**coerceNumberToFloat32**
 
+<details disabled>
+<summary tabindex="-1">Added in <code>0.2.0</code></summary>
+No other changes yet.
+</details>
+
 ```grain
 coerceNumberToFloat32 : Number -> Float32
 ```
 
+Converts a Number to a Float32.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`number`|`Number`|The value to convert|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Float32`|The Number represented as a Float32|
+
 ### Numbers.**coerceNumberToFloat64**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.2.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 coerceNumberToFloat64 : Number -> Float64
 ```
 
+Converts a Number to a Float64.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`number`|`Number`|The value to convert|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Float64`|The Number represented as a Float64|
+
 ### Numbers.**coerceInt32ToNumber**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.2.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 coerceInt32ToNumber : Int32 -> Number
 ```
 
+Converts an Int32 to a Number.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`value`|`Int32`|The value to convert|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The Int32 represented as a Number|
+
 ### Numbers.**coerceInt64ToNumber**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.2.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 coerceInt64ToNumber : Int64 -> Number
 ```
 
+Converts an Int64 to a Number.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`value`|`Int64`|The value to convert|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The Int64 represented as a Number|
+
 ### Numbers.**coerceBigIntToNumber**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.5.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 coerceBigIntToNumber : BigInt -> Number
 ```
+
+Converts a BigInt to a Number.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`num`|`BigInt`|The value to convert|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The BigInt represented as a Number|
 
 ### Numbers.**coerceRationalToNumber**
 
@@ -284,15 +704,53 @@ coerceRationalToNumber : Rational -> Number
 
 ### Numbers.**coerceFloat32ToNumber**
 
+<details disabled>
+<summary tabindex="-1">Added in <code>0.2.0</code></summary>
+No other changes yet.
+</details>
+
 ```grain
 coerceFloat32ToNumber : Float32 -> Number
 ```
 
+Converts a Float32 to a Number.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`float`|`Float32`|The value to convert|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The Float32 represented as a Number|
+
 ### Numbers.**coerceFloat64ToNumber**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.2.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 coerceFloat64ToNumber : Float64 -> Number
 ```
+
+Converts a Float64 to a Number.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`float`|`Float64`|The value to convert|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The Float64 represented as a Number|
 
 ### Numbers.**convertExactToInexact**
 
@@ -308,45 +766,184 @@ convertInexactToExact : Number -> Number
 
 ### Numbers.**(+)**
 
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
+
 ```grain
 (+) : (Number, Number) -> Number
 ```
 
+Computes the sum of its operands.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`num1`|`Number`|The first operand|
+|`num2`|`Number`|The second operand|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The sum of the two operands|
+
 ### Numbers.**(-)**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 (-) : (Number, Number) -> Number
 ```
 
+Computes the difference of its operands.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`num1`|`Number`|The first operand|
+|`num2`|`Number`|The second operand|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The difference of the two operands|
+
 ### Numbers.**(*)**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 (*) : (Number, Number) -> Number
 ```
 
+Computes the product of its operands.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`num1`|`Number`|The first operand|
+|`num2`|`Number`|The second operand|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The product of the two operands|
+
 ### Numbers.**(/)**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 (/) : (Number, Number) -> Number
 ```
 
+Computes the quotient of its operands.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`num1`|`Number`|The first operand|
+|`num2`|`Number`|The second operand|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The quotient of the two operands|
+
 ### Numbers.**(%)**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 (%) : (Number, Number) -> Number
 ```
 
+Computes the remainder of the division of the first operand by the second.
+The result will have the sign of the second operand.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`num1`|`Number`|The first operand|
+|`num2`|`Number`|The second operand|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The modulus of its operands|
+
 ### Numbers.**incr**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 incr : Number -> Number
 ```
 
+Increments the value by one.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`value`|`Number`|The value to increment|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The incremented value|
+
 ### Numbers.**decr**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 decr : Number -> Number
 ```
+
+Decrements the value by one.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`value`|`Number`|The value to decrement|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The decremented value|
 
 ### Numbers.**isBigInt**
 

--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -202,6 +202,17 @@ let reverse = list => {
   iter(list, [])
 }
 
+/**
+ * Concatenate two strings.
+ *
+ * @param str1: The beginning string
+ * @param str2: The ending string
+ * @returns The combined string
+ *
+ * @example "Foo" ++ "Bar" == "FooBar"
+ *
+ * @since v0.2.0
+ */
 @unsafe
 provide let concat = (s1: String, s2: String) => {
   let ptr1 = WasmI32.fromGrain(s1)
@@ -657,12 +668,30 @@ recordToString = (ptr, recordArity, fields, contentOffset, extraIndents) => {
   join(strings)
 }
 
+/**
+ * Converts the given operand to a string.
+ * Provides a better representation of data types if those types are provided from the module.
+ *
+ * @param value: The operand
+ * @returns The operand, as a string
+ *
+ * @since v0.1.0
+ */
 @unsafe
 provide let toString = value => {
   let value = WasmI32.fromGrain(value)
   toStringHelp(value, 0n, true)
 }
 
+/**
+ * Prints the given operand to the console. Works for any type. Internally, calls `toString`
+ * on the operand, so a better representation of data type will be printed if those types
+ * are provided from the module.
+ *
+ * @param value: The operand
+ *
+ * @since v0.1.0
+ */
 @unsafe
 provide let print = value => {
   // First convert the value to string, if it isn't one already.

--- a/stdlib/runtime/string.md
+++ b/stdlib/runtime/string.md
@@ -8,19 +8,80 @@ Functions and constants included in the String module.
 
 ### String.**concat**
 
+<details disabled>
+<summary tabindex="-1">Added in <code>0.2.0</code></summary>
+No other changes yet.
+</details>
+
 ```grain
 concat : (String, String) -> String
 ```
 
+Concatenate two strings.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`str1`|`String`|The beginning string|
+|`str2`|`String`|The ending string|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`String`|The combined string|
+
+Examples:
+
+```grain
+"Foo" ++ "Bar" == "FooBar"
+```
+
 ### String.**toString**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 toString : a -> String
 ```
 
+Converts the given operand to a string.
+Provides a better representation of data types if those types are provided from the module.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`value`|`a`|The operand|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`String`|The operand, as a string|
+
 ### String.**print**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.1.0</code></summary>
+No other changes yet.
+</details>
 
 ```grain
 print : a -> Void
 ```
+
+Prints the given operand to the console. Works for any type. Internally, calls `toString`
+on the operand, so a better representation of data type will be printed if those types
+are provided from the module.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`value`|`a`|The operand|
 


### PR DESCRIPTION
Graindoc will now pull docs from the original definition of a value/type/module. This was enabled by adding all of the location information to the CMI. Note that each file that provides a value needs to be recompiled through the parse phase so we can get the parsed comments.

This is a breaking change to graindoc since it will **only** pull from the original definition. You can see that I had to move definitions into the runtime to make this work. That results in the docs existing in the runtime and then in the stdlib places they are re-provided.

This should also solve the problem @alex-snezhko brought up in discord since each thing being documented will pull the exact definition.

Closes #1626