### PR TITLE
chore(stdlib): Update `set`, `sort` & `rotate` examples in Array module

### DIFF
--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -148,9 +148,9 @@ provide let get = (index, array) => {
  * @param value: The value to store
  * @param array: The array to update
  * @example
- * let arr = [>3,2,1] 
- * Array.sort((a, b) => a - b, arr)
- * assert arr == [>1,2,3]
+ * let arr = [> 1, 2, 3, 4, 5] 
+ * Array.set(1, 9, arr)
+ * assert arr == [> 1, 9, 3, 4, 5]
  *
  * @since v0.1.0
  * @history v0.2.0: Argument order changed to data-last

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -147,6 +147,7 @@ provide let get = (index, array) => {
  * @param index: The index to update
  * @param value: The value to store
  * @param array: The array to update
+ *
  * @example
  * let array = [> 1, 2, 3, 4, 5] 
  * Array.set(1, 9, array)

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -960,9 +960,9 @@ provide let sort = (comp, array) => {
  * @param arr: The array to be rotated
  *
  * @example
- * let arr = [> 1, 2, 3, 4, 5]
- * Array.rotate(2, arr)
- * assert arr == [> 4, 5, 1, 2, 3]
+ * let array = [> 1, 2, 3, 4, 5]
+ * Array.rotate(2, array)
+ * assert array == [> 4, 5, 1, 2, 3]
  *
  * @example
  * let array = [> 1, 2, 3, 4, 5]

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -965,9 +965,9 @@ provide let sort = (comp, array) => {
  * assert arr == [> 4, 5, 1, 2, 3]
  *
  * @example
- * let arr = [> 1, 2, 3, 4, 5]
- * Array.rotate(-1, arr)
- * assert arr == [> 2, 3, 4, 5, 1]
+ * let array = [> 1, 2, 3, 4, 5]
+ * Array.rotate(-1, array)
+ * assert array == [> 2, 3, 4, 5, 1]
  * 
  * @since v0.4.5
  *

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -148,9 +148,9 @@ provide let get = (index, array) => {
  * @param value: The value to store
  * @param array: The array to update
  * @example
- * let arr = [> 1, 2, 3, 4, 5] 
- * Array.set(1, 9, arr)
- * assert arr == [> 1, 9, 3, 4, 5]
+ * let array = [> 1, 2, 3, 4, 5] 
+ * Array.set(1, 9, array)
+ * assert array == [> 1, 9, 3, 4, 5]
  *
  * @since v0.1.0
  * @history v0.2.0: Argument order changed to data-last

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -147,7 +147,10 @@ provide let get = (index, array) => {
  * @param index: The index to update
  * @param value: The value to store
  * @param array: The array to update
- * @example Array.set(1, 9, [> 1, 2, 3, 4, 5]) == [> 1, 9, 3, 4, 5]
+ * @example
+ * let arr = [>3,2,1] 
+ * Array.sort((a, b) => a - b, arr)
+ * assert arr == [>1,2,3]
  *
  * @since v0.1.0
  * @history v0.2.0: Argument order changed to data-last
@@ -910,6 +913,9 @@ provide let slice = (startIndex, endIndex, array) => {
  * Ordering is calculated using a comparator function which takes two array elements and must return 0 if both are equal, a positive number if the first is greater, and a negative number if the first is smaller.
  * @param comp: The comparator function used to indicate sort order
  * @param array: The array to be sorted
+ *
+ * @example Array.sort((a, b) => a - b, my_sort_array) //[> 9, 2, 5] becomes [> 2, 5, 9]
+ *
  * @since v0.4.5
  */
 provide let sort = (comp, array) => {
@@ -950,8 +956,8 @@ provide let sort = (comp, array) => {
  * @param n: The number of elements to rotate by
  * @param arr: The array to be rotated
  *
- * @example let array = [> 1, 2, 3, 4, 5]; rotate(2, arr); arr == [> 3, 4, 5, 1, 2]
- * @example let array = [> 1, 2, 3, 4, 5]; rotate(-1, arr); arr == [> 5, 1, 2, 3, 4]
+ * @example let my_rot_array = [> 1, 2, 3, 4, 5]; Array.rotate(2, my_rot_array) // [> 1, 2, 3, 4, 5] becomes [> 4, 5, 1, 2, 3]
+ * @example let array = [> 1, 2, 3, 4, 5]; Array.rotate(-1, my_rot_array2) // [> 1, 2, 3, 4, 5] becomes [> 2, 3, 4, 5, 1]
  * @since v0.4.5
  *
  * @history v0.6.0: Behavior changed from right-rotation to left-rotation

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -914,7 +914,10 @@ provide let slice = (startIndex, endIndex, array) => {
  * @param comp: The comparator function used to indicate sort order
  * @param array: The array to be sorted
  *
- * @example Array.sort((a, b) => a - b, my_sort_array) //[> 9, 2, 5] becomes [> 2, 5, 9]
+ * @example
+ * let arr = [>3,2,1]
+ * Array.sort((a, b) => a - b, arr)
+ * assert arr == [>1,2,3]
  *
  * @since v0.4.5
  */
@@ -956,8 +959,16 @@ provide let sort = (comp, array) => {
  * @param n: The number of elements to rotate by
  * @param arr: The array to be rotated
  *
- * @example let my_rot_array = [> 1, 2, 3, 4, 5]; Array.rotate(2, my_rot_array) // [> 1, 2, 3, 4, 5] becomes [> 4, 5, 1, 2, 3]
- * @example let array = [> 1, 2, 3, 4, 5]; Array.rotate(-1, my_rot_array2) // [> 1, 2, 3, 4, 5] becomes [> 2, 3, 4, 5, 1]
+ * @example
+ * let arr = [> 1, 2, 3, 4, 5]
+ * Array.rotate(2, arr)
+ * assert arr == [> 4, 5, 1, 2, 3]
+ *
+ * @example
+ * let arr = [> 1, 2, 3, 4, 5]
+ * Array.rotate(-1, arr)
+ * assert arr == [> 2, 3, 4, 5, 1]
+ * 
  * @since v0.4.5
  *
  * @history v0.6.0: Behavior changed from right-rotation to left-rotation

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -915,9 +915,9 @@ provide let slice = (startIndex, endIndex, array) => {
  * @param array: The array to be sorted
  *
  * @example
- * let arr = [>3,2,1]
- * Array.sort((a, b) => a - b, arr)
- * assert arr == [>1,2,3]
+ * let array = [> 3, 2, 1]
+ * Array.sort(compare, array)
+ * assert array == [> 1, 2, 3]
  *
  * @since v0.4.5
  */

--- a/stdlib/array.md
+++ b/stdlib/array.md
@@ -213,7 +213,9 @@ Parameters:
 Examples:
 
 ```grain
-Array.set(1, 9, [> 1, 2, 3, 4, 5]) == [> 1, 9, 3, 4, 5]
+let array = [> 1, 2, 3, 4, 5] 
+Array.set(1, 9, array)
+assert array == [> 1, 9, 3, 4, 5]
 ```
 
 ### Array.**append**
@@ -1187,6 +1189,14 @@ Parameters:
 |`comp`|`(a, a) -> Number`|The comparator function used to indicate sort order|
 |`array`|`Array<a>`|The array to be sorted|
 
+Examples:
+
+```grain
+let array = [> 3, 2, 1]
+Array.sort(compare, array)
+assert array == [> 1, 2, 3]
+```
+
 ### Array.**rotate**
 
 <details>
@@ -1221,10 +1231,14 @@ Parameters:
 Examples:
 
 ```grain
-let array = [> 1, 2, 3, 4, 5]; rotate(2, arr); arr == [> 3, 4, 5, 1, 2]
+let array = [> 1, 2, 3, 4, 5]
+Array.rotate(2, array)
+assert array == [> 4, 5, 1, 2, 3]
 ```
 
 ```grain
-let array = [> 1, 2, 3, 4, 5]; rotate(-1, arr); arr == [> 5, 1, 2, 3, 4]
+let array = [> 1, 2, 3, 4, 5]
+Array.rotate(-1, array)
+assert array == [> 2, 3, 4, 5, 1]
 ```
 


### PR DESCRIPTION
Updated `Array.set`, `Array.sort`, and `Array.rotate` to working multi-line examples.