### PR TITLE
feat(stdlib): Add `linearInterpolate`, `linearMap` and `clamp`

### DIFF
--- a/compiler/test/stdlib/number.test.gr
+++ b/compiler/test/stdlib/number.test.gr
@@ -710,3 +710,79 @@ assert Number.toRadians(1/4) == 0.004363323129985824
 assert Number.toRadians(9223372036854775809) == 160978210179491630.0
 assert Number.toRadians(Infinity) == Infinity
 assert Number.isNaN(Number.toRadians(NaN))
+
+// Number.clamp
+// TODO(#471): Use Range Syntax
+assert Number.clamp({ rangeStart: 0, rangeEnd: 1 }, 1) == 1
+assert Number.clamp({ rangeStart: 0, rangeEnd: 1 }, 0) == 0
+assert Number.clamp({ rangeStart: 0, rangeEnd: 1 }, 0.5) == 0.5
+assert Number.clamp({ rangeStart: 0, rangeEnd: 1 }, 1/2) == 1/2
+assert Number.clamp({ rangeStart: 0, rangeEnd: 1/2 }, 1/2) == 1/2
+assert Number.clamp({ rangeStart: 0, rangeEnd: 1 }, -0.1) == 0
+assert Number.clamp({ rangeStart: 0, rangeEnd: 1 }, -1) == 0
+assert Number.clamp({ rangeStart: 0, rangeEnd: 1 }, 1.1) == 1
+assert Number.clamp({ rangeStart: 0, rangeEnd: 1 }, 2) == 1
+assert Number.clamp({ rangeStart: -1, rangeEnd: 1 }, -1) == -1
+assert Number.clamp({ rangeStart: -2, rangeEnd: -1 }, -1) == -1
+assert Number.clamp({ rangeStart: -2, rangeEnd: -1 }, -2) == -2
+assert Number.clamp({ rangeStart: -1, rangeEnd: -2 }, -2) == -2
+assert Number.clamp({ rangeStart: -1, rangeEnd: -2 }, -2) == -2
+assert Number.clamp({ rangeStart: Infinity, rangeEnd: -Infinity }, 2) == 2
+assert Number.clamp({ rangeStart: -Infinity, rangeEnd: Infinity }, 2) == 2
+assert Number.clamp({ rangeStart: Infinity, rangeEnd: -Infinity }, Infinity) ==
+  Infinity
+assert Number.isNaN(
+  Number.clamp({ rangeStart: -Infinity, rangeEnd: Infinity }, NaN)
+)
+assert Number.isNaN(Number.clamp({ rangeStart: 0, rangeEnd: -1 }, NaN))
+
+// Number.linearInterpolate
+// TODO(#471): Use Range Syntax
+assert Number.linearInterpolate({ rangeStart: 0, rangeEnd: 1 }, 0) == 0
+assert Number.linearInterpolate({ rangeStart: 0, rangeEnd: 1 }, 1) == 1
+assert Number.linearInterpolate({ rangeStart: 0, rangeEnd: 1 }, 0.5) == 0.5
+assert Number.linearInterpolate({ rangeStart: 0, rangeEnd: 1 }, 0.75) == 0.75
+assert Number.linearInterpolate({ rangeStart: 0, rangeEnd: 100 }, 0.75) == 75
+assert Number.linearInterpolate({ rangeStart: 0, rangeEnd: 100 }, 1/4) == 25
+assert Number.linearInterpolate({ rangeStart: -100, rangeEnd: 0 }, 0.5) == -50
+assert Number.linearInterpolate({ rangeStart: -100, rangeEnd: 100 }, 0.5) == 0
+assert Number.linearInterpolate({ rangeStart: -100, rangeEnd: 100 }, 1/2) == 0
+
+// Number.linearMap
+// TODO(#471): Use Range Syntax
+assert Number.linearMap(
+  { rangeStart: 0, rangeEnd: 1 },
+  { rangeStart: 0, rangeEnd: 100 },
+  1/2
+) ==
+  50
+assert Number.linearMap(
+  { rangeStart: 0, rangeEnd: 1 },
+  { rangeStart: 0, rangeEnd: 50 },
+  1/2
+) ==
+  25
+assert Number.linearMap(
+  { rangeStart: -1, rangeEnd: 1 },
+  { rangeStart: 0, rangeEnd: 50 },
+  0
+) ==
+  25
+assert Number.linearMap(
+  { rangeStart: -1, rangeEnd: 1 },
+  { rangeStart: 0, rangeEnd: 50 },
+  2
+) ==
+  50
+assert Number.linearMap(
+  { rangeStart: -1, rangeEnd: 1 },
+  { rangeStart: 0, rangeEnd: 50 },
+  -2
+) ==
+  0
+assert Number.linearMap(
+  { rangeStart: -1, rangeEnd: 1 },
+  { rangeStart: 0, rangeEnd: 200 },
+  0.5
+) ==
+  150

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -672,9 +672,9 @@ provide let toRadians = degrees => degrees * (pi / 180)
 provide let toDegrees = radians => radians * (180 / pi)
 
 /**
- * Constrains a number to a given range (inclusive).
+ * Constrains a number to a given inclusive range.
  *
- * @param range: The inclusive range to clamp within.
+ * @param range: The inclusive range to clamp within
  * @param input: The number to clamp
  * @returns The constrained number
  *
@@ -693,10 +693,10 @@ provide let clamp = (range, input) => {
 }
 
 /**
- * Blends between a linear range (inclusive) of numbers using a given weight.
+ * maps a `weight` between 0 and 1 a the given inclusive range.
  *
  * @param range: An inclusive range to interpolate between
- * @param weight: a weight between 0 and 1 to interpolate by
+ * @param weight: The weight between 0 and 1 used to interpolate
  * @returns The blended value
  *
  * @throws InvalidArgument(String): When `weight` is not between 0 and 1
@@ -709,14 +709,14 @@ provide let linearInterpolate = (range, weight) => {
   if (weight < 0 || weight > 1 || isNaN(weight))
     throw Exception.InvalidArgument("Weight must be between 0 and 1")
   if (isInfinite(range.rangeStart) || isInfinite(range.rangeEnd))
-    throw Exception.InvalidArgument("The Range must be finite")
+    throw Exception.InvalidArgument("The range must be finite")
   if (isNaN(range.rangeStart) || isNaN(range.rangeEnd))
-    throw Exception.InvalidArgument("The Range must not include NaN")
+    throw Exception.InvalidArgument("The range must not include NaN")
   (range.rangeEnd - range.rangeStart) * weight + range.rangeStart
 }
 
 /**
- * Scales a number from one range (inclusive) to another (inclusive).
+ * Scales a number from one inclusive range to another inclusive range.
  * If the number is outside the input range, it will be clamped.
  *
  * @param inputRange: The inclusive numeric range you are mapping from

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -672,7 +672,7 @@ provide let toRadians = degrees => degrees * (pi / 180)
 provide let toDegrees = radians => radians * (180 / pi)
 
 /**
- * Constrains a number to a given inclusive range.
+ * Constrains a number within the given inclusive range.
  *
  * @param range: The inclusive range to clamp within
  * @param input: The number to clamp
@@ -693,10 +693,10 @@ provide let clamp = (range, input) => {
 }
 
 /**
- * maps a `weight` between 0 and 1 a the given inclusive range.
+ * Maps a weight between 0 and 1 within the given inclusive range.
  *
- * @param range: An inclusive range to interpolate between
- * @param weight: The weight between 0 and 1 used to interpolate
+ * @param range: The inclusive range to interpolate within
+ * @param weight: The weight to interpolate
  * @returns The blended value
  *
  * @throws InvalidArgument(String): When `weight` is not between 0 and 1
@@ -719,10 +719,9 @@ provide let linearInterpolate = (range, weight) => {
  * Scales a number from one inclusive range to another inclusive range.
  * If the number is outside the input range, it will be clamped.
  *
- * @param inputRange: The inclusive numeric range you are mapping from
- * @param outputRange: The inclusive numeric range you are mapping to
+ * @param inputRange: The inclusive range you are mapping from
+ * @param outputRange: The inclusive range you are mapping to
  * @param current: The number to map
- *
  * @returns The mapped number
  *
  * @throws InvalidArgument(String): When `inputRange` is not finite

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -696,7 +696,7 @@ provide let clamp = (range, input) => {
  * Linearly interpolates across the provided range by the given amount.
  *
  * @param range: An inclusive Range to interpolate between
- * @param amount: an amount between 0 and 1, anything outside the range will produce an extrapolation i.e `lerp(0, 100, 2)` will produce 200
+ * @param amount: an amount between 0 and 1, anything outside the range will produce an extrapolation, i.e. `lerp(0, 100, 2)` will produce 200
  * @returns The interpolated value
  *
  * @throws InvalidArgument(String): When `amount` is not between 0 and 1 or `range` is not finite

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -670,3 +670,89 @@ provide let toRadians = degrees => degrees * (pi / 180)
  * @since v0.5.4
  */
 provide let toDegrees = radians => radians * (180 / pi)
+
+/**
+ * Clamps a number to a given range.
+ *
+ * @param range: The inclusive range to clamp within.
+ * @param input: The number to clamp
+ * @returns The clamped number
+ *
+ * @since v0.6.0
+ */
+provide let clamp = (range, input) => {
+  if (isNaN(input)) {
+    input
+  } else {
+    let rangeEnd = max(range.rangeStart, range.rangeEnd)
+    let rangeStart = min(range.rangeStart, range.rangeEnd)
+
+    if (input > rangeEnd) rangeEnd else if (input < rangeStart) rangeStart
+    else input
+  }
+}
+
+/**
+ * Linearly interpolates across the provided range by the given amount.
+ *
+ * @param range: An inclusive Range to interpolate between
+ * @param amount: an amount between 0 and 1, anything outside the range will produce an extrapolation i.e `lerp(0, 100, 2)` will produce 200
+ * @returns The interpolated value
+ *
+ * @throws InvalidArgument(String): When `amount` is not between 0 and 1 or `range` is not finite
+ *
+ * @since v0.6.0
+ */
+provide let linearInterpolate = (range, amount) => {
+  if (amount < 0 || amount > 1 || isNaN(amount))
+    throw Exception.InvalidArgument("Amount must be between 0 and 1")
+  if (
+    isInfinite(range.rangeStart) ||
+    isInfinite(range.rangeEnd) ||
+    isNaN(range.rangeStart) ||
+    isNaN(range.rangeEnd)
+  ) throw Exception.InvalidArgument("The Range must be finite and not NaN")
+  (range.rangeEnd - range.rangeStart) * amount + range.rangeStart
+}
+
+/**
+ * Linearly maps the given number from one range to another.
+ *
+ * @param inputRange: The inclusive numeric range you are mapping from.
+ * @param outputRange: The inclusive numeric range you are mapping to.
+ * @param current: The number to map
+ * @returns The interpolated value, if the input is outside the input range, the output will be clamped to the output range.
+ *
+ * @throws InvalidArgument(String): When `inputRange` or `outputRange` are not finite
+ *
+ * @since v0.6.0
+ */
+provide let linearMap = (inputRange, outputRange, current) => {
+  if (isNaN(current)) {
+    current
+  } else {
+    if (
+      isInfinite(inputRange.rangeStart) ||
+      isInfinite(inputRange.rangeEnd) ||
+      isNaN(inputRange.rangeStart) ||
+      isNaN(inputRange.rangeEnd)
+    )
+      throw Exception.InvalidArgument(
+        "The inputRange must be finite and not NaN"
+      )
+    if (
+      isInfinite(outputRange.rangeStart) ||
+      isInfinite(outputRange.rangeEnd) ||
+      isNaN(outputRange.rangeStart) ||
+      isNaN(outputRange.rangeEnd)
+    )
+      throw Exception.InvalidArgument(
+        "The outputRange must be finite and not NaN"
+      )
+    let mapped = (current - inputRange.rangeStart) *
+      (outputRange.rangeEnd - outputRange.rangeStart) /
+      (inputRange.rangeEnd - inputRange.rangeStart) +
+      outputRange.rangeStart
+    clamp(outputRange, mapped)
+  }
+}

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -672,11 +672,11 @@ provide let toRadians = degrees => degrees * (pi / 180)
 provide let toDegrees = radians => radians * (180 / pi)
 
 /**
- * Clamps a number to a given range.
+ * Constrains a number to a given range (inclusive).
  *
  * @param range: The inclusive range to clamp within.
  * @param input: The number to clamp
- * @returns The clamped number
+ * @returns The constrained number
  *
  * @since v0.6.0
  */
@@ -693,37 +693,42 @@ provide let clamp = (range, input) => {
 }
 
 /**
- * Linearly interpolates across the provided range by the given amount.
+ * Blends between a linear range (inclusive) of numbers using a given weight.
  *
- * @param range: An inclusive Range to interpolate between
- * @param amount: an amount between 0 and 1, anything outside the range will produce an extrapolation, i.e. `lerp(0, 100, 2)` will produce 200
- * @returns The interpolated value
+ * @param range: An inclusive range to interpolate between
+ * @param weight: a weight between 0 and 1 to interpolate by
+ * @returns The blended value
  *
- * @throws InvalidArgument(String): When `amount` is not between 0 and 1 or `range` is not finite
+ * @throws InvalidArgument(String): When `weight` is not between 0 and 1
+ * @throws InvalidArgument(String): When `range` is not finite
+ * @throws InvalidArgument(String): When `range` includes NaN
  *
  * @since v0.6.0
  */
-provide let linearInterpolate = (range, amount) => {
-  if (amount < 0 || amount > 1 || isNaN(amount))
-    throw Exception.InvalidArgument("Amount must be between 0 and 1")
-  if (
-    isInfinite(range.rangeStart) ||
-    isInfinite(range.rangeEnd) ||
-    isNaN(range.rangeStart) ||
-    isNaN(range.rangeEnd)
-  ) throw Exception.InvalidArgument("The Range must be finite and not NaN")
-  (range.rangeEnd - range.rangeStart) * amount + range.rangeStart
+provide let linearInterpolate = (range, weight) => {
+  if (weight < 0 || weight > 1 || isNaN(weight))
+    throw Exception.InvalidArgument("Weight must be between 0 and 1")
+  if (isInfinite(range.rangeStart) || isInfinite(range.rangeEnd))
+    throw Exception.InvalidArgument("The Range must be finite")
+  if (isNaN(range.rangeStart) || isNaN(range.rangeEnd))
+    throw Exception.InvalidArgument("The Range must not include NaN")
+  (range.rangeEnd - range.rangeStart) * weight + range.rangeStart
 }
 
 /**
- * Linearly maps the given number from one range to another.
+ * Scales a number from one range (inclusive) to another (inclusive).
+ * If the number is outside the input range, it will be clamped.
  *
- * @param inputRange: The inclusive numeric range you are mapping from.
- * @param outputRange: The inclusive numeric range you are mapping to.
+ * @param inputRange: The inclusive numeric range you are mapping from
+ * @param outputRange: The inclusive numeric range you are mapping to
  * @param current: The number to map
- * @returns The interpolated value, if the input is outside the input range, the output will be clamped to the output range.
  *
- * @throws InvalidArgument(String): When `inputRange` or `outputRange` are not finite
+ * @returns The mapped number
+ *
+ * @throws InvalidArgument(String): When `inputRange` is not finite
+ * @throws InvalidArgument(String): When `inputRange` includes NaN
+ * @throws InvalidArgument(String): When `outputRange` is not finite
+ * @throws InvalidArgument(String): When `outputRange` includes NaN
  *
  * @since v0.6.0
  */
@@ -731,24 +736,14 @@ provide let linearMap = (inputRange, outputRange, current) => {
   if (isNaN(current)) {
     current
   } else {
-    if (
-      isInfinite(inputRange.rangeStart) ||
-      isInfinite(inputRange.rangeEnd) ||
-      isNaN(inputRange.rangeStart) ||
-      isNaN(inputRange.rangeEnd)
-    )
-      throw Exception.InvalidArgument(
-        "The inputRange must be finite and not NaN"
-      )
-    if (
-      isInfinite(outputRange.rangeStart) ||
-      isInfinite(outputRange.rangeEnd) ||
-      isNaN(outputRange.rangeStart) ||
-      isNaN(outputRange.rangeEnd)
-    )
-      throw Exception.InvalidArgument(
-        "The outputRange must be finite and not NaN"
-      )
+    if (isInfinite(inputRange.rangeStart) || isInfinite(inputRange.rangeEnd))
+      throw Exception.InvalidArgument("The inputRange must be finite")
+    if (isNaN(inputRange.rangeStart) || isNaN(inputRange.rangeEnd))
+      throw Exception.InvalidArgument("The inputRange must not include NaN")
+    if (isInfinite(outputRange.rangeStart) || isInfinite(outputRange.rangeEnd))
+      throw Exception.InvalidArgument("The outputRange must be finite")
+    if (isNaN(outputRange.rangeStart) || isNaN(outputRange.rangeEnd))
+      throw Exception.InvalidArgument("The outputRange must not include NaN")
     let mapped = (current - inputRange.rangeStart) *
       (outputRange.rangeEnd - outputRange.rangeStart) /
       (inputRange.rangeEnd - inputRange.rangeStart) +

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -997,7 +997,7 @@ No other changes yet.
 clamp : (range: Range<Number>, input: Number) -> Number
 ```
 
-Constrains a number to a given inclusive range.
+Constrains a number within the given inclusive range.
 
 Parameters:
 
@@ -1023,14 +1023,14 @@ No other changes yet.
 linearInterpolate : (range: Range<Number>, weight: Number) -> Number
 ```
 
-maps a `weight` between 0 and 1 a the given inclusive range.
+Maps a weight between 0 and 1 within the given inclusive range.
 
 Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`range`|`Range<Number>`|An inclusive range to interpolate between|
-|`weight`|`Number`|The weight between 0 and 1 used to interpolate|
+|`range`|`Range<Number>`|The inclusive range to interpolate within|
+|`weight`|`Number`|The weight to interpolate|
 
 Returns:
 
@@ -1066,8 +1066,8 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`inputRange`|`Range<Number>`|The inclusive numeric range you are mapping from|
-|`outputRange`|`Range<Number>`|The inclusive numeric range you are mapping to|
+|`inputRange`|`Range<Number>`|The inclusive range you are mapping from|
+|`outputRange`|`Range<Number>`|The inclusive range you are mapping to|
 |`current`|`Number`|The number to map|
 
 Returns:

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -986,3 +986,94 @@ Returns:
 |----|-----------|
 |`Number`|The value in degrees|
 
+### Number.**clamp**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+clamp : (Range<Number>, Number) -> Number
+```
+
+Clamps a number to a given range.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`range`|`Range<Number>`|The inclusive range to clamp within.|
+|`input`|`Number`|The number to clamp|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The clamped number|
+
+### Number.**linearInterpolate**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+linearInterpolate : (Range<Number>, Number) -> Number
+```
+
+Linearly interpolates across the provided range by the given amount.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`range`|`Range<Number>`|An inclusive Range to interpolate between|
+|`amount`|`Number`|an amount between 0 and 1, anything outside the range will produce an extrapolation i.e `lerp(0, 100, 2)` will produce 200|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The interpolated value|
+
+Throws:
+
+`InvalidArgument(String)`
+
+* When `amount` is not between 0 and 1 or `range` is not finite
+
+### Number.**linearMap**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+linearMap : (Range<Number>, Range<Number>, Number) -> Number
+```
+
+Linearly maps the given number from one range to another.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`inputRange`|`Range<Number>`|The inclusive numeric range you are mapping from.|
+|`outputRange`|`Range<Number>`|The inclusive numeric range you are mapping to.|
+|`current`|`Number`|The number to map|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The interpolated value, if the input is outside the input range, the output will be clamped to the output range.|
+
+Throws:
+
+`InvalidArgument(String)`
+
+* When `inputRange` or `outputRange` are not finite
+

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -997,13 +997,13 @@ No other changes yet.
 clamp : (range: Range<Number>, input: Number) -> Number
 ```
 
-Constrains a number to a given range (inclusive).
+Constrains a number to a given inclusive range.
 
 Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`range`|`Range<Number>`|The inclusive range to clamp within.|
+|`range`|`Range<Number>`|The inclusive range to clamp within|
 |`input`|`Number`|The number to clamp|
 
 Returns:
@@ -1023,14 +1023,14 @@ No other changes yet.
 linearInterpolate : (range: Range<Number>, weight: Number) -> Number
 ```
 
-Blends between a linear range (inclusive) of numbers using a given weight.
+maps a `weight` between 0 and 1 a the given inclusive range.
 
 Parameters:
 
 |param|type|description|
 |-----|----|-----------|
 |`range`|`Range<Number>`|An inclusive range to interpolate between|
-|`weight`|`Number`|a weight between 0 and 1 to interpolate by|
+|`weight`|`Number`|The weight between 0 and 1 used to interpolate|
 
 Returns:
 
@@ -1059,7 +1059,7 @@ linearMap :
    Number
 ```
 
-Scales a number from one range (inclusive) to another (inclusive).
+Scales a number from one inclusive range to another inclusive range.
 If the number is outside the input range, it will be clamped.
 
 Parameters:

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -1030,7 +1030,7 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`range`|`Range<Number>`|An inclusive Range to interpolate between|
-|`amount`|`Number`|an amount between 0 and 1, anything outside the range will produce an extrapolation i.e `lerp(0, 100, 2)` will produce 200|
+|`amount`|`Number`|an amount between 0 and 1, anything outside the range will produce an extrapolation, i.e. `lerp(0, 100, 2)` will produce 200|
 
 Returns:
 

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -994,10 +994,10 @@ No other changes yet.
 </details>
 
 ```grain
-clamp : (Range<Number>, Number) -> Number
+clamp : (range: Range<Number>, input: Number) -> Number
 ```
 
-Clamps a number to a given range.
+Constrains a number to a given range (inclusive).
 
 Parameters:
 
@@ -1010,7 +1010,7 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`Number`|The clamped number|
+|`Number`|The constrained number|
 
 ### Number.**linearInterpolate**
 
@@ -1020,29 +1020,31 @@ No other changes yet.
 </details>
 
 ```grain
-linearInterpolate : (Range<Number>, Number) -> Number
+linearInterpolate : (range: Range<Number>, weight: Number) -> Number
 ```
 
-Linearly interpolates across the provided range by the given amount.
+Blends between a linear range (inclusive) of numbers using a given weight.
 
 Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`range`|`Range<Number>`|An inclusive Range to interpolate between|
-|`amount`|`Number`|an amount between 0 and 1, anything outside the range will produce an extrapolation, i.e. `lerp(0, 100, 2)` will produce 200|
+|`range`|`Range<Number>`|An inclusive range to interpolate between|
+|`weight`|`Number`|a weight between 0 and 1 to interpolate by|
 
 Returns:
 
 |type|description|
 |----|-----------|
-|`Number`|The interpolated value|
+|`Number`|The blended value|
 
 Throws:
 
 `InvalidArgument(String)`
 
-* When `amount` is not between 0 and 1 or `range` is not finite
+* When `weight` is not between 0 and 1
+* When `range` is not finite
+* When `range` includes NaN
 
 ### Number.**linearMap**
 
@@ -1052,28 +1054,34 @@ No other changes yet.
 </details>
 
 ```grain
-linearMap : (Range<Number>, Range<Number>, Number) -> Number
+linearMap :
+  (inputRange: Range<Number>, outputRange: Range<Number>, current: Number) ->
+   Number
 ```
 
-Linearly maps the given number from one range to another.
+Scales a number from one range (inclusive) to another (inclusive).
+If the number is outside the input range, it will be clamped.
 
 Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`inputRange`|`Range<Number>`|The inclusive numeric range you are mapping from.|
-|`outputRange`|`Range<Number>`|The inclusive numeric range you are mapping to.|
+|`inputRange`|`Range<Number>`|The inclusive numeric range you are mapping from|
+|`outputRange`|`Range<Number>`|The inclusive numeric range you are mapping to|
 |`current`|`Number`|The number to map|
 
 Returns:
 
 |type|description|
 |----|-----------|
-|`Number`|The interpolated value, if the input is outside the input range, the output will be clamped to the output range.|
+|`Number`|The mapped number|
 
 Throws:
 
 `InvalidArgument(String)`
 
-* When `inputRange` or `outputRange` are not finite
+* When `inputRange` is not finite
+* When `inputRange` includes NaN
+* When `outputRange` is not finite
+* When `outputRange` includes NaN
 


### PR DESCRIPTION
This pr adds `linearInterpolate`, `linearMap` and `clamp` to the `Number` stdlib.


This currrently is using the compilers in built `Range` record in the tests but should eventually be switched to the range syntax whenever it is added.

This is work on: #1017 