### PR TITLE
chore(stdlib): Add `throws` documentation to array

### DIFF
--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -58,7 +58,7 @@ provide let length = array => {
  * @param item: The value to store at each index
  * @returns The new array
  *
- * @throws InvalidArgument(String): When `length` is not an integer
+ * @throws InvalidArgument(String): When `length` is not an int32
  * @throws InvalidArgument(String): When `length` is negative
  *
  * @example Array.make(5, "foo") // [> "foo", "foo", "foo", "foo", "foo"]
@@ -91,7 +91,7 @@ provide let make: (Number, a) -> Array<a> = (length: Number, item: a) => {
  * @param fn: The initializer function to call with each index, where the value returned will be used to initialize the element
  * @returns The new array
  *
- * @throws InvalidArgument(String): When `length` is not an integer
+ * @throws InvalidArgument(String): When `length` is not an int32
  * @throws InvalidArgument(String): When `length` is negative
  *
  * @example Array.init(5, n => n + 3) // [> 3, 4, 5, 6, 7]
@@ -129,6 +129,10 @@ provide let init: (Number, Number -> a) -> Array<a> =
  * @param index: The index to access
  * @param array: The array to access
  * @returns The element from the array
+ *
+ * @throws IndexOutOfBounds: When `index` is not an int32
+ * @throws IndexOutOfBounds: When `index` is out of bounds
+ *
  * @example Array.get(1,[> 1, 2, 3, 4, 5]) == 2
  *
  * @since v0.1.0
@@ -147,6 +151,10 @@ provide let get = (index, array) => {
  * @param index: The index to update
  * @param value: The value to store
  * @param array: The array to update
+ *
+ * @throws IndexOutOfBounds: When `index` is not an int32
+ * @throws IndexOutOfBounds: When `index` is out of bounds
+ *
  * @example Array.set(1, 9, [> 1, 2, 3, 4, 5]) == [> 1, 9, 3, 4, 5]
  *
  * @since v0.1.0
@@ -163,6 +171,9 @@ provide let set = (index, value, array) => {
  * @param array1: The array containing elements to appear first
  * @param array2: The array containing elements to appear second
  * @returns The new array containing elements from `array1` followed by elements from `array2`
+ *
+ * @throws InvalidArgument(String): When the combined length of the two arrays is not an int32
+ *
  * @example Array.append([> 1, 2], [> 3, 4, 5]) == [> 1, 2, 3, 4, 5]
  *
  * @since v0.1.0
@@ -186,6 +197,9 @@ provide let append = (array1, array2) => {
  *
  * @param arrays: A list containing all arrays to combine
  * @returns The new array
+ *
+ * @throws InvalidArgument(String): When the combined length of the all arrays is not an int32
+ *
  * @example Array.concat([[> 1, 2], [> 3, 4], [> 5, 6]]) == [> 1, 2, 3, 4, 5, 6]
  *
  * @since v0.1.0
@@ -405,6 +419,8 @@ provide let reducei = (fn, initial, array) => {
  * @param array: The array to iterate
  * @returns The new array
  *
+ * @throws InvalidArgument(String): When the combined length of the all arrays is not an int32
+ *
  * @since v0.3.0
  */
 provide let flatMap = (fn, array) => {
@@ -485,6 +501,9 @@ provide let fill = (value, array) => {
  * @param start: The index to begin replacement
  * @param stop: The (exclusive) index to end replacement
  * @param array: The array to update
+ *
+ * @throws Failure(String): When the start index is out of bounds
+ * @throws Failure(String): When the start index is greater then the stop index
  *
  * @since v0.2.0
  */
@@ -639,6 +658,8 @@ provide let findIndex = (fn, array) => {
  * @param array2: The array to provide values for the second tuple element
  * @returns The new array containing all pairs of `(a, b)`
  *
+ * @throws InvalidArgument(String): When the multiplied array lengths are not an int32
+ *
  * @since v0.2.0
  */
 provide let product = (array1: Array<a>, array2: Array<b>) => {
@@ -768,7 +789,7 @@ provide let unique = array => {
  * @param array2: The array to provide values for the second tuple element
  * @returns The new array containing indexed pairs of `(a, b)`
  *
- * @throws Failure(String): When the arrays have different sizes
+ * @throws IndexOutOfBounds(String): When the arrays have different sizes
  *
  * @since v0.4.0
  * @history v0.6.0: Support zipping arrays of different sizes
@@ -796,6 +817,8 @@ provide let zip = (array1: Array<a>, array2: Array<b>) => {
  * @param array1: The array whose elements will each be passed to the function as the first argument
  * @param array2: The array whose elements will each be passed to the function as the second argument
  * @returns The new array containing elements derived from applying the function to pairs of input array elements
+ *
+ * @throws IndexOutOfBounds(String): When the arrays have different sizes
  *
  * @example Array.zipWith((a, b) => a + b, [> 1, 2, 3], [> 4, 5, 6]) // [> 5, 7, 9]
  * @example Array.zipWith((a, b) => a * b, [> 1, 2, 3], [> 4, 5]) // [> 4, 10]

--- a/stdlib/array.md
+++ b/stdlib/array.md
@@ -87,7 +87,7 @@ Throws:
 
 `InvalidArgument(String)`
 
-* When `length` is not an integer
+* When `length` is not an int32
 * When `length` is negative
 
 Examples:
@@ -128,7 +128,7 @@ Throws:
 
 `InvalidArgument(String)`
 
-* When `length` is not an integer
+* When `length` is not an int32
 * When `length` is negative
 
 Examples:
@@ -173,6 +173,13 @@ Returns:
 |----|-----------|
 |`a`|The element from the array|
 
+Throws:
+
+`IndexOutOfBounds`
+
+* When `index` is not an int32
+* When `index` is out of bounds
+
 Examples:
 
 ```grain
@@ -210,6 +217,13 @@ Parameters:
 |`value`|`a`|The value to store|
 |`array`|`Array<a>`|The array to update|
 
+Throws:
+
+`IndexOutOfBounds`
+
+* When `index` is not an int32
+* When `index` is out of bounds
+
 Examples:
 
 ```grain
@@ -243,6 +257,12 @@ Returns:
 |----|-----------|
 |`Array<a>`|The new array containing elements from `array1` followed by elements from `array2`|
 
+Throws:
+
+`InvalidArgument(String)`
+
+* When the combined length of the two arrays is not an int32
+
 Examples:
 
 ```grain
@@ -274,6 +294,12 @@ Returns:
 |type|description|
 |----|-----------|
 |`Array<a>`|The new array|
+
+Throws:
+
+`InvalidArgument(String)`
+
+* When the combined length of the all arrays is not an int32
 
 Examples:
 
@@ -585,6 +611,12 @@ Returns:
 |----|-----------|
 |`Array<a>`|The new array|
 
+Throws:
+
+`InvalidArgument(String)`
+
+* When the combined length of the all arrays is not an int32
+
 ### Array.**every**
 
 <details disabled>
@@ -681,6 +713,13 @@ Parameters:
 |`start`|`Number`|The index to begin replacement|
 |`stop`|`Number`|The (exclusive) index to end replacement|
 |`array`|`Array<a>`|The array to update|
+
+Throws:
+
+`Failure(String)`
+
+* When the start index is out of bounds
+* When the start index is greater then the stop index
 
 ### Array.**reverse**
 
@@ -863,6 +902,12 @@ Returns:
 |----|-----------|
 |`Array<(a, b)>`|The new array containing all pairs of `(a, b)`|
 
+Throws:
+
+`InvalidArgument(String)`
+
+* When the multiplied array lengths are not an int32
+
 ### Array.**count**
 
 <details disabled>
@@ -1035,7 +1080,7 @@ Returns:
 
 Throws:
 
-`Failure(String)`
+`IndexOutOfBounds(String)`
 
 * When the arrays have different sizes
 
@@ -1072,6 +1117,12 @@ Returns:
 |type|description|
 |----|-----------|
 |`Array<c>`|The new array containing elements derived from applying the function to pairs of input array elements|
+
+Throws:
+
+`IndexOutOfBounds(String)`
+
+* When the arrays have different sizes
 
 Examples:
 


### PR DESCRIPTION
This pr adds `@throws` graindoc to the array module.

A question I have is I used `int32` over `interger` for most of the throws docs because an i64 isnt current supported I am wondering if this is good or if there is a better altnerative, or if we just want to say integer.

My other questions was related to `fromList` you could technically have a list that has a length that is out of the i32 range right, I dont know if you could fit that in memory or what. but if you were to call `fromList` that would throw an exception I am wondering if I should add a `@throws` to that or just leave it given its virtually impossible to construct.




closes: #1520 