### PR TITLE
feat(compiler)!: Custom box printing

### DIFF
--- a/compiler/test/suites/strings.re
+++ b/compiler/test/suites/strings.re
@@ -241,6 +241,8 @@ bar", 1))|},
     {|print(("foo\"bar", 1))|},
     "(\"foo\\\"bar\", 1)\n",
   );
+  assertRun("toString_boxing1", {|print(box(1))|}, "box(1)\n");
+  assertRun("toString_boxing2", {|print(box(true))|}, "box(true)\n");
   assertCompileError(
     "string_err",
     "let x = \"hello\"; x + \", world\"",

--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -28,7 +28,6 @@ include "runtime/unsafe/tags" as Tags
 include "runtime/numberUtils" as NumberUtils
 
 include "runtime/dataStructures" as DataStructures
-
 from DataStructures use { allocateString, allocateArray, untagSimpleNumber }
 
 foreign wasm fd_write: (

--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -28,6 +28,7 @@ include "runtime/unsafe/tags" as Tags
 include "runtime/numberUtils" as NumberUtils
 
 include "runtime/dataStructures" as DataStructures
+
 from DataStructures use { allocateString, allocateArray, untagSimpleNumber }
 
 foreign wasm fd_write: (
@@ -512,13 +513,12 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
         WasmI32.store(ptr, 0x80000000n | tupleLength, 4n)
         let comspace = ", "
         let rparen = ")"
+        let mut lparen = "("
         let mut strings = [rparen]
         if (tupleLength <= 1n) {
           // Special case: unary tuple, which is not valid Grain syntax; however, boxed values
           // are stored as a unary tuple, so we keep this in case one gets printed
-          let comma = ","
-          strings = [comma, ...strings]
-          void
+          lparen = "Box("
         }
         for (let mut i = tupleLength * 4n - 4n; i >= 0n; i -= 4n) {
           let item = toStringHelp(
@@ -534,7 +534,6 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
         WasmI32.store(ptr, tupleLength, 4n)
 
         Memory.incRef(WasmI32.fromGrain(strings))
-        let lparen = "("
         strings = [lparen, ...strings]
 
         join(strings)

--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -515,11 +515,6 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
         let rparen = ")"
         let mut lparen = "("
         let mut strings = [rparen]
-        if (tupleLength <= 1n) {
-          // Special case: unary tuple, which is not valid Grain syntax; however, boxed values
-          // are stored as a unary tuple, so we keep this in case one gets printed
-          lparen = "Box("
-        }
         for (let mut i = tupleLength * 4n - 4n; i >= 0n; i -= 4n) {
           let item = toStringHelp(
             WasmI32.load(ptr + i, 8n),
@@ -535,7 +530,11 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
 
         Memory.incRef(WasmI32.fromGrain(strings))
         strings = [lparen, ...strings]
-
+        if (tupleLength <= 1n) {
+          // Special case: unary tuple, which is not valid Grain syntax; however, boxed values
+          // are stored as a unary tuple, so we keep this in case one gets printed
+          strings = ["box", ...strings]
+        }
         join(strings)
       }
     },


### PR DESCRIPTION
This pr adds custom box printing.
Now single argument tuples will be wrinted as `Box(1)` intead of `(1,)` given the only safe way to create a single arugment tuple is by using the box primitive.

I am wondering where I would add a regression test for this if needed I couldn't see anywhere, that we were testing `print` or `toString`.

Closes: #1620 