### PR TITLE
fix: Fix String.ReplaceAll

### DIFF
--- a/compiler/test/stdlib/string.test.gr
+++ b/compiler/test/stdlib/string.test.gr
@@ -238,6 +238,7 @@ assert String.replaceAll("/", "\/", "/test/test/test/") ==
   "\/test\/test\/test\/"
 assert String.replaceAll(",", "|", "test,test,test") == "test|test|test"
 
+assert String.replaceAll("MeowMeow", "Meow", "MeowMeowMeowMeow") == "MeowMeow"
 let processBytes = b => {
   let ret = Array.make(Bytes.length(b), 0l)
   for (let mut i = 0; i < Bytes.length(b); i += 1) {

--- a/stdlib/string.gr
+++ b/stdlib/string.gr
@@ -1035,6 +1035,8 @@ provide let replaceAll =
         found = true
         foundCount += 1n
         foundIndexes = [tagSimpleNumber(foundIndex), ...foundIndexes]
+        foundIndex -= patternLen - 1n
+        i -= patternLen - 1n
       }
     }
     if (found) {


### PR DESCRIPTION
This pr fixes #1700 , The issue had nothing todo with the recursive pattern given how ReplaceAll only replaces the strings after it finds them all the real issue was that in the inital implementation it was never accounted for a scenario of the distance betweeen two matching patterns being smaller then the matching length this new pr changes that so when we find a match we increment by the length of the pattern.


Essentially what was happening is in the example below we were matching three sets of `Meow` when the second two `Meow`s should be eaten by the first match and the last match.
```
String.replaceAll("MeowMeow", "Meow", "MeowMeowMeowMeow")
```