### PR TITLE
chore(compiler): Represent the else branch of PExpIf as an option instead of empty block

### DIFF
--- a/compiler/src/parsing/ast_helper.rei
+++ b/compiler/src/parsing/ast_helper.rei
@@ -194,7 +194,7 @@ module Expression: {
       ~attributes: attributes=?,
       expression,
       expression,
-      expression
+      option(expression)
     ) =>
     expression;
   let while_:

--- a/compiler/src/parsing/ast_mapper.re
+++ b/compiler/src/parsing/ast_mapper.re
@@ -112,7 +112,7 @@ module E = {
         ~attributes,
         sub.expr(sub, c),
         sub.expr(sub, t),
-        sub.expr(sub, f),
+        Option.map(sub.expr(sub), f),
       )
     | PExpWhile(c, e) =>
       while_(~loc, ~attributes, sub.expr(sub, c), sub.expr(sub, e))

--- a/compiler/src/parsing/parser.mly
+++ b/compiler/src/parsing/parser.mly
@@ -509,7 +509,7 @@ let_expr:
   | ELSE opt_eols expr { $3 }
 
 if_expr:
-  | IF lparen expr rparen opt_eols expr ioption(else_expr) %prec _if { Expression.if_ ~loc:(to_loc $loc) $3 $6 (Option.value ~default:(Expression.block ~loc:(to_loc $loc($7)) []) $7) }
+  | IF lparen expr rparen opt_eols expr ioption(else_expr) %prec _if { Expression.if_ ~loc:(to_loc $loc) $3 $6 $7 }
 
 while_expr:
   | WHILE lparen expr rparen block { Expression.while_ ~loc:(to_loc $loc) $3 $5 }

--- a/compiler/src/parsing/parsetree.re
+++ b/compiler/src/parsing/parsetree.re
@@ -497,7 +497,7 @@ and expression_desc =
   | PExpPrim1(prim1, expression)
   | PExpPrim2(prim2, expression, expression)
   | PExpPrimN(primn, list(expression))
-  | PExpIf(expression, expression, expression)
+  | PExpIf(expression, expression, option(expression))
   | PExpWhile(expression, expression)
   | PExpFor(
       option(expression),

--- a/compiler/src/parsing/parsetree_iter.re
+++ b/compiler/src/parsing/parsetree_iter.re
@@ -267,7 +267,7 @@ and iter_expression =
   | PExpIf(c, t, f) =>
     iter_expression(hooks, c);
     iter_expression(hooks, t);
-    iter_expression(hooks, f);
+    Option.iter(iter_expression(hooks), f);
   | PExpWhile(c, b) =>
     iter_expression(hooks, c);
     iter_expression(hooks, b);

--- a/compiler/src/parsing/well_formedness.re
+++ b/compiler/src/parsing/well_formedness.re
@@ -453,10 +453,10 @@ let malformed_return_statements = (errs, super) => {
         };
       };
       find(expressions);
-    | PExpIf(_, _, {pexp_desc: PExpBlock([])}) =>
+    | PExpIf(_, _, None) =>
       // If expressions with no else branch are not considered
       false
-    | PExpIf(_, ifso, ifnot) =>
+    | PExpIf(_, ifso, Some(ifnot)) =>
       has_returning_branch(ifso) || has_returning_branch(ifnot)
     | PExpMatch(_, branches) =>
       List.exists(branch => has_returning_branch(branch.pmb_body), branches)
@@ -480,7 +480,7 @@ let malformed_return_statements = (errs, super) => {
         };
       };
       collect(expressions);
-    | PExpIf(_, ifso, ifnot) when has_returning_branch(exp) =>
+    | PExpIf(_, ifso, Some(ifnot)) when has_returning_branch(exp) =>
       collect_non_returning_branches(ifso, [])
       @ collect_non_returning_branches(ifnot, acc)
     | PExpMatch(_, branches) when has_returning_branch(exp) =>

--- a/compiler/src/typed/typecore.re
+++ b/compiler/src/typed/typecore.re
@@ -1337,8 +1337,8 @@ and type_expect_ =
       );
 
     let (ifso, ifnot) =
-      switch (sifnot.pexp_desc) {
-      | PExpBlock([]) =>
+      switch (sifnot) {
+      | None =>
         let void_exp = {
           exp_desc: TExpConstant(Const_void),
           exp_loc: loc,
@@ -1358,7 +1358,7 @@ and type_expect_ =
           );
         let ifnot = {...void_exp, exp_desc: TExpBlock([void_exp])};
         (ifso, ifnot);
-      | _ =>
+      | Some(sifnot) =>
         let ifso = type_expect(env, sifso, ty_expected_explained);
         let ifnot = type_expect(env, sifnot, ty_expected_explained);
         /* Both types should match */

--- a/compiler/test/suites/basic_functionality.re
+++ b/compiler/test/suites/basic_functionality.re
@@ -165,6 +165,11 @@ describe("basic functionality", ({test, testSkip}) => {
   assertSnapshot("if_one_sided5", "let mut x = 1; if (3 < 4) x = 2 + 3");
   assertSnapshot("if_one_sided6", "let mut x = 1; if (3 < 4) x = 2 + 3; x");
   assertCompileError(
+    "if_empty_block",
+    "if (false) 1 else {}",
+    "Syntax error",
+  );
+  assertCompileError(
     "if_one_sided_type_err",
     "let foo = (if (false) { ignore(5) }); let bar = foo + 5; bar",
     "has type Void but",


### PR DESCRIPTION
While working on the formatter stuff, I noticed that we represented the `else` branch as an empty block in the AST. This makes things like the formatter harder, so I think we should just change it to `option(expression)`.