### PR TITLE
chore(compiler): Escape `"` in char well formness error

### DIFF
--- a/compiler/src/parsing/well_formedness.re
+++ b/compiler/src/parsing/well_formedness.re
@@ -33,7 +33,7 @@ let prepare_error =
           ~loc,
           "This character literal contains multiple characters: '%s'\nDid you mean to create the string \"%s\" instead?",
           cl,
-          cl,
+          Str.global_replace(Str.regexp({|"|}), {|\"|}, cl),
         )
       | ExternalAlias(name, loc) =>
         errorf(~loc, "Alias '%s' should be at most one level deep.", name)

--- a/compiler/test/suites/chars.re
+++ b/compiler/test/suites/chars.re
@@ -67,9 +67,15 @@ describe("chars", ({test, testSkip}) => {
   assertRun("char_toString_escape8", {|print(('\v', 1))|}, "('\\v', 1)\n");
   assertRun("char_toString_escape9", {|print(('\'', 1))|}, "('\\'', 1)\n");
   assertCompileError(
-    "char_illegal",
+    "char_illegal1",
     "'abc'",
     "This character literal contains multiple characters: 'abc'\nDid you mean to create the string \"abc\" instead?",
+  );
+  assertCompileError(
+    "char_illegal2",
+    {|'{"test": 1}'|},
+    {|This character literal contains multiple characters: '{"test": 1}'
+Did you mean to create the string "{\"test\": 1}" instead?|},
   );
   assertCompileError(
     "unicode_err1",

--- a/compiler/test/suites/chars.re
+++ b/compiler/test/suites/chars.re
@@ -74,8 +74,8 @@ describe("chars", ({test, testSkip}) => {
   assertCompileError(
     "char_illegal2",
     {|'{"test": 1}'|},
-    {|This character literal contains multiple characters: '{"test": 1}'
-Did you mean to create the string "{\"test\": 1}" instead?|},
+    {|This character literal contains multiple characters: '\{"test": 1\}'
+Did you mean to create the string "\{\\"test\\": 1\}" instead?|},
   );
   assertCompileError(
     "unicode_err1",


### PR DESCRIPTION
This pr escapes `"` in the error for chars that are meant to be strings.


This is because in a case like `'{"test":1}'` when the compiler asks you if you mean `"{"test":1}"` it would be an invalid string so instead the new error looks like `"{\"test\":1}'` 