### PR TITLE
fix(graindoc): Use Markdown bold helper for each case of bolding

### DIFF
--- a/compiler/graindoc/docblock.re
+++ b/compiler/graindoc/docblock.re
@@ -116,7 +116,7 @@ let () =
 let title_for_api = (~module_namespace, name) => {
   switch (module_namespace) {
   | Some(module_namespace) =>
-    Format.sprintf("%s.**%s**", module_namespace, name)
+    Format.sprintf("%s.%s", module_namespace, Markdown.bold(name))
   | None => name
   };
 };


### PR DESCRIPTION
In #1685, I added the fix for escaping values; however, when @spotandjake generated his docs in #1690 the fix wasn't applied. I traced it down to this line not using the markdown helpers and trying to do bolding itself.