### PR TITLE
chore(compiler): Remove unused prim values on value_descriptions

### DIFF
--- a/compiler/src/parsing/ast_helper.re
+++ b/compiler/src/parsing/ast_helper.re
@@ -461,14 +461,13 @@ module PrimitiveDescription = {
 };
 
 module ValueDescription = {
-  let mk = (~loc=?, ~mod_, ~name, ~alias, ~typ, ~prim, ()) => {
+  let mk = (~loc=?, ~mod_, ~name, ~alias, ~typ, ()) => {
     let loc = Option.value(~default=Location.dummy_loc, loc);
     {
       pval_mod: mod_,
       pval_name: name,
       pval_name_alias: alias,
       pval_type: typ,
-      pval_prim: prim,
       pval_loc: loc,
     };
   };

--- a/compiler/src/parsing/ast_helper.rei
+++ b/compiler/src/parsing/ast_helper.rei
@@ -311,7 +311,6 @@ module ValueDescription: {
       ~name: str,
       ~alias: option(str),
       ~typ: parsed_type,
-      ~prim: list(string),
       unit
     ) =>
     value_description;

--- a/compiler/src/parsing/parser.mly
+++ b/compiler/src/parsing/parser.mly
@@ -644,7 +644,7 @@ type_id_str:
   | UIDENT { Location.mkloc $1 (to_loc $loc) }
 
 foreign_stmt:
-  | FOREIGN WASM id_str colon typ as_prefix(id_str)? FROM file_path { ValueDescription.mk ~loc:(to_loc $loc) ~mod_:$8 ~name:$3 ~alias:$6 ~typ:$5 ~prim:[] () }
+  | FOREIGN WASM id_str colon typ as_prefix(id_str)? FROM file_path { ValueDescription.mk ~loc:(to_loc $loc) ~mod_:$8 ~name:$3 ~alias:$6 ~typ:$5 () }
 
 prim:
   | primitive_ { Location.mkloc $1 (to_loc $loc) }

--- a/compiler/src/parsing/parsetree.re
+++ b/compiler/src/parsing/parsetree.re
@@ -559,7 +559,6 @@ type value_description = {
   pval_name: loc(string),
   pval_name_alias: option(loc(string)),
   pval_type: parsed_type,
-  pval_prim: list(string),
   [@sexp_drop_if sexp_locs_disabled]
   pval_loc: Location.t,
 };

--- a/compiler/src/typed/typedecl.re
+++ b/compiler/src/typed/typedecl.re
@@ -928,7 +928,6 @@ let transl_value_decl = (env, loc, valdecl) => {
     tvd_name: valdecl.pval_name,
     tvd_desc: cty,
     tvd_val: v,
-    tvd_prim: valdecl.pval_prim,
     tvd_loc: valdecl.pval_loc,
   };
 

--- a/compiler/src/typed/typedtree.re
+++ b/compiler/src/typed/typedtree.re
@@ -550,7 +550,6 @@ type value_description = {
   tvd_name: loc(string),
   tvd_desc: core_type,
   tvd_val: Types.value_description,
-  tvd_prim: list(string),
   [@sexp_drop_if sexp_locs_disabled]
   tvd_loc: Location.t,
 };

--- a/compiler/src/typed/typedtree.rei
+++ b/compiler/src/typed/typedtree.rei
@@ -513,7 +513,6 @@ type value_description = {
   tvd_name: loc(string),
   tvd_desc: core_type,
   tvd_val: Types.value_description,
-  tvd_prim: list(string),
   [@sexp_drop_if sexp_locs_disabled]
   tvd_loc: Location.t,
 };


### PR DESCRIPTION
This removes the `pval_prim` and `tvd_prim` labels on `value_description`. I believe these were used before `primitive_description` existed, but we should be able to remove now because it was always an empty list.