### PR TITLE
feat(stdlib)!: Add an exception to `%` when used on floats

### DIFF
--- a/stdlib/pervasives.md
+++ b/stdlib/pervasives.md
@@ -457,9 +457,16 @@ Returns:
 
 ### Pervasives.**(%)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.1.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>0.1.0</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>next</code></td><td>Throws an error if either operand is not an integer</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
@@ -481,6 +488,16 @@ Returns:
 |type|description|
 |----|-----------|
 |`Number`|The modulus of its operands|
+
+Throws:
+
+`ModuloByZero`
+
+* If the second operand is zero
+
+`NonIntegerModulus`
+
+* If either operand is not an integer
 
 ### Pervasives.**(\*\*)**
 

--- a/stdlib/runtime/exception.gr
+++ b/stdlib/runtime/exception.gr
@@ -93,6 +93,7 @@ provide let panicWithException = (e: Exception) => {
 
 provide exception DivisionByZero
 provide exception ModuloByZero
+provide exception NonIntegerModulus
 provide exception Overflow
 provide exception NumberNotIntlike
 provide exception NumberNotRational
@@ -114,6 +115,7 @@ let runtimeErrorPrinter = e => {
     IndexNonInteger => Some("IndexNonInteger: Index not an integer"),
     DivisionByZero => Some("DivisionByZero: Division by zero"),
     ModuloByZero => Some("ModuloByZero: Modulo by zero"),
+    NonIntegerModulus => Some("NonIntegerModulus: Modulo with float"),
     Overflow => Some("Overflow: Number overflow"),
     NumberNotIntlike =>
       Some("NumberNotIntlike: Can't coerce number to integer"),

--- a/stdlib/runtime/numbers.gr
+++ b/stdlib/runtime/numbers.gr
@@ -1139,10 +1139,10 @@ provide let cmpRationals = (x, y) => {
 
 /**
  * Finds the numerator of the rational number.
- * 
+ *
  * @param x: The rational number to inspect
  * @returns The numerator of the rational number
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -1155,10 +1155,10 @@ provide let rationalNumerator = (x: Rational) => {
 
 /**
  * Finds the denominator of the rational number.
- * 
+ *
  * @param x: The rational number to inspect
  * @returns The denominator of the rational number
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -1573,8 +1573,14 @@ let numberMod = (x, y) => {
   // incRef x and y to reuse them via WasmI32.toGrain
   Memory.incRef(x)
   Memory.incRef(y)
-  let xval = coerceNumberToWasmI64(WasmI32.toGrain(x): Number)
-  let yval = coerceNumberToWasmI64(WasmI32.toGrain(y): Number)
+  // If X or Y is a float, give a nicer error
+  let xPtr = WasmI32.toGrain(x)
+  let yPtr = WasmI32.toGrain(y)
+  if (!isInteger(xPtr) && !isInteger(yPtr)) {
+    throw Exception.NonIntegerModulus
+  }
+  let xval = coerceNumberToWasmI64(xPtr: Number)
+  let yval = coerceNumberToWasmI64(yPtr: Number)
   if (WasmI64.eqz(yval)) {
     throw Exception.ModuloByZero
   }
@@ -2337,7 +2343,7 @@ provide let coerceNumberToBigInt = (x: Number) => {
  *
  * @param number: The value to convert
  * @returns The Number represented as a Rational
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -2513,7 +2519,7 @@ provide let coerceBigIntToNumber = (x: BigInt) => {
  *
  * @param rational: The value to convert
  * @returns The Rational represented as a Number
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -2674,7 +2680,11 @@ provide let (/) = (x: Number, y: Number) => {
  * @param num2: The second operand
  * @returns The modulus of its operands
  *
+ * @throws ModuloByZero: If the second operand is zero
+ * @throws NonIntegerModulus: If either operand is not an integer
+ *
  * @since v0.1.0
+ * @history v0.6.0: Throws an error if either operand is not an integer
  */
 @unsafe
 provide let (%) = (x: Number, y: Number) => {

--- a/stdlib/runtime/numbers.md
+++ b/stdlib/runtime/numbers.md
@@ -1176,9 +1176,16 @@ Returns:
 
 ### Numbers.**(%)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.1.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>0.1.0</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>next</code></td><td>Throws an error if either operand is not an integer</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
@@ -1200,6 +1207,16 @@ Returns:
 |type|description|
 |----|-----------|
 |`Number`|The modulus of its operands|
+
+Throws:
+
+`ModuloByZero`
+
+* If the second operand is zero
+
+`NonIntegerModulus`
+
+* If either operand is not an integer
 
 ### Numbers.**incr**
 


### PR DESCRIPTION
This pr works on #1371 The ideal fix will eventually be to make `%` modulo work on floats but given that isnt staged for `v0.6.0` it makes sense to give it a nicer error until it is fixed. It would also make sense to rename that issue or open a new issue after this named `make modulo support floats`