### PR TITLE
feat(stdlib): Add `asin`, `acos`, `atan`, `isClose` to Number module

### DIFF
--- a/compiler/test/stdlib/number.test.gr
+++ b/compiler/test/stdlib/number.test.gr
@@ -326,6 +326,8 @@ assert Number.isClose(-0, 0.000000001, None, Some(1e-9))
 assert Number.isClose(1.1, 1.10000001, None, Some(1e-9)) == false
 assert Number.isClose(1.1, 1.100000001, None, Some(1e-9))
 assert Number.isClose(Infinity, Infinity, None, None)
+assert Number.isClose(-Infinity, -Infinity, None, None)
+assert Number.isClose(Infinity, -Infinity, None, None) == false
 assert Number.isClose(NaN, NaN, None, None) == false
 assert Number.isClose(Infinity, 99999999999999999, None, None) == false
 

--- a/compiler/test/stdlib/number.test.gr
+++ b/compiler/test/stdlib/number.test.gr
@@ -719,10 +719,26 @@ assert Number.isClose(
   -0.746077811411067326,
   relativeTolerance=1e-9
 )
-assert Number.isClose(Number.asin(1.0), 1.57079632679489656, relativeTolerance=1e-9)
-assert Number.isClose(Number.asin(1), 1.57079632679489656, relativeTolerance=1e-9)
-assert Number.isClose(Number.asin(-1.0), -1.57079632679489656, relativeTolerance=1e-9)
-assert Number.isClose(Number.asin(-1), -1.57079632679489656, relativeTolerance=1e-9)
+assert Number.isClose(
+  Number.asin(1.0),
+  1.57079632679489656,
+  relativeTolerance=1e-9
+)
+assert Number.isClose(
+  Number.asin(1),
+  1.57079632679489656,
+  relativeTolerance=1e-9
+)
+assert Number.isClose(
+  Number.asin(-1.0),
+  -1.57079632679489656,
+  relativeTolerance=1e-9
+)
+assert Number.isClose(
+  Number.asin(-1),
+  -1.57079632679489656,
+  relativeTolerance=1e-9
+)
 assert Number.asin(0) == 0.0
 assert Number.asin(0.0) == 0.0
 assert Number.asin(-0.0) == -0.0
@@ -793,7 +809,11 @@ assert Number.isClose(
   -0.386186417755213118,
   relativeTolerance=1e-9
 )
-assert Number.isClose(Number.atan(1/2), 0.4636476090008061, relativeTolerance=1e-9)
+assert Number.isClose(
+  Number.atan(1/2),
+  0.4636476090008061,
+  relativeTolerance=1e-9
+)
 assert Number.isClose(
   Number.atan(0.77415229659130369),
   0.658780243165382196,
@@ -811,8 +831,16 @@ assert Number.isClose(Number.atan(-1), Number.pi / -4, relativeTolerance=1e-9)
 assert Number.atan(0) == 0.0
 assert Number.atan(0.0) == 0.0
 assert Number.atan(-0.0) == -0.0
-assert Number.isClose(Number.atan(Infinity), Number.pi / 2, relativeTolerance=1e-9)
-assert Number.isClose(Number.atan(-Infinity), Number.pi / -2, relativeTolerance=1e-9)
+assert Number.isClose(
+  Number.atan(Infinity),
+  Number.pi / 2,
+  relativeTolerance=1e-9
+)
+assert Number.isClose(
+  Number.atan(-Infinity),
+  Number.pi / -2,
+  relativeTolerance=1e-9
+)
 assert Number.isNaN(Number.atan(NaN))
 
 // Number.gamma

--- a/compiler/test/stdlib/number.test.gr
+++ b/compiler/test/stdlib/number.test.gr
@@ -303,6 +303,32 @@ assert Number.neg(BI.toNumber(-1234t)) == BI.toNumber(1234t)
 assert Number.isNaN(-NaN)
 assert Number.neg(Infinity) == -Infinity
 
+// Number.isClose
+assert Number.isClose(1.0, 1.0, None, None)
+assert Number.isClose(1.0, 1.0, Some(0.5), Some(0.5))
+assert Number.isClose(1.0, 1.0, Some(0), Some(0))
+assert Number.isClose(0.0, 0.0, None, None)
+assert Number.isClose(0.0, 0.0, Some(0.5), Some(0.5))
+assert Number.isClose(0.0, 0.0, Some(0), Some(0))
+assert Number.isClose(1, 1, None, None)
+assert Number.isClose(1, 1, Some(0.5), Some(0.5))
+assert Number.isClose(1, 1, Some(0), Some(0))
+assert Number.isClose(1/2, 1/2, None, None)
+assert Number.isClose(1/2, 1/2, Some(0.5), Some(0.5))
+assert Number.isClose(1/2, 1/2, Some(0), Some(0))
+assert Number.isClose(0, 0.1, None, None) == false
+assert Number.isClose(0, 0.000000001, None, None) == false
+assert Number.isClose(0, 0.00000001, None, Some(1e-9)) == false
+assert Number.isClose(0, 0.000000001, None, Some(1e-9))
+assert Number.isClose(-0, 0.000000001, None, None) == false
+assert Number.isClose(-0, 0.00000001, None, Some(1e-9)) == false
+assert Number.isClose(-0, 0.000000001, None, Some(1e-9))
+assert Number.isClose(1.1, 1.10000001, None, Some(1e-9)) == false
+assert Number.isClose(1.1, 1.100000001, None, Some(1e-9))
+assert Number.isClose(Infinity, Infinity, None, None)
+assert Number.isClose(NaN, NaN, None, None) == false
+assert Number.isClose(Infinity, 99999999999999999, None, None) == false
+
 // isFloat
 assert Number.isFloat(0.0)
 assert Number.isFloat(1.5)
@@ -657,6 +683,107 @@ assert Number.tan(1/2) > 0.5463 && Number.tan(1/2) < 0.5464
 assert Number.isNaN(Number.tan(9223372036854775809))
 assert Number.isNaN(Number.tan(Infinity))
 assert Number.isNaN(Number.tan(NaN))
+
+// Number.asin
+assert Number.isNaN(Number.asin(-8.06684839057968084))
+assert Number.isNaN(Number.asin(-1.1))
+assert Number.isNaN(Number.asin(4.06684839057968084))
+assert Number.isNaN(Number.asin(1.1))
+assert Number.isNaN(Number.asin(15/10))
+assert Number.isNaN(Number.asin(-15/10))
+assert Number.isClose(
+  Number.asin(0.661985898099504477),
+  0.723465243951545878,
+  Some(1e-9),
+  None
+)
+assert Number.isClose(
+  Number.asin(0.56175974622072411),
+  0.596511362227406194,
+  Some(1e-9),
+  None
+)
+assert Number.isClose(
+  Number.asin(-0.40660392238535531),
+  -0.418733744293772248,
+  Some(1e-9),
+  None
+)
+assert Number.isClose(Number.asin(1/2), Number.pi / 6, Some(1e-9), None)
+assert Number.isClose(
+  Number.asin(0.77415229659130369),
+  0.885374810931274348,
+  Some(1e-9),
+  None
+)
+assert Number.isClose(
+  Number.asin(-0.678763702639402444),
+  -0.746077811411067326,
+  Some(1e-9),
+  None
+)
+assert Number.isClose(Number.asin(1.0), 1.57079632679489656, Some(1e-9), None)
+assert Number.isClose(Number.asin(1), 1.57079632679489656, Some(1e-9), None)
+assert Number.isClose(Number.asin(-1.0), -1.57079632679489656, Some(1e-9), None)
+assert Number.isClose(Number.asin(-1), -1.57079632679489656, Some(1e-9), None)
+assert Number.asin(0) == 0.0
+assert Number.asin(0.0) == 0.0
+assert Number.asin(-0.0) == -0.0
+assert Number.isNaN(Number.asin(1.00000000000000022))
+assert Number.isNaN(Number.asin(-1.00000000000000022))
+assert Number.isNaN(Number.asin(Infinity))
+assert Number.isNaN(Number.asin(-Infinity))
+assert Number.isNaN(Number.asin(NaN))
+
+// Number.acos
+assert Number.isNaN(Number.acos(-8.06684839057968084))
+assert Number.isNaN(Number.acos(-1.1))
+assert Number.isNaN(Number.acos(4.06684839057968084))
+assert Number.isNaN(Number.acos(1.1))
+assert Number.isNaN(Number.acos(15/10))
+assert Number.isNaN(Number.acos(-15/10))
+assert Number.isClose(
+  Number.acos(0.661985898099504477),
+  0.84733108284335068,
+  Some(1e-9),
+  None
+)
+assert Number.isClose(
+  Number.acos(0.56175974622072411),
+  0.974284964567490364,
+  Some(1e-9),
+  None
+)
+assert Number.isClose(
+  Number.acos(-0.40660392238535531),
+  1.98953007108866897,
+  Some(1e-9),
+  None
+)
+assert Number.isClose(Number.acos(1/2), Number.pi / 3, Some(1e-9), None)
+assert Number.isClose(
+  Number.acos(0.77415229659130369),
+  0.68542151586362221,
+  Some(1e-9),
+  None
+)
+assert Number.isClose(
+  Number.acos(-0.678763702639402444),
+  2.31687413820596388,
+  Some(1e-9),
+  None
+)
+assert Number.isClose(Number.acos(-1.0), Number.pi, Some(1e-9), None)
+assert Number.isClose(Number.acos(-1), Number.pi, Some(1e-9), None)
+assert Number.isClose(Number.acos(0.0), Number.pi / 2, Some(1e-9), None)
+assert Number.isClose(Number.acos(0), Number.pi / 2, Some(1e-9), None)
+assert Number.acos(1) == 0.0
+assert Number.acos(1.0) == 0.0
+assert Number.isNaN(Number.acos(1.00000000000000022))
+assert Number.isNaN(Number.acos(-1.00000000000000022))
+assert Number.isNaN(Number.acos(Infinity))
+assert Number.isNaN(Number.acos(-Infinity))
+assert Number.isNaN(Number.acos(NaN))
 
 // Number.gamma
 // Note: Currently gamma will overflow the memory when using a bigint as such there are no tests for this

--- a/compiler/test/stdlib/number.test.gr
+++ b/compiler/test/stdlib/number.test.gr
@@ -303,34 +303,6 @@ assert Number.neg(BI.toNumber(-1234t)) == BI.toNumber(1234t)
 assert Number.isNaN(-NaN)
 assert Number.neg(Infinity) == -Infinity
 
-// Number.isClose
-assert Number.isClose(1.0, 1.0)
-assert Number.isClose(1.0, 1.0, rel_tol=0.5, abs_tol=0.5)
-assert Number.isClose(1.0, 1.0, rel_tol=0, abs_tol=0)
-assert Number.isClose(0.0, 0.0)
-assert Number.isClose(0.0, 0.0, rel_tol=0.5, abs_tol=0.5)
-assert Number.isClose(0.0, 0.0, rel_tol=0, abs_tol=0)
-assert Number.isClose(1, 1)
-assert Number.isClose(1, 1, rel_tol=0.5, abs_tol=0.5)
-assert Number.isClose(1, 1, rel_tol=0, abs_tol=0)
-assert Number.isClose(1/2, 1/2)
-assert Number.isClose(1/2, 1/2, rel_tol=0.5, abs_tol=0.5)
-assert Number.isClose(1/2, 1/2, rel_tol=0, abs_tol=0)
-assert Number.isClose(0, 0.1) == false
-assert Number.isClose(0, 0.000000001) == false
-assert Number.isClose(0, 0.00000001, abs_tol=1e-9) == false
-assert Number.isClose(0, 0.000000001, abs_tol=1e-9)
-assert Number.isClose(-0, 0.000000001) == false
-assert Number.isClose(-0, 0.00000001, abs_tol=1e-9) == false
-assert Number.isClose(-0, 0.000000001, abs_tol=1e-9)
-assert Number.isClose(1.1, 1.10000001, abs_tol=1e-9) == false
-assert Number.isClose(1.1, 1.100000001, abs_tol=1e-9)
-assert Number.isClose(Infinity, Infinity)
-assert Number.isClose(-Infinity, -Infinity)
-assert Number.isClose(Infinity, -Infinity) == false
-assert Number.isClose(NaN, NaN) == false
-assert Number.isClose(Infinity, 99999999999999999) == false
-
 // isFloat
 assert Number.isFloat(0.0)
 assert Number.isFloat(1.5)
@@ -413,6 +385,34 @@ assert Number.isInfinite(-25.00) == false
 assert Number.isInfinite(1/2) == false
 assert Number.isInfinite(-1/2) == false
 assert Number.isInfinite(BI.toNumber(-1t)) == false
+
+// Number.isClose
+assert Number.isClose(1.0, 1.0)
+assert Number.isClose(1.0, 1.0, relativeTolerance=0.5, absoluteTolerance=0.5)
+assert Number.isClose(1.0, 1.0, relativeTolerance=0, absoluteTolerance=0)
+assert Number.isClose(0.0, 0.0)
+assert Number.isClose(0.0, 0.0, relativeTolerance=0.5, absoluteTolerance=0.5)
+assert Number.isClose(0.0, 0.0, relativeTolerance=0, absoluteTolerance=0)
+assert Number.isClose(1, 1)
+assert Number.isClose(1, 1, relativeTolerance=0.5, absoluteTolerance=0.5)
+assert Number.isClose(1, 1, relativeTolerance=0, absoluteTolerance=0)
+assert Number.isClose(1/2, 1/2)
+assert Number.isClose(1/2, 1/2, relativeTolerance=0.5, absoluteTolerance=0.5)
+assert Number.isClose(1/2, 1/2, relativeTolerance=0, absoluteTolerance=0)
+assert Number.isClose(0, 0.1) == false
+assert Number.isClose(0, 0.000000001) == false
+assert Number.isClose(0, 0.00000001, absoluteTolerance=1e-9) == false
+assert Number.isClose(0, 0.000000001, absoluteTolerance=1e-9)
+assert Number.isClose(-0, 0.000000001) == false
+assert Number.isClose(-0, 0.00000001, absoluteTolerance=1e-9) == false
+assert Number.isClose(-0, 0.000000001, absoluteTolerance=1e-9)
+assert Number.isClose(1.1, 1.10000001, absoluteTolerance=1e-9) == false
+assert Number.isClose(1.1, 1.100000001, absoluteTolerance=1e-9)
+assert Number.isClose(Infinity, Infinity)
+assert Number.isClose(-Infinity, -Infinity)
+assert Number.isClose(Infinity, -Infinity) == false
+assert Number.isClose(NaN, NaN) == false
+assert Number.isClose(Infinity, 99999999999999999) == false
 
 // parseFloat
 // tests taken from Go's /src/strconv/atof_test.go
@@ -696,33 +696,33 @@ assert Number.isNaN(Number.asin(-15/10))
 assert Number.isClose(
   Number.asin(0.661985898099504477),
   0.723465243951545878,
-  rel_tol=1e-9
+  relativeTolerance=1e-9
 )
 assert Number.isClose(
   Number.asin(0.56175974622072411),
   0.596511362227406194,
-  rel_tol=1e-9
+  relativeTolerance=1e-9
 )
 assert Number.isClose(
   Number.asin(-0.40660392238535531),
   -0.418733744293772248,
-  rel_tol=1e-9
+  relativeTolerance=1e-9
 )
-assert Number.isClose(Number.asin(1/2), Number.pi / 6, rel_tol=1e-9)
+assert Number.isClose(Number.asin(1/2), Number.pi / 6, relativeTolerance=1e-9)
 assert Number.isClose(
   Number.asin(0.77415229659130369),
   0.885374810931274348,
-  rel_tol=1e-9
+  relativeTolerance=1e-9
 )
 assert Number.isClose(
   Number.asin(-0.678763702639402444),
   -0.746077811411067326,
-  rel_tol=1e-9
+  relativeTolerance=1e-9
 )
-assert Number.isClose(Number.asin(1.0), 1.57079632679489656, rel_tol=1e-9)
-assert Number.isClose(Number.asin(1), 1.57079632679489656, rel_tol=1e-9)
-assert Number.isClose(Number.asin(-1.0), -1.57079632679489656, rel_tol=1e-9)
-assert Number.isClose(Number.asin(-1), -1.57079632679489656, rel_tol=1e-9)
+assert Number.isClose(Number.asin(1.0), 1.57079632679489656, relativeTolerance=1e-9)
+assert Number.isClose(Number.asin(1), 1.57079632679489656, relativeTolerance=1e-9)
+assert Number.isClose(Number.asin(-1.0), -1.57079632679489656, relativeTolerance=1e-9)
+assert Number.isClose(Number.asin(-1), -1.57079632679489656, relativeTolerance=1e-9)
 assert Number.asin(0) == 0.0
 assert Number.asin(0.0) == 0.0
 assert Number.asin(-0.0) == -0.0
@@ -742,33 +742,33 @@ assert Number.isNaN(Number.acos(-15/10))
 assert Number.isClose(
   Number.acos(0.661985898099504477),
   0.84733108284335068,
-  rel_tol=1e-9
+  relativeTolerance=1e-9
 )
 assert Number.isClose(
   Number.acos(0.56175974622072411),
   0.974284964567490364,
-  rel_tol=1e-9
+  relativeTolerance=1e-9
 )
 assert Number.isClose(
   Number.acos(-0.40660392238535531),
   1.98953007108866897,
-  rel_tol=1e-9
+  relativeTolerance=1e-9
 )
-assert Number.isClose(Number.acos(1/2), Number.pi / 3, rel_tol=1e-9)
+assert Number.isClose(Number.acos(1/2), Number.pi / 3, relativeTolerance=1e-9)
 assert Number.isClose(
   Number.acos(0.77415229659130369),
   0.68542151586362221,
-  rel_tol=1e-9
+  relativeTolerance=1e-9
 )
 assert Number.isClose(
   Number.acos(-0.678763702639402444),
   2.31687413820596388,
-  rel_tol=1e-9
+  relativeTolerance=1e-9
 )
-assert Number.isClose(Number.acos(-1.0), Number.pi, rel_tol=1e-9)
-assert Number.isClose(Number.acos(-1), Number.pi, rel_tol=1e-9)
-assert Number.isClose(Number.acos(0.0), Number.pi / 2, rel_tol=1e-9)
-assert Number.isClose(Number.acos(0), Number.pi / 2, rel_tol=1e-9)
+assert Number.isClose(Number.acos(-1.0), Number.pi, relativeTolerance=1e-9)
+assert Number.isClose(Number.acos(-1), Number.pi, relativeTolerance=1e-9)
+assert Number.isClose(Number.acos(0.0), Number.pi / 2, relativeTolerance=1e-9)
+assert Number.isClose(Number.acos(0), Number.pi / 2, relativeTolerance=1e-9)
 assert Number.acos(1) == 0.0
 assert Number.acos(1.0) == 0.0
 assert Number.isNaN(Number.acos(1.00000000000000022))
@@ -781,38 +781,38 @@ assert Number.isNaN(Number.acos(NaN))
 assert Number.isClose(
   Number.atan(0.661985898099504477),
   0.584755067023832509,
-  rel_tol=1e-9
+  relativeTolerance=1e-9
 )
 assert Number.isClose(
   Number.atan(0.56175974622072411),
   0.511826953162888065,
-  rel_tol=1e-9
+  relativeTolerance=1e-9
 )
 assert Number.isClose(
   Number.atan(-0.40660392238535531),
   -0.386186417755213118,
-  rel_tol=1e-9
+  relativeTolerance=1e-9
 )
-assert Number.isClose(Number.atan(1/2), 0.4636476090008061, rel_tol=1e-9)
+assert Number.isClose(Number.atan(1/2), 0.4636476090008061, relativeTolerance=1e-9)
 assert Number.isClose(
   Number.atan(0.77415229659130369),
   0.658780243165382196,
-  rel_tol=1e-9
+  relativeTolerance=1e-9
 )
 assert Number.isClose(
   Number.atan(-0.678763702639402444),
   -0.596330782697347184,
-  rel_tol=1e-9
+  relativeTolerance=1e-9
 )
-assert Number.isClose(Number.atan(1.0), Number.pi / 4, rel_tol=1e-9)
-assert Number.isClose(Number.atan(1), Number.pi / 4, rel_tol=1e-9)
-assert Number.isClose(Number.atan(-1.0), Number.pi / -4, rel_tol=1e-9)
-assert Number.isClose(Number.atan(-1), Number.pi / -4, rel_tol=1e-9)
+assert Number.isClose(Number.atan(1.0), Number.pi / 4, relativeTolerance=1e-9)
+assert Number.isClose(Number.atan(1), Number.pi / 4, relativeTolerance=1e-9)
+assert Number.isClose(Number.atan(-1.0), Number.pi / -4, relativeTolerance=1e-9)
+assert Number.isClose(Number.atan(-1), Number.pi / -4, relativeTolerance=1e-9)
 assert Number.atan(0) == 0.0
 assert Number.atan(0.0) == 0.0
 assert Number.atan(-0.0) == -0.0
-assert Number.isClose(Number.atan(Infinity), Number.pi / 2, rel_tol=1e-9)
-assert Number.isClose(Number.atan(-Infinity), Number.pi / -2, rel_tol=1e-9)
+assert Number.isClose(Number.atan(Infinity), Number.pi / 2, relativeTolerance=1e-9)
+assert Number.isClose(Number.atan(-Infinity), Number.pi / -2, relativeTolerance=1e-9)
 assert Number.isNaN(Number.atan(NaN))
 
 // Number.gamma

--- a/compiler/test/stdlib/number.test.gr
+++ b/compiler/test/stdlib/number.test.gr
@@ -787,6 +787,49 @@ assert Number.isNaN(Number.acos(Infinity))
 assert Number.isNaN(Number.acos(-Infinity))
 assert Number.isNaN(Number.acos(NaN))
 
+// Number.atan
+assert Number.isClose(
+  Number.atan(0.661985898099504477),
+  0.584755067023832509,
+  Some(1e-9),
+  None
+)
+assert Number.isClose(
+  Number.atan(0.56175974622072411),
+  0.511826953162888065,
+  Some(1e-9),
+  None
+)
+assert Number.isClose(
+  Number.atan(-0.40660392238535531),
+  -0.386186417755213118,
+  Some(1e-9),
+  None
+)
+assert Number.isClose(Number.atan(1/2), 0.4636476090008061, Some(1e-9), None)
+assert Number.isClose(
+  Number.atan(0.77415229659130369),
+  0.658780243165382196,
+  Some(1e-9),
+  None
+)
+assert Number.isClose(
+  Number.atan(-0.678763702639402444),
+  -0.596330782697347184,
+  Some(1e-9),
+  None
+)
+assert Number.isClose(Number.atan(1.0), Number.pi / 4, Some(1e-9), None)
+assert Number.isClose(Number.atan(1), Number.pi / 4, Some(1e-9), None)
+assert Number.isClose(Number.atan(-1.0), Number.pi / -4, Some(1e-9), None)
+assert Number.isClose(Number.atan(-1), Number.pi / -4, Some(1e-9), None)
+assert Number.atan(0) == 0.0
+assert Number.atan(0.0) == 0.0
+assert Number.atan(-0.0) == -0.0
+assert Number.isClose(Number.atan(Infinity), Number.pi / 2, Some(1e-9), None)
+assert Number.isClose(Number.atan(-Infinity), Number.pi / -2, Some(1e-9), None)
+assert Number.isNaN(Number.atan(NaN))
+
 // Number.gamma
 // Note: Currently gamma will overflow the memory when using a bigint as such there are no tests for this
 assert Number.gamma(10.5) < 1133278.3889488 &&

--- a/compiler/test/stdlib/number.test.gr
+++ b/compiler/test/stdlib/number.test.gr
@@ -304,32 +304,32 @@ assert Number.isNaN(-NaN)
 assert Number.neg(Infinity) == -Infinity
 
 // Number.isClose
-assert Number.isClose(1.0, 1.0, None, None)
-assert Number.isClose(1.0, 1.0, Some(0.5), Some(0.5))
-assert Number.isClose(1.0, 1.0, Some(0), Some(0))
-assert Number.isClose(0.0, 0.0, None, None)
-assert Number.isClose(0.0, 0.0, Some(0.5), Some(0.5))
-assert Number.isClose(0.0, 0.0, Some(0), Some(0))
-assert Number.isClose(1, 1, None, None)
-assert Number.isClose(1, 1, Some(0.5), Some(0.5))
-assert Number.isClose(1, 1, Some(0), Some(0))
-assert Number.isClose(1/2, 1/2, None, None)
-assert Number.isClose(1/2, 1/2, Some(0.5), Some(0.5))
-assert Number.isClose(1/2, 1/2, Some(0), Some(0))
-assert Number.isClose(0, 0.1, None, None) == false
-assert Number.isClose(0, 0.000000001, None, None) == false
-assert Number.isClose(0, 0.00000001, None, Some(1e-9)) == false
-assert Number.isClose(0, 0.000000001, None, Some(1e-9))
-assert Number.isClose(-0, 0.000000001, None, None) == false
-assert Number.isClose(-0, 0.00000001, None, Some(1e-9)) == false
-assert Number.isClose(-0, 0.000000001, None, Some(1e-9))
-assert Number.isClose(1.1, 1.10000001, None, Some(1e-9)) == false
-assert Number.isClose(1.1, 1.100000001, None, Some(1e-9))
-assert Number.isClose(Infinity, Infinity, None, None)
-assert Number.isClose(-Infinity, -Infinity, None, None)
-assert Number.isClose(Infinity, -Infinity, None, None) == false
-assert Number.isClose(NaN, NaN, None, None) == false
-assert Number.isClose(Infinity, 99999999999999999, None, None) == false
+assert Number.isClose(1.0, 1.0)
+assert Number.isClose(1.0, 1.0, rel_tol=0.5, abs_tol=0.5)
+assert Number.isClose(1.0, 1.0, rel_tol=0, abs_tol=0)
+assert Number.isClose(0.0, 0.0)
+assert Number.isClose(0.0, 0.0, rel_tol=0.5, abs_tol=0.5)
+assert Number.isClose(0.0, 0.0, rel_tol=0, abs_tol=0)
+assert Number.isClose(1, 1)
+assert Number.isClose(1, 1, rel_tol=0.5, abs_tol=0.5)
+assert Number.isClose(1, 1, rel_tol=0, abs_tol=0)
+assert Number.isClose(1/2, 1/2)
+assert Number.isClose(1/2, 1/2, rel_tol=0.5, abs_tol=0.5)
+assert Number.isClose(1/2, 1/2, rel_tol=0, abs_tol=0)
+assert Number.isClose(0, 0.1) == false
+assert Number.isClose(0, 0.000000001) == false
+assert Number.isClose(0, 0.00000001, abs_tol=1e-9) == false
+assert Number.isClose(0, 0.000000001, abs_tol=1e-9)
+assert Number.isClose(-0, 0.000000001) == false
+assert Number.isClose(-0, 0.00000001, abs_tol=1e-9) == false
+assert Number.isClose(-0, 0.000000001, abs_tol=1e-9)
+assert Number.isClose(1.1, 1.10000001, abs_tol=1e-9) == false
+assert Number.isClose(1.1, 1.100000001, abs_tol=1e-9)
+assert Number.isClose(Infinity, Infinity)
+assert Number.isClose(-Infinity, -Infinity)
+assert Number.isClose(Infinity, -Infinity) == false
+assert Number.isClose(NaN, NaN) == false
+assert Number.isClose(Infinity, 99999999999999999) == false
 
 // isFloat
 assert Number.isFloat(0.0)
@@ -696,38 +696,33 @@ assert Number.isNaN(Number.asin(-15/10))
 assert Number.isClose(
   Number.asin(0.661985898099504477),
   0.723465243951545878,
-  Some(1e-9),
-  None
+  rel_tol=1e-9
 )
 assert Number.isClose(
   Number.asin(0.56175974622072411),
   0.596511362227406194,
-  Some(1e-9),
-  None
+  rel_tol=1e-9
 )
 assert Number.isClose(
   Number.asin(-0.40660392238535531),
   -0.418733744293772248,
-  Some(1e-9),
-  None
+  rel_tol=1e-9
 )
-assert Number.isClose(Number.asin(1/2), Number.pi / 6, Some(1e-9), None)
+assert Number.isClose(Number.asin(1/2), Number.pi / 6, rel_tol=1e-9)
 assert Number.isClose(
   Number.asin(0.77415229659130369),
   0.885374810931274348,
-  Some(1e-9),
-  None
+  rel_tol=1e-9
 )
 assert Number.isClose(
   Number.asin(-0.678763702639402444),
   -0.746077811411067326,
-  Some(1e-9),
-  None
+  rel_tol=1e-9
 )
-assert Number.isClose(Number.asin(1.0), 1.57079632679489656, Some(1e-9), None)
-assert Number.isClose(Number.asin(1), 1.57079632679489656, Some(1e-9), None)
-assert Number.isClose(Number.asin(-1.0), -1.57079632679489656, Some(1e-9), None)
-assert Number.isClose(Number.asin(-1), -1.57079632679489656, Some(1e-9), None)
+assert Number.isClose(Number.asin(1.0), 1.57079632679489656, rel_tol=1e-9)
+assert Number.isClose(Number.asin(1), 1.57079632679489656, rel_tol=1e-9)
+assert Number.isClose(Number.asin(-1.0), -1.57079632679489656, rel_tol=1e-9)
+assert Number.isClose(Number.asin(-1), -1.57079632679489656, rel_tol=1e-9)
 assert Number.asin(0) == 0.0
 assert Number.asin(0.0) == 0.0
 assert Number.asin(-0.0) == -0.0
@@ -747,38 +742,33 @@ assert Number.isNaN(Number.acos(-15/10))
 assert Number.isClose(
   Number.acos(0.661985898099504477),
   0.84733108284335068,
-  Some(1e-9),
-  None
+  rel_tol=1e-9
 )
 assert Number.isClose(
   Number.acos(0.56175974622072411),
   0.974284964567490364,
-  Some(1e-9),
-  None
+  rel_tol=1e-9
 )
 assert Number.isClose(
   Number.acos(-0.40660392238535531),
   1.98953007108866897,
-  Some(1e-9),
-  None
+  rel_tol=1e-9
 )
-assert Number.isClose(Number.acos(1/2), Number.pi / 3, Some(1e-9), None)
+assert Number.isClose(Number.acos(1/2), Number.pi / 3, rel_tol=1e-9)
 assert Number.isClose(
   Number.acos(0.77415229659130369),
   0.68542151586362221,
-  Some(1e-9),
-  None
+  rel_tol=1e-9
 )
 assert Number.isClose(
   Number.acos(-0.678763702639402444),
   2.31687413820596388,
-  Some(1e-9),
-  None
+  rel_tol=1e-9
 )
-assert Number.isClose(Number.acos(-1.0), Number.pi, Some(1e-9), None)
-assert Number.isClose(Number.acos(-1), Number.pi, Some(1e-9), None)
-assert Number.isClose(Number.acos(0.0), Number.pi / 2, Some(1e-9), None)
-assert Number.isClose(Number.acos(0), Number.pi / 2, Some(1e-9), None)
+assert Number.isClose(Number.acos(-1.0), Number.pi, rel_tol=1e-9)
+assert Number.isClose(Number.acos(-1), Number.pi, rel_tol=1e-9)
+assert Number.isClose(Number.acos(0.0), Number.pi / 2, rel_tol=1e-9)
+assert Number.isClose(Number.acos(0), Number.pi / 2, rel_tol=1e-9)
 assert Number.acos(1) == 0.0
 assert Number.acos(1.0) == 0.0
 assert Number.isNaN(Number.acos(1.00000000000000022))
@@ -791,43 +781,38 @@ assert Number.isNaN(Number.acos(NaN))
 assert Number.isClose(
   Number.atan(0.661985898099504477),
   0.584755067023832509,
-  Some(1e-9),
-  None
+  rel_tol=1e-9
 )
 assert Number.isClose(
   Number.atan(0.56175974622072411),
   0.511826953162888065,
-  Some(1e-9),
-  None
+  rel_tol=1e-9
 )
 assert Number.isClose(
   Number.atan(-0.40660392238535531),
   -0.386186417755213118,
-  Some(1e-9),
-  None
+  rel_tol=1e-9
 )
-assert Number.isClose(Number.atan(1/2), 0.4636476090008061, Some(1e-9), None)
+assert Number.isClose(Number.atan(1/2), 0.4636476090008061, rel_tol=1e-9)
 assert Number.isClose(
   Number.atan(0.77415229659130369),
   0.658780243165382196,
-  Some(1e-9),
-  None
+  rel_tol=1e-9
 )
 assert Number.isClose(
   Number.atan(-0.678763702639402444),
   -0.596330782697347184,
-  Some(1e-9),
-  None
+  rel_tol=1e-9
 )
-assert Number.isClose(Number.atan(1.0), Number.pi / 4, Some(1e-9), None)
-assert Number.isClose(Number.atan(1), Number.pi / 4, Some(1e-9), None)
-assert Number.isClose(Number.atan(-1.0), Number.pi / -4, Some(1e-9), None)
-assert Number.isClose(Number.atan(-1), Number.pi / -4, Some(1e-9), None)
+assert Number.isClose(Number.atan(1.0), Number.pi / 4, rel_tol=1e-9)
+assert Number.isClose(Number.atan(1), Number.pi / 4, rel_tol=1e-9)
+assert Number.isClose(Number.atan(-1.0), Number.pi / -4, rel_tol=1e-9)
+assert Number.isClose(Number.atan(-1), Number.pi / -4, rel_tol=1e-9)
 assert Number.atan(0) == 0.0
 assert Number.atan(0.0) == 0.0
 assert Number.atan(-0.0) == -0.0
-assert Number.isClose(Number.atan(Infinity), Number.pi / 2, Some(1e-9), None)
-assert Number.isClose(Number.atan(-Infinity), Number.pi / -2, Some(1e-9), None)
+assert Number.isClose(Number.atan(Infinity), Number.pi / 2, rel_tol=1e-9)
+assert Number.isClose(Number.atan(-Infinity), Number.pi / -2, rel_tol=1e-9)
 assert Number.isNaN(Number.atan(NaN))
 
 // Number.gamma

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -314,9 +314,16 @@ provide let neg = (x: Number) => x * -1
  * @since v0.6.0
  */
 provide let isClose = (a, b, rel_tol, abs_tol) => {
-  if (a == Infinity && b == Infinity) {
+  if (a == Infinity && b == Infinity || a == -Infinity && b == -Infinity) {
     true
-  } else if (a == NaN || b == NaN || a == Infinity || b == Infinity) {
+  } else if (
+    a == NaN ||
+    b == NaN ||
+    a == Infinity ||
+    b == Infinity ||
+    a == -Infinity ||
+    b == -Infinity
+  ) {
     false
   } else {
     let rel_tol = match (rel_tol) {

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -429,7 +429,6 @@ provide let isInfinite = (x: Number) => {
  * @param b: The second value
  * @param relativeTolerance: The maximum tolerance to use relative to the larger absolute value `a` or `b`
  * @param absoluteTolerance: The absolute tolerance to use, regardless of the values of `a` or `b`
- *
  * @returns `true` if the values are considered close to each other or `false` otherwise
  *
  * @since v0.6.0
@@ -633,10 +632,10 @@ let rf = z => {
   p / q
 }
 /**
- * Computes the inverse sine of the given angle
+ * Computes the inverse sine of the given angle.
  *
- * @param angle: A number between -1 and 1, representing the angle's sine value.
- * @returns The inverse sine (angle in radians between `-pi/2` and `pi/2`) of the given `angle`. The result will be `NaN` if the given `angle` is less than `-1` or greater than `1`
+ * @param angle: A number between -1 and 1, representing the angle's sine value
+ * @returns The inverse sine (angle in radians between `-pi/2` and `pi/2`) of the given `angle` or `NaN` if the given `angle` is not between`-1` and `1`
  *
  * @since v0.6.0
  */
@@ -697,10 +696,10 @@ provide let asin = angle => {
 }
 
 /**
- * Computes the inverse cosine of the given angle
+ * Computes the inverse cosine of the given angle.
  *
- * @param angle: A number between -1 and 1, representing the angle's cosine value.
- * @returnsThe inverse cosine (angle in radians between `-pi/2` and `pi/2`) of the given `angle`. The result will be `NaN` if the given `angle` is less than `-1` or greater than `1`
+ * @param angle: A number between -1 and 1, representing the angle's cosine value
+ * @returns The inverse cosine (angle in radians between `-pi/2` and `pi/2`) of the given `angle` or `NaN` if the given `angle` is not between`-1` and `1`
  *
  * @since v0.6.0
  */
@@ -772,10 +771,10 @@ provide let acos = angle => {
 }
 
 /**
- * Computes the inverse tangent of the given angle
+ * Computes the inverse tangent of the given angle.
  *
- * @param angle: A number between -1 and 1, representing the angle's tangent value.
- * @returns The inverse tangent (angle in radians between `-pi/2` and `pi/2`) of the given `angle`. The result will be `NaN` if the given `angle` is less than `-1` or greater than `1`
+ * @param angle: A number between -1 and 1, representing the angle's tangent value
+ * @returns The inverse tangent (angle in radians between `-pi/2` and `pi/2`) of the given `angle` or `NaN` if the given `angle` is not between`-1` and `1`
  *
  * @since v0.6.0
  */

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -1,12 +1,13 @@
 /*
  * ====================================================
+ * Applies to all functions with a comment referring here.
+ *
  * Copyright (C) 2004 by Sun Microsystems, Inc. All rights reserved.
  *
  * Permission to use, copy, modify, and distribute this
  * software is freely granted, provided that this notice
  * is preserved.
  *
- * Applies to all functions with a comment referring here.
  * ====================================================
  */
 
@@ -306,31 +307,6 @@ provide let abs = (x: Number) => if (0 > x) x * -1 else x
 provide let neg = (x: Number) => x * -1
 
 /**
- * Computes the inverse sine of the given angle
- *
- * @param x: A number between -1 and 1, representing the angle's sine value.
- * @returns The inverse sine (angle in radians between `-pi/2` and `pi/2`) of x. If x is less than `-1` or greater than `1`, return NaN
- *
- * @since v0.6.0
- */
-provide let isClose = (a, b, rel_tol=1e-9, abs_tol=0.0) => {
-  if (a == Infinity && b == Infinity || a == -Infinity && b == -Infinity) {
-    true
-  } else if (
-    a == NaN ||
-    b == NaN ||
-    a == Infinity ||
-    b == Infinity ||
-    a == -Infinity ||
-    b == -Infinity
-  ) {
-    false
-  } else {
-    abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
-  }
-}
-
-/**
  * Checks if a number is a floating point value.
  *
  * @param x: The number to check
@@ -442,6 +418,29 @@ provide let isInfinite = (x: Number) => {
       false
     }
   } else {
+    false
+  }
+}
+
+/**
+ * Determines weather two values are considered close to each other using a relative and absolute tolerance.
+ *
+ * @param a: The first value
+ * @param b: The second value
+ * @param relativeTolerance: The relative tolerance to use
+ * @param absoluteTolerance: The absolute tolerance to use
+ *
+ * @returns `true` if the values are considered close to each other or `false` otherwise
+ *
+ * @since v0.6.0
+ */
+provide let isClose = (a, b, relativeTolerance=1e-9, absoluteTolerance=0.0) => {
+  if (a == b) {
+    true
+  } else if (isFinite(a) && isFinite(b)) {
+    abs(a - b) <= max(relativeTolerance * max(abs(a), abs(b)), absoluteTolerance)
+  } else {
+    // NaN and infinities which were not equal
     false
   }
 }

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -644,7 +644,7 @@ let rf = z => {
  * Computes the inverse sine of the given angle
  *
  * @param x: A number between -1 and 1, representing the angle's sine value.
- * @returns The inverse sine (angle in radians between `-pi/2` and `pi/2`) of x. If x is less than `-1` or greater than `1`, return NaN
+ * @returns The inverse sine (angle in radians between `-pi/2` and `pi/2`) of x. If x is less than `-1` or greater than `1`, returns NaN
  *
  * @since v0.6.0
  */
@@ -709,7 +709,7 @@ provide let asin = angle => {
  * Computes the inverse cosine of the given angle
  *
  * @param x: A number between -1 and 1, representing the angle's cosine value.
- * @returns The inverse cosine (angle in radians between `-pi/2` and `pi/2`) of x. If x is less than `-1` or greater than `1`, return NaN
+ * @returns The inverse cosine (angle in radians between `-pi/2` and `pi/2`) of x. If x is less than `-1` or greater than `1`, returns NaN
  *
  * @since v0.6.0
  */
@@ -778,6 +778,106 @@ provide let acos = angle => {
   let c = (z - df * df) / (s + df)
   let w = rf(z) * s + c
   return WasmI32.toGrain(newFloat64(2.0W * (df + w))): Number
+}
+
+/**
+ * Computes the inverse tangent of the given angle
+ *
+ * @param x: A number between -1 and 1, representing the angle's tangent value.
+ * @returns The inverse tangent (angle in radians between `-pi/2` and `pi/2`) of x. If x is less than `-1` or greater than `1`, returns NaN
+ *
+ * @since v0.6.0
+ */
+@unsafe
+provide let atan = angle => {
+  // see: musl/src/math/asin.c and SUN COPYRIGHT NOTICE at top of file
+  let origAngle = Numbers.coerceNumberToWasmF64(angle)
+  let mut x = origAngle
+  // Constants
+  let atanhi0 = 4.63647609000806093515e-01W // atan(0.5)hi 0x3FDDAC67, 0x0561BB4F
+  let atanhi1 = 7.85398163397448278999e-01W // atan(1.0)hi 0x3FE921FB, 0x54442D18
+  let atanhi2 = 9.82793723247329054082e-01W // atan(1.5)hi 0x3FEF730B, 0xD281F69B
+  let atanhi3 = 1.57079632679489655800e+00W // atan(inf)hi 0x3FF921FB, 0x54442D18
+  let atanlo0 = 2.26987774529616870924e-17W // atan(0.5)lo 0x3C7A2B7F, 0x222F65E2
+  let atanlo1 = 3.06161699786838301793e-17W // atan(1.0)lo 0x3C81A626, 0x33145C07
+  let atanlo2 = 1.39033110312309984516e-17W // atan(1.5)lo 0x3C700788, 0x7AF0CBBD
+  let atanlo3 = 6.12323399573676603587e-17W // atan(inf)lo 0x3C91A626, 0x33145C07
+  let aT0 = 3.33333333333329318027e-01W // 0x3FD55555, 0x5555550D
+  let aT1 = -1.99999999998764832476e-01W // 0xBFC99999, 0x9998EBC4
+  let aT2 = 1.42857142725034663711e-01W // 0x3FC24924, 0x920083FF
+  let aT3 = -1.11111104054623557880e-01W // 0xBFBC71C6, 0xFE231671
+  let aT4 = 9.09088713343650656196e-02W // 0x3FB745CD, 0xC54C206E
+  let aT5 = -7.69187620504482999495e-02W // 0xBFB3B0F2, 0xAF749A6D
+  let aT6 = 6.66107313738753120669e-02W // 0x3FB10D66, 0xA0D03D51
+  let aT7 = -5.83357013379057348645e-02W // 0xBFADDE2D, 0x52DEFD9A
+  let aT8 = 4.97687799461593236017e-02W // 0x3FA97B4B, 0x24760DEB
+  let aT9 = -3.65315727442169155270e-02W // 0xBFA2B444, 0x2C6A6C2F
+  let aT10 = 1.62858201153657823623e-02W // 0x3F90AD3A, 0xE322DA11
+  let ox1p_120f = 7.52316e-37W
+  // Operators
+  from WasmI32 use {
+    shrU as (>>),
+    and as (&),
+    ltU as (<),
+    geU as (>=),
+    eq as (==),
+  }
+  from WasmF64 use { add as (+), sub as (-), mul as (*), div as (/) }
+  // Calculations
+  let ix = WasmI32.wrapI64(WasmI64.shrU(WasmI64.reinterpretF64(x), 32N))
+  let sx = x
+  let ix = ix & 0x7FFFFFFFn
+  /* if |x| >= 2^66 */
+  if (ix >= 0x44100000n) {
+    if (isNaN(angle)) return NaN
+    let z = atanhi3 + ox1p_120f
+    return WasmI32.toGrain(newFloat64(WasmF64.copySign(z, sx))): Number
+  }
+  let mut id = 3n
+  /* |x| < 0.4375 */
+  if (ix < 0x3FDC0000n) {
+    /* |x| < 2^-27 */
+    if (ix < 0x3E400000n) return angle
+    id = -1n
+  } else {
+    x = WasmF64.abs(x)
+    /* |x| < 1.1875 */
+    if (ix < 0x3FF30000n) {
+      /*  7/16 <= |x| < 11/16 */
+      if (ix < 0x3FE60000n) {
+        id = 0n
+        x = (2.0W * x - 1.0W) / (2.0W + x)
+      } else { /* 11/16 <= |x| < 19/16 */
+        id = 1n
+        x = (x - 1.0W) / (x + 1.0W)
+      }
+    } else {
+      /* |x| < 2.4375 */
+      if (ix < 0x40038000n) {
+        id = 2n
+        x = (x - 1.5W) / (1.0W + 1.5W * x)
+      } else { /* 2.4375 <= |x| < 2^66 */
+        x = -1.0W / x
+      }
+    }
+  }
+  let z = x * x
+  let w = z * z
+  let s1 = z * (aT0 + w * (aT2 + w * (aT4 + w * (aT6 + w * (aT8 + w * aT10)))))
+  let s2 = w * (aT1 + w * (aT3 + w * (aT5 + w * (aT7 + w * aT9))))
+  let s3 = x * (s1 + s2)
+  from WasmI32 use { ltS as (<) }
+  if (id < 0n)
+    return WasmI32.toGrain(newFloat64(WasmF64.copySign(x - s3, sx))): Number
+  let mut z = 0.0W
+  match (id) {
+    0n => z = atanhi0 - (s3 - atanlo0 - x),
+    1n => z = atanhi1 - (s3 - atanlo1 - x),
+    2n => z = atanhi2 - (s3 - atanlo2 - x),
+    3n => z = atanhi3 - (s3 + atanlo3 - x),
+    _ => fail "Unreachable",
+  }
+  return WasmI32.toGrain(newFloat64(WasmF64.copySign(z, sx))): Number
 }
 
 // Math.gamma implemented using the Lanczos approximation

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -423,7 +423,7 @@ provide let isInfinite = (x: Number) => {
 }
 
 /**
- * Determines weather two values are considered close to each other using a relative and absolute tolerance.
+ * Determines whether two values are considered close to each other using a relative and absolute tolerance.
  *
  * @param a: The first value
  * @param b: The second value

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -1,3 +1,15 @@
+/*
+ * ====================================================
+ * Copyright (C) 2004 by Sun Microsystems, Inc. All rights reserved.
+ *
+ * Permission to use, copy, modify, and distribute this
+ * software is freely granted, provided that this notice
+ * is preserved.
+ *
+ * Applies to all functions with a comment referring here.
+ * ====================================================
+ */
+
 /**
  * Utilities for working with numbers.
  *
@@ -294,6 +306,32 @@ provide let abs = (x: Number) => if (0 > x) x * -1 else x
 provide let neg = (x: Number) => x * -1
 
 /**
+ * Computes the inverse sine of the given angle
+ *
+ * @param x: A number between -1 and 1, representing the angle's sine value.
+ * @returns The inverse sine (angle in radians between `-pi/2` and `pi/2`) of x. If x is less than `-1` or greater than `1`, return NaN
+ *
+ * @since v0.6.0
+ */
+provide let isClose = (a, b, rel_tol, abs_tol) => {
+  if (a == Infinity && b == Infinity) {
+    true
+  } else if (a == NaN || b == NaN || a == Infinity || b == Infinity) {
+    false
+  } else {
+    let rel_tol = match (rel_tol) {
+      None => 1e-9,
+      Some(x) => x,
+    }
+    let abs_tol = match (abs_tol) {
+      None => 0.0,
+      Some(x) => x,
+    }
+    abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
+  }
+}
+
+/**
  * Checks if a number is a floating point value.
  *
  * @param x: The number to check
@@ -572,6 +610,167 @@ provide let tan = (radians: Number) => {
   } else {
     sin(radians) / cos(radians)
   }
+}
+
+@unsafe
+let rf = z => {
+  // see: musl/src/math/asin.c and SUN COPYRIGHT NOTICE at top of file
+  // Operators
+  from WasmF64 use { add as (+), mul as (*), div as (/) }
+  /* coefficients for R(x^2) */
+  let pS0 = 1.66666666666666657415e-01W /* 0x3FC55555, 0x55555555 */
+  let pS1 = -3.25565818622400915405e-01W /* 0xBFD4D612, 0x03EB6F7D */
+  let pS2 = 2.01212532134862925881e-01W /* 0x3FC9C155, 0x0E884455 */
+  let pS3 = -4.00555345006794114027e-02W /* 0xBFA48228, 0xB5688F3B */
+  let pS4 = 7.91534994289814532176e-04W /* 0x3F49EFE0, 0x7501B288 */
+  let pS5 = 3.47933107596021167570e-05W /* 0x3F023DE1, 0x0DFDF709 */
+  let qS1 = -2.40339491173441421878e+00W /* 0xC0033A27, 0x1C8A2D4B */
+  let qS2 = 2.02094576023350569471e+00W /* 0x40002AE5, 0x9C598AC8 */
+  let qS3 = -6.88283971605453293030e-01W /* 0xBFE6066C, 0x1B8D0159 */
+  let qS4 = 7.70381505559019352791e-02W /* 0x3FB3B8C5, 0xB12E9282 */
+  // Calculations
+  let p = z * (pS0 + z * (pS1 + z * (pS2 + z * (pS3 + z * (pS4 + z * pS5)))))
+  let q = 1.0W + z * (qS1 + z * (qS2 + z * (qS3 + z * qS4)))
+  p / q
+}
+/**
+ * Computes the inverse sine of the given angle
+ *
+ * @param x: A number between -1 and 1, representing the angle's sine value.
+ * @returns The inverse sine (angle in radians between `-pi/2` and `pi/2`) of x. If x is less than `-1` or greater than `1`, return NaN
+ *
+ * @since v0.6.0
+ */
+@unsafe
+provide let asin = angle => {
+  // see: musl/src/math/asin.c and SUN COPYRIGHT NOTICE at top of file
+  let origAngle = Numbers.coerceNumberToWasmF64(angle)
+  let mut x = origAngle
+
+  let pio2_hi = 1.57079632679489655800e+00W /* 0x3FF921FB, 0x54442D18 */
+  let pio2_lo = 6.12323399573676603587e-17W /* 0x3C91A626, 0x33145C07 */
+  let ox1p_120f = 7.52316e-37W
+
+  from WasmI32 use { and as (&), or as (|), leU as (<), geU as (>=) }
+  from WasmF64 use { add as (+), sub as (-), mul as (*), div as (/) }
+
+  let hx = WasmI32.wrapI64(WasmI64.shrU(WasmI64.reinterpretF64(x), 32N))
+  let ix = hx & 0x7fffffffn
+  /* |x| >= 1 or nan */
+  if (ix >= 0x3ff00000n) {
+    let lx = WasmI32.wrapI64(WasmI64.reinterpretF64(x))
+    from WasmI32 use { sub as (-) }
+    /* asin(1) = +-pi/2 with inexact */
+    if (WasmI32.eqz(ix - 0x3ff00000n | lx))
+      return WasmI32.toGrain(newFloat64(x * pio2_hi + ox1p_120f)): Number
+    return WasmI32.toGrain(newFloat64(NaNW)): Number
+  }
+  /* |x| < 0.5 */
+  if (ix < 0x3fe00000n) {
+    /* if 0x1p-1022 <= |x| < 0x1p-26, avoid raising underflow */
+    let output =
+      if (ix < 0x3e500000n && ix >= 0x00100000n) x else x + x * rf(x * x)
+    return WasmI32.toGrain(newFloat64(output)): Number
+  }
+  /* 1 > |x| >= 0.5 */
+  let z = (1.0W - WasmF64.abs(x)) * 0.5W
+  let s = WasmF64.sqrt(z)
+  let r = rf(z)
+  /* if |x| > 0.975 */
+  if (ix >= 0x3fef3333n) {
+    x = pio2_hi - (2.0W * (s + s * r) - pio2_lo)
+  } else {
+    from WasmI64 use { and as (&) }
+    /* f+c = sqrt(z) */
+    let f = WasmF64.reinterpretI64(
+      WasmI64.reinterpretF64(s) & 0xFFFFFFFF00000000N
+    )
+    let c = (z - f * f) / (s + f)
+    x = 0.5W * pio2_hi -
+      (2.0W * s * r -
+        (pio2_lo -
+          2.0W * c) -
+        (0.5W * pio2_hi -
+          2.0W * f))
+  }
+  from WasmI32 use { shrU as (>>) }
+  x = WasmF64.copySign(x, origAngle)
+  return WasmI32.toGrain(newFloat64(x)): Number
+}
+
+/**
+ * Computes the inverse cosine of the given angle
+ *
+ * @param x: A number between -1 and 1, representing the angle's cosine value.
+ * @returns The inverse cosine (angle in radians between `-pi/2` and `pi/2`) of x. If x is less than `-1` or greater than `1`, return NaN
+ *
+ * @since v0.6.0
+ */
+@unsafe
+provide let acos = angle => {
+  // see: musl/src/math/acos.c and SUN COPYRIGHT NOTICE at top of file
+  let origAngle = Numbers.coerceNumberToWasmF64(angle)
+  let mut x = origAngle
+
+  let pio2_hi = 1.57079632679489655800e+00W /* 0x3FF921FB, 0x54442D18 */
+  let pio2_lo = 6.12323399573676603587e-17W /* 0x3C91A626, 0x33145C07 */
+  let ox1p_120f = 7.52316e-37W
+
+  from WasmI32 use {
+    shrU as (>>),
+    and as (&),
+    or as (|),
+    ne as (!=),
+    leU as (<),
+    geU as (>=),
+    leU as (<=),
+  }
+  from WasmF64 use { add as (+), sub as (-), mul as (*), div as (/) }
+
+  let hx = WasmI32.wrapI64(WasmI64.shrU(WasmI64.reinterpretF64(x), 32N))
+  let ix = hx & 0x7fffffffn
+
+  /* |x| >= 1 or nan */
+  if (ix >= 0x3ff00000n) {
+    let lx = WasmI32.wrapI64(WasmI64.reinterpretF64(x))
+    from WasmI32 use { sub as (-) }
+    if (WasmI32.eqz(ix - 0x3ff00000n | lx)) {
+      /* acos(1)=0, acos(-1)=pi */
+      if (hx >> 31n != 0n)
+        return WasmI32.toGrain(newFloat64(2.0W * pio2_hi + ox1p_120f)): Number
+      else return 0
+    }
+    return WasmI32.toGrain(newFloat64(NaNW)): Number
+  }
+  /* |x| < 0.5 */
+  if (ix < 0x3fe00000n) {
+    /* |x| < 2**-57 */
+    let output =
+      if (ix <= 0x3c600000n) pio2_hi + ox1p_120f
+      else pio2_hi -
+        (x -
+          (pio2_lo -
+            x * rf(x * x)))
+    return WasmI32.toGrain(newFloat64(output)): Number
+  }
+  /* x < -0.5 */
+  if (hx >> 31n != 0n) {
+    let z = (1.0W + x) * 0.5W
+    let s = WasmF64.sqrt(z)
+    let w = rf(z) * s - pio2_lo
+    return WasmI32.toGrain(newFloat64(2.0W * (pio2_hi - (s + w)))): Number
+  }
+
+  /* x > 0.5 */
+  from WasmI64 use { and as (&) }
+  let z = (1.0W - x) * 0.5W
+  let s = WasmF64.sqrt(z)
+  let df = WasmF64.reinterpretI64(
+    WasmI64.reinterpretF64(s) & 0xFFFFFFFF00000000N
+  )
+  let c = (z - df * df) / (s + df)
+  let w = rf(z) * s + c
+  return WasmI32.toGrain(newFloat64(2.0W * (df + w))): Number
 }
 
 // Math.gamma implemented using the Lanczos approximation

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -635,7 +635,7 @@ let rf = z => {
 /**
  * Computes the inverse sine of the given angle
  *
- * @param x: A number between -1 and 1, representing the angle's sine value.
+ * @param angle: A number between -1 and 1, representing the angle's sine value.
  * @returns The inverse sine (angle in radians between `-pi/2` and `pi/2`) of x. If x is less than `-1` or greater than `1`, returns NaN
  *
  * @since v0.6.0
@@ -699,7 +699,7 @@ provide let asin = angle => {
 /**
  * Computes the inverse cosine of the given angle
  *
- * @param x: A number between -1 and 1, representing the angle's cosine value.
+ * @param angle: A number between -1 and 1, representing the angle's cosine value.
  * @returns The inverse cosine (angle in radians between `-pi/2` and `pi/2`) of x. If x is less than `-1` or greater than `1`, returns NaN
  *
  * @since v0.6.0
@@ -774,7 +774,7 @@ provide let acos = angle => {
 /**
  * Computes the inverse tangent of the given angle
  *
- * @param x: A number between -1 and 1, representing the angle's tangent value.
+ * @param angle: A number between -1 and 1, representing the angle's tangent value.
  * @returns The inverse tangent (angle in radians between `-pi/2` and `pi/2`) of x. If x is less than `-1` or greater than `1`, returns NaN
  *
  * @since v0.6.0

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -636,7 +636,7 @@ let rf = z => {
  * Computes the inverse sine of the given angle
  *
  * @param angle: A number between -1 and 1, representing the angle's sine value.
- * @returns The inverse sine (angle in radians between `-pi/2` and `pi/2`) of x. If x is less than `-1` or greater than `1`, returns NaN
+ * @returns The inverse sine (angle in radians between `-pi/2` and `pi/2`) of the given `angle`. The result will be `NaN` if the given `angle` is less than `-1` or greater than `1`
  *
  * @since v0.6.0
  */
@@ -700,7 +700,7 @@ provide let asin = angle => {
  * Computes the inverse cosine of the given angle
  *
  * @param angle: A number between -1 and 1, representing the angle's cosine value.
- * @returns The inverse cosine (angle in radians between `-pi/2` and `pi/2`) of x. If x is less than `-1` or greater than `1`, returns NaN
+ * @returnsThe inverse cosine (angle in radians between `-pi/2` and `pi/2`) of the given `angle`. The result will be `NaN` if the given `angle` is less than `-1` or greater than `1`
  *
  * @since v0.6.0
  */
@@ -775,7 +775,7 @@ provide let acos = angle => {
  * Computes the inverse tangent of the given angle
  *
  * @param angle: A number between -1 and 1, representing the angle's tangent value.
- * @returns The inverse tangent (angle in radians between `-pi/2` and `pi/2`) of x. If x is less than `-1` or greater than `1`, returns NaN
+ * @returns The inverse tangent (angle in radians between `-pi/2` and `pi/2`) of the given `angle`. The result will be `NaN` if the given `angle` is less than `-1` or greater than `1`
  *
  * @since v0.6.0
  */

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -438,7 +438,8 @@ provide let isClose = (a, b, relativeTolerance=1e-9, absoluteTolerance=0.0) => {
   if (a == b) {
     true
   } else if (isFinite(a) && isFinite(b)) {
-    abs(a - b) <= max(relativeTolerance * max(abs(a), abs(b)), absoluteTolerance)
+    abs(a - b) <=
+      max(relativeTolerance * max(abs(a), abs(b)), absoluteTolerance)
   } else {
     // NaN and infinities which were not equal
     false

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -427,8 +427,8 @@ provide let isInfinite = (x: Number) => {
  *
  * @param a: The first value
  * @param b: The second value
- * @param relativeTolerance: The relative tolerance to use
- * @param absoluteTolerance: The absolute tolerance to use
+ * @param relativeTolerance: The maximum tolerance to use relative to the larger absolute value `a` or `b`
+ * @param absoluteTolerance: The absolute tolerance to use, regardless of the values of `a` or `b`
  *
  * @returns `true` if the values are considered close to each other or `false` otherwise
  *

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -615,7 +615,7 @@ provide let tan = (radians: Number) => {
 let rf = z => {
   // see: musl/src/math/asin.c and SUN COPYRIGHT NOTICE at top of file
   // Operators
-  from WasmF64 use { add as (+), mul as (*), div as (/) }
+  from WasmF64 use { (+), (*), (/) }
   /* coefficients for R(x^2) */
   let pS0 = 1.66666666666666657415e-01W /* 0x3FC55555, 0x55555555 */
   let pS1 = -3.25565818622400915405e-01W /* 0xBFD4D612, 0x03EB6F7D */
@@ -649,15 +649,16 @@ provide let asin = angle => {
   let pio2_hi = 1.57079632679489655800e+00W /* 0x3FF921FB, 0x54442D18 */
   let pio2_lo = 6.12323399573676603587e-17W /* 0x3C91A626, 0x33145C07 */
 
-  from WasmI32 use { and as (&), or as (|), leU as (<), geU as (>=) }
-  from WasmF64 use { add as (+), sub as (-), mul as (*), div as (/) }
+  from WasmI32 use { (&), (|), leU as (<), geU as (>=) }
+  from WasmI64 use { (>>>) }
+  from WasmF64 use { (+), (-), (*), (/) }
 
-  let hx = WasmI32.wrapI64(WasmI64.shrU(WasmI64.reinterpretF64(x), 32N))
+  let hx = WasmI32.wrapI64(WasmI64.reinterpretF64(x) >>> 32N)
   let ix = hx & 0x7fffffffn
   /* |x| >= 1 or nan */
   if (ix >= 0x3ff00000n) {
     let lx = WasmI32.wrapI64(WasmI64.reinterpretF64(x))
-    from WasmI32 use { sub as (-) }
+    from WasmI32 use { (-) }
     /* asin(1) = +-pi/2 with inexact */
     if (WasmI32.eqz(ix - 0x3ff00000n | lx))
       return WasmI32.toGrain(newFloat64(x * pio2_hi + 0x1p-120W)): Number
@@ -678,7 +679,7 @@ provide let asin = angle => {
   if (ix >= 0x3fef3333n) {
     x = pio2_hi - (2.0W * (s + s * r) - pio2_lo)
   } else {
-    from WasmI64 use { and as (&) }
+    from WasmI64 use { (&) }
     /* f+c = sqrt(z) */
     let f = WasmF64.reinterpretI64(
       WasmI64.reinterpretF64(s) & 0xFFFFFFFF00000000N
@@ -691,7 +692,6 @@ provide let asin = angle => {
         (0.5W * pio2_hi -
           2.0W * f))
   }
-  from WasmI32 use { shrU as (>>) }
   x = WasmF64.copySign(x, origAngle)
   return WasmI32.toGrain(newFloat64(x)): Number
 }
@@ -714,23 +714,24 @@ provide let acos = angle => {
   let pio2_lo = 6.12323399573676603587e-17W /* 0x3C91A626, 0x33145C07 */
 
   from WasmI32 use {
-    shrU as (>>),
-    and as (&),
-    or as (|),
-    ne as (!=),
+    (>>),
+    (&),
+    (|),
+    (!=),
     leU as (<),
     geU as (>=),
     leU as (<=),
   }
-  from WasmF64 use { add as (+), sub as (-), mul as (*), div as (/) }
+  from WasmI64 use { (>>>) }
+  from WasmF64 use { (+), (-), (*), (/) }
 
-  let hx = WasmI32.wrapI64(WasmI64.shrU(WasmI64.reinterpretF64(x), 32N))
+  let hx = WasmI32.wrapI64(WasmI64.reinterpretF64(x) >>> 32N)
   let ix = hx & 0x7fffffffn
 
   /* |x| >= 1 or nan */
   if (ix >= 0x3ff00000n) {
     let lx = WasmI32.wrapI64(WasmI64.reinterpretF64(x))
-    from WasmI32 use { sub as (-) }
+    from WasmI32 use { (-) }
     if (WasmI32.eqz(ix - 0x3ff00000n | lx)) {
       /* acos(1)=0, acos(-1)=pi */
       if (hx >> 31n != 0n)
@@ -759,7 +760,7 @@ provide let acos = angle => {
   }
 
   /* x > 0.5 */
-  from WasmI64 use { and as (&) }
+  from WasmI64 use { (&) }
   let z = (1.0W - x) * 0.5W
   let s = WasmF64.sqrt(z)
   let df = WasmF64.reinterpretI64(
@@ -804,16 +805,11 @@ provide let atan = angle => {
   let aT9 = -3.65315727442169155270e-02W // 0xBFA2B444, 0x2C6A6C2F
   let aT10 = 1.62858201153657823623e-02W // 0x3F90AD3A, 0xE322DA11
   // Operators
-  from WasmI32 use {
-    shrU as (>>),
-    and as (&),
-    ltU as (<),
-    geU as (>=),
-    eq as (==),
-  }
-  from WasmF64 use { add as (+), sub as (-), mul as (*), div as (/) }
+  from WasmI32 use { (&), (<), (>=), (==) }
+  from WasmI64 use { (>>>) }
+  from WasmF64 use { (+), (-), (*), (/) }
   // Calculations
-  let ix = WasmI32.wrapI64(WasmI64.shrU(WasmI64.reinterpretF64(x), 32N))
+  let ix = WasmI32.wrapI64(WasmI64.reinterpretF64(x) >>> 32N)
   let sx = x
   let ix = ix & 0x7FFFFFFFn
   /* if |x| >= 2^66 */
@@ -855,7 +851,7 @@ provide let atan = angle => {
   let s1 = z * (aT0 + w * (aT2 + w * (aT4 + w * (aT6 + w * (aT8 + w * aT10)))))
   let s2 = w * (aT1 + w * (aT3 + w * (aT5 + w * (aT7 + w * aT9))))
   let s3 = x * (s1 + s2)
-  from WasmI32 use { ltS as (<) }
+  from WasmI32 use { (<) }
   if (id < 0n)
     return WasmI32.toGrain(newFloat64(WasmF64.copySign(x - s3, sx))): Number
   let mut z = 0.0W

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -313,7 +313,7 @@ provide let neg = (x: Number) => x * -1
  *
  * @since v0.6.0
  */
-provide let isClose = (a, b, rel_tol, abs_tol) => {
+provide let isClose = (a, b, rel_tol=1e-9, abs_tol=0.0) => {
   if (a == Infinity && b == Infinity || a == -Infinity && b == -Infinity) {
     true
   } else if (
@@ -326,14 +326,6 @@ provide let isClose = (a, b, rel_tol, abs_tol) => {
   ) {
     false
   } else {
-    let rel_tol = match (rel_tol) {
-      None => 1e-9,
-      Some(x) => x,
-    }
-    let abs_tol = match (abs_tol) {
-      None => 0.0,
-      Some(x) => x,
-    }
     abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
   }
 }
@@ -656,7 +648,6 @@ provide let asin = angle => {
 
   let pio2_hi = 1.57079632679489655800e+00W /* 0x3FF921FB, 0x54442D18 */
   let pio2_lo = 6.12323399573676603587e-17W /* 0x3C91A626, 0x33145C07 */
-  let ox1p_120f = 7.52316e-37W
 
   from WasmI32 use { and as (&), or as (|), leU as (<), geU as (>=) }
   from WasmF64 use { add as (+), sub as (-), mul as (*), div as (/) }
@@ -669,7 +660,7 @@ provide let asin = angle => {
     from WasmI32 use { sub as (-) }
     /* asin(1) = +-pi/2 with inexact */
     if (WasmI32.eqz(ix - 0x3ff00000n | lx))
-      return WasmI32.toGrain(newFloat64(x * pio2_hi + ox1p_120f)): Number
+      return WasmI32.toGrain(newFloat64(x * pio2_hi + 0x1p-120W)): Number
     return WasmI32.toGrain(newFloat64(NaNW)): Number
   }
   /* |x| < 0.5 */
@@ -721,7 +712,6 @@ provide let acos = angle => {
 
   let pio2_hi = 1.57079632679489655800e+00W /* 0x3FF921FB, 0x54442D18 */
   let pio2_lo = 6.12323399573676603587e-17W /* 0x3C91A626, 0x33145C07 */
-  let ox1p_120f = 7.52316e-37W
 
   from WasmI32 use {
     shrU as (>>),
@@ -744,7 +734,7 @@ provide let acos = angle => {
     if (WasmI32.eqz(ix - 0x3ff00000n | lx)) {
       /* acos(1)=0, acos(-1)=pi */
       if (hx >> 31n != 0n)
-        return WasmI32.toGrain(newFloat64(2.0W * pio2_hi + ox1p_120f)): Number
+        return WasmI32.toGrain(newFloat64(2.0W * pio2_hi + 0x1p-120W)): Number
       else return 0
     }
     return WasmI32.toGrain(newFloat64(NaNW)): Number
@@ -753,7 +743,7 @@ provide let acos = angle => {
   if (ix < 0x3fe00000n) {
     /* |x| < 2**-57 */
     let output =
-      if (ix <= 0x3c600000n) pio2_hi + ox1p_120f
+      if (ix <= 0x3c600000n) pio2_hi + 0x1p-120W
       else pio2_hi -
         (x -
           (pio2_lo -
@@ -813,7 +803,6 @@ provide let atan = angle => {
   let aT8 = 4.97687799461593236017e-02W // 0x3FA97B4B, 0x24760DEB
   let aT9 = -3.65315727442169155270e-02W // 0xBFA2B444, 0x2C6A6C2F
   let aT10 = 1.62858201153657823623e-02W // 0x3F90AD3A, 0xE322DA11
-  let ox1p_120f = 7.52316e-37W
   // Operators
   from WasmI32 use {
     shrU as (>>),
@@ -830,7 +819,7 @@ provide let atan = angle => {
   /* if |x| >= 2^66 */
   if (ix >= 0x44100000n) {
     if (isNaN(angle)) return NaN
-    let z = atanhi3 + ox1p_120f
+    let z = atanhi3 + 0x1p-120W
     return WasmI32.toGrain(newFloat64(WasmF64.copySign(z, sx))): Number
   }
   let mut id = 3n

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -722,8 +722,8 @@ Parameters:
 |-----|----|-----------|
 |`a`|`Number`|The first value|
 |`b`|`Number`|The second value|
-|`relativeTolerance`|`Option<Number>`|The relative tolerance to use|
-|`absoluteTolerance`|`Option<Number>`|The absolute tolerance to use|
+|`relativeTolerance`|`Option<Number>`|The maximum tolerance to use relative to the larger absolute value `a` or `b`|
+|`absoluteTolerance`|`Option<Number>`|The absolute tolerance to use, regardless of the values of `a` or `b`|
 
 Returns:
 

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -927,7 +927,7 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`Number`|The inverse sine (angle in radians between `-pi/2` and `pi/2`) of x. If x is less than `-1` or greater than `1`, returns NaN|
+|`Number`|The inverse sine (angle in radians between `-pi/2` and `pi/2`) of the given `angle`. The result will be `NaN` if the given `angle` is less than `-1` or greater than `1`|
 
 ### Number.**acos**
 
@@ -952,7 +952,7 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`Number`|The inverse cosine (angle in radians between `-pi/2` and `pi/2`) of x. If x is less than `-1` or greater than `1`, returns NaN|
+|`Number`|The inverse cosine (angle in radians between `-pi/2` and `pi/2`) of the given `angle`. The result will be `NaN` if the given `angle` is less than `-1` or greater than `1`|
 
 ### Number.**atan**
 
@@ -977,7 +977,7 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`Number`|The inverse tangent (angle in radians between `-pi/2` and `pi/2`) of x. If x is less than `-1` or greater than `1`, returns NaN|
+|`Number`|The inverse tangent (angle in radians between `-pi/2` and `pi/2`) of the given `angle`. The result will be `NaN` if the given `angle` is less than `-1` or greater than `1`|
 
 ### Number.**gamma**
 

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -549,31 +549,6 @@ Returns:
 |----|-----------|
 |`Number`|The negated operand|
 
-### Number.**isClose**
-
-<details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
-No other changes yet.
-</details>
-
-```grain
-isClose : (a: Number, b: Number, ?rel_tol: Number, ?abs_tol: Number) -> Bool
-```
-
-Computes the inverse sine of the given angle
-
-Parameters:
-
-|param|type|description|
-|-----|----|-----------|
-|`x`|`Number`|A number between -1 and 1, representing the angle's sine value.|
-
-Returns:
-
-|type|description|
-|----|-----------|
-|`Bool`|The inverse sine (angle in radians between `-pi/2` and `pi/2`) of x. If x is less than `-1` or greater than `1`, return NaN|
-
 ### Number.**isFloat**
 
 <details disabled>
@@ -725,6 +700,36 @@ Returns:
 |type|description|
 |----|-----------|
 |`Bool`|`true` if the value is infinite or `false` otherwise|
+
+### Number.**isClose**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+isClose :
+  (a: Number, b: Number, ?relativeTolerance: Number,
+   ?absoluteTolerance: Number) -> Bool
+```
+
+Determines weather two values are considered close to each other using a relative and absolute tolerance.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`a`|`Number`|The first value|
+|`b`|`Number`|The second value|
+|`relativeTolerance`|`Option<Number>`|The relative tolerance to use|
+|`absoluteTolerance`|`Option<Number>`|The absolute tolerance to use|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Bool`|`true` if the values are considered close to each other or `false` otherwise|
 
 ### Number.**parseInt**
 

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -714,7 +714,7 @@ isClose :
    ?absoluteTolerance: Number) => Bool
 ```
 
-Determines weather two values are considered close to each other using a relative and absolute tolerance.
+Determines whether two values are considered close to each other using a relative and absolute tolerance.
 
 Parameters:
 

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -922,7 +922,7 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`Number`|The inverse sine (angle in radians between `-pi/2` and `pi/2`) of x. If x is less than `-1` or greater than `1`, return NaN|
+|`Number`|The inverse sine (angle in radians between `-pi/2` and `pi/2`) of x. If x is less than `-1` or greater than `1`, returns NaN|
 
 ### Number.**acos**
 
@@ -947,7 +947,32 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`Number`|The inverse cosine (angle in radians between `-pi/2` and `pi/2`) of x. If x is less than `-1` or greater than `1`, return NaN|
+|`Number`|The inverse cosine (angle in radians between `-pi/2` and `pi/2`) of x. If x is less than `-1` or greater than `1`, returns NaN|
+
+### Number.**atan**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+atan : Number -> Number
+```
+
+Computes the inverse tangent of the given angle
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`x`|`Number`|A number between -1 and 1, representing the angle's tangent value.|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The inverse tangent (angle in radians between `-pi/2` and `pi/2`) of x. If x is less than `-1` or greater than `1`, returns NaN|
 
 ### Number.**gamma**
 

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -711,7 +711,7 @@ No other changes yet.
 ```grain
 isClose :
   (a: Number, b: Number, ?relativeTolerance: Number,
-   ?absoluteTolerance: Number) -> Bool
+   ?absoluteTolerance: Number) => Bool
 ```
 
 Determines weather two values are considered close to each other using a relative and absolute tolerance.
@@ -912,7 +912,7 @@ No other changes yet.
 </details>
 
 ```grain
-asin : (angle: Number) -> Number
+asin : (angle: Number) => Number
 ```
 
 Computes the inverse sine of the given angle
@@ -937,7 +937,7 @@ No other changes yet.
 </details>
 
 ```grain
-acos : (angle: Number) -> Number
+acos : (angle: Number) => Number
 ```
 
 Computes the inverse cosine of the given angle
@@ -962,7 +962,7 @@ No other changes yet.
 </details>
 
 ```grain
-atan : (angle: Number) -> Number
+atan : (angle: Number) => Number
 ```
 
 Computes the inverse tangent of the given angle

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -549,6 +549,31 @@ Returns:
 |----|-----------|
 |`Number`|The negated operand|
 
+### Number.**isClose**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+isClose : (Number, Number, Option<Number>, Option<Number>) -> Bool
+```
+
+Computes the inverse sine of the given angle
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`x`|`Number`|A number between -1 and 1, representing the angle's sine value.|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Bool`|The inverse sine (angle in radians between `-pi/2` and `pi/2`) of x. If x is less than `-1` or greater than `1`, return NaN|
+
 ### Number.**isFloat**
 
 <details disabled>
@@ -873,6 +898,56 @@ Returns:
 |type|description|
 |----|-----------|
 |`Number`|The computed tangent|
+
+### Number.**asin**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+asin : Number -> Number
+```
+
+Computes the inverse sine of the given angle
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`x`|`Number`|A number between -1 and 1, representing the angle's sine value.|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The inverse sine (angle in radians between `-pi/2` and `pi/2`) of x. If x is less than `-1` or greater than `1`, return NaN|
+
+### Number.**acos**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+acos : Number -> Number
+```
+
+Computes the inverse cosine of the given angle
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`x`|`Number`|A number between -1 and 1, representing the angle's cosine value.|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The inverse cosine (angle in radians between `-pi/2` and `pi/2`) of x. If x is less than `-1` or greater than `1`, return NaN|
 
 ### Number.**gamma**
 

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -557,7 +557,7 @@ No other changes yet.
 </details>
 
 ```grain
-isClose : (Number, Number, Option<Number>, Option<Number>) -> Bool
+isClose : (a: Number, b: Number, ?rel_tol: Number, ?abs_tol: Number) -> Bool
 ```
 
 Computes the inverse sine of the given angle
@@ -907,7 +907,7 @@ No other changes yet.
 </details>
 
 ```grain
-asin : Number -> Number
+asin : (angle: Number) -> Number
 ```
 
 Computes the inverse sine of the given angle
@@ -932,7 +932,7 @@ No other changes yet.
 </details>
 
 ```grain
-acos : Number -> Number
+acos : (angle: Number) -> Number
 ```
 
 Computes the inverse cosine of the given angle
@@ -957,7 +957,7 @@ No other changes yet.
 </details>
 
 ```grain
-atan : Number -> Number
+atan : (angle: Number) -> Number
 ```
 
 Computes the inverse tangent of the given angle

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -915,19 +915,19 @@ No other changes yet.
 asin : (angle: Number) => Number
 ```
 
-Computes the inverse sine of the given angle
+Computes the inverse sine of the given angle.
 
 Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`angle`|`Number`|A number between -1 and 1, representing the angle's sine value.|
+|`angle`|`Number`|A number between -1 and 1, representing the angle's sine value|
 
 Returns:
 
 |type|description|
 |----|-----------|
-|`Number`|The inverse sine (angle in radians between `-pi/2` and `pi/2`) of the given `angle`. The result will be `NaN` if the given `angle` is less than `-1` or greater than `1`|
+|`Number`|The inverse sine (angle in radians between `-pi/2` and `pi/2`) of the given `angle` or `NaN` if the given `angle` is not between`-1` and `1`|
 
 ### Number.**acos**
 
@@ -940,19 +940,19 @@ No other changes yet.
 acos : (angle: Number) => Number
 ```
 
-Computes the inverse cosine of the given angle
+Computes the inverse cosine of the given angle.
 
 Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`angle`|`Number`|A number between -1 and 1, representing the angle's cosine value.|
+|`angle`|`Number`|A number between -1 and 1, representing the angle's cosine value|
 
 Returns:
 
 |type|description|
 |----|-----------|
-|`Number`|The inverse cosine (angle in radians between `-pi/2` and `pi/2`) of the given `angle`. The result will be `NaN` if the given `angle` is less than `-1` or greater than `1`|
+|`Number`|The inverse cosine (angle in radians between `-pi/2` and `pi/2`) of the given `angle` or `NaN` if the given `angle` is not between`-1` and `1`|
 
 ### Number.**atan**
 
@@ -965,19 +965,19 @@ No other changes yet.
 atan : (angle: Number) => Number
 ```
 
-Computes the inverse tangent of the given angle
+Computes the inverse tangent of the given angle.
 
 Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`angle`|`Number`|A number between -1 and 1, representing the angle's tangent value.|
+|`angle`|`Number`|A number between -1 and 1, representing the angle's tangent value|
 
 Returns:
 
 |type|description|
 |----|-----------|
-|`Number`|The inverse tangent (angle in radians between `-pi/2` and `pi/2`) of the given `angle`. The result will be `NaN` if the given `angle` is less than `-1` or greater than `1`|
+|`Number`|The inverse tangent (angle in radians between `-pi/2` and `pi/2`) of the given `angle` or `NaN` if the given `angle` is not between`-1` and `1`|
 
 ### Number.**gamma**
 

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -722,8 +722,8 @@ Parameters:
 |-----|----|-----------|
 |`a`|`Number`|The first value|
 |`b`|`Number`|The second value|
-|`relativeTolerance`|`Option<Number>`|The maximum tolerance to use relative to the larger absolute value `a` or `b`|
-|`absoluteTolerance`|`Option<Number>`|The absolute tolerance to use, regardless of the values of `a` or `b`|
+|`?relativeTolerance`|`Number`|The maximum tolerance to use relative to the larger absolute value `a` or `b`|
+|`?absoluteTolerance`|`Number`|The absolute tolerance to use, regardless of the values of `a` or `b`|
 
 Returns:
 
@@ -921,7 +921,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`x`|`Number`|A number between -1 and 1, representing the angle's sine value.|
+|`angle`|`Number`|A number between -1 and 1, representing the angle's sine value.|
 
 Returns:
 
@@ -946,7 +946,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`x`|`Number`|A number between -1 and 1, representing the angle's cosine value.|
+|`angle`|`Number`|A number between -1 and 1, representing the angle's cosine value.|
 
 Returns:
 
@@ -971,7 +971,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`x`|`Number`|A number between -1 and 1, representing the angle's tangent value.|
+|`angle`|`Number`|A number between -1 and 1, representing the angle's tangent value.|
 
 Returns:
 


### PR DESCRIPTION
This pr adds `Number.asin`, `Number.acos` and `Number.isClose` to the Number stdlib. I was just going to add `asin` and `acos` but given that the methods being used to calculate `asin` and `acos` are approximations I decided to also add `isClose` to make the testing more concise.

isClose is taken from https://peps.python.org/pep-0485/#proposed-implementation,
The license on it just says its in the public domain I think that means we can use it but I honestly dont know happy to find an alternative approach though if that isnt allowed.

The `asin` and `acos` functions are from:
https://git.musl-libc.org/cgit/musl/tree/src/math/asin.c
Just like `pow`.

This is a draft because `isClose` is blocked on optional Arguments for a nice api, once that gets merged I will go back and refactor the function to not use Options.

Blocked: #388 

Work for: #1017 

Note: if you guys are fine with merging in with a worse api based on options I am happy todo that too.