### PR TITLE
feat(stdlib)!: Provide empty byte array from Bytes.make

### DIFF
--- a/compiler/test/stdlib/string.test.gr
+++ b/compiler/test/stdlib/string.test.gr
@@ -271,11 +271,8 @@ assert processBytes(String.encode("𐐷", String.UTF32_BE)) == [> 0x00us, 0x01us
 // formatter-ignore
 assert processBytes(String.encode("𐐷", String.UTF32_LE)) == [> 0x37us, 0x04us, 0x01us, 0x00us]
 
-let buf = Bytes.make(12)
-// ensure buffer is clear for our assertions on contents
-Bytes.clear(buf)
 // formatter-ignore
-assert processBytes(String.encodeAt("𐐷", String.UTF16_BE, buf, 5)) == [> 0x00us, 0x00us, 0x00us, 0x00us, 0x00us, 0xD8us, 0x01us, 0xDCus, 0x37us, 0x00us, 0x00us, 0x00us]
+assert processBytes(String.encodeAt("𐐷", String.UTF16_BE, Bytes.make(12), 5)) == [> 0x00us, 0x00us, 0x00us, 0x00us, 0x00us, 0xD8us, 0x01us, 0xDCus, 0x37us, 0x00us, 0x00us, 0x00us]
 // test that BOM is prepended:
 // formatter-ignore
 assert processBytes(String.encodeWithBom("𐐷", String.UTF8)) == [> 0xEFus, 0xBBus, 0xBFus, 0xF0us, 0x90us, 0x90us, 0xB7us]
@@ -319,45 +316,38 @@ assert String.decode(String.encode(emojis, String.UTF32_BE), String.UTF32_BE) ==
 assert String.decode(String.encode(emojis, String.UTF32_LE), String.UTF32_LE) ==
   emojis
 
-let buf = Bytes.make(500)
-// ensure buffer is clear for our assertions on contents
-Bytes.clear(buf)
 // decodeRange
 // 51 is chosen to stress-test these functions, since it's not an aligned offset
 assert String.decodeRange(
-  String.encodeAt(emojis, String.UTF8, buf, 51),
+  String.encodeAt(emojis, String.UTF8, Bytes.make(500), 51),
   String.UTF8,
   51,
   98
 ) ==
   emojis
-Bytes.clear(buf)
 assert String.decodeRange(
-  String.encodeAt(emojis, String.UTF16_LE, buf, 51),
+  String.encodeAt(emojis, String.UTF16_LE, Bytes.make(500), 51),
   String.UTF16_LE,
   51,
   164
 ) ==
   emojis
-Bytes.clear(buf)
 assert String.decodeRange(
-  String.encodeAt(emojis, String.UTF16_BE, buf, 51),
+  String.encodeAt(emojis, String.UTF16_BE, Bytes.make(500), 51),
   String.UTF16_BE,
   51,
   164
 ) ==
   emojis
-Bytes.clear(buf)
 assert String.decodeRange(
-  String.encodeAt(emojis, String.UTF32_LE, buf, 51),
+  String.encodeAt(emojis, String.UTF32_LE, Bytes.make(500), 51),
   String.UTF32_LE,
   51,
   296
 ) ==
   emojis
-Bytes.clear(buf)
 assert String.decodeRange(
-  String.encodeAt(emojis, String.UTF32_BE, buf, 51),
+  String.encodeAt(emojis, String.UTF32_BE, Bytes.make(500), 51),
   String.UTF32_BE,
   51,
   296
@@ -365,91 +355,80 @@ assert String.decodeRange(
   emojis
 
 // keepBom should be no-op, since there is no BOM
-Bytes.clear(buf)
 assert String.decodeRangeKeepBom(
-  String.encodeAt(emojis, String.UTF8, buf, 51),
+  String.encodeAt(emojis, String.UTF8, Bytes.make(500), 51),
   String.UTF8,
   51,
   98
 ) ==
   emojis
-Bytes.clear(buf)
 assert String.decodeRangeKeepBom(
-  String.encodeAt(emojis, String.UTF16_LE, buf, 51),
+  String.encodeAt(emojis, String.UTF16_LE, Bytes.make(500), 51),
   String.UTF16_LE,
   51,
   164
 ) ==
   emojis
-Bytes.clear(buf)
 assert String.decodeRangeKeepBom(
-  String.encodeAt(emojis, String.UTF16_BE, buf, 51),
+  String.encodeAt(emojis, String.UTF16_BE, Bytes.make(500), 51),
   String.UTF16_BE,
   51,
   164
 ) ==
   emojis
-Bytes.clear(buf)
 assert String.decodeRangeKeepBom(
-  String.encodeAt(emojis, String.UTF32_LE, buf, 51),
+  String.encodeAt(emojis, String.UTF32_LE, Bytes.make(500), 51),
   String.UTF32_LE,
   51,
   296
 ) ==
   emojis
-Bytes.clear(buf)
 assert String.decodeRangeKeepBom(
-  String.encodeAt(emojis, String.UTF32_BE, buf, 51),
+  String.encodeAt(emojis, String.UTF32_BE, Bytes.make(500), 51),
   String.UTF32_BE,
   51,
   296
 ) ==
   emojis
 // but, when we include it, it should preserve it:
-Bytes.clear(buf)
 assert String.decodeRangeKeepBom(
-  String.encodeAtWithBom(emojis, String.UTF16_LE, buf, 51),
+  String.encodeAtWithBom(emojis, String.UTF16_LE, Bytes.make(500), 51),
   String.UTF16_LE,
   51,
   166
 ) !=
   emojis
 // BOM-skipping should be default:
-Bytes.clear(buf)
 assert String.decodeRange(
-  String.encodeAtWithBom(emojis, String.UTF8, buf, 51),
+  String.encodeAtWithBom(emojis, String.UTF8, Bytes.make(500), 51),
   String.UTF8,
   51,
   101
 ) ==
   emojis
-Bytes.clear(buf)
 assert String.decodeRange(
-  String.encodeAtWithBom(emojis, String.UTF16_LE, buf, 51),
+  String.encodeAtWithBom(emojis, String.UTF16_LE, Bytes.make(500), 51),
   String.UTF16_LE,
   51,
   166
 ) ==
   emojis
-Bytes.clear(buf)
 assert String.decodeRange(
-  String.encodeAtWithBom(emojis, String.UTF16_BE, buf, 51),
+  String.encodeAtWithBom(emojis, String.UTF16_BE, Bytes.make(500), 51),
   String.UTF16_BE,
   51,
   166
 ) ==
   emojis
-Bytes.clear(buf)
 assert String.decodeRange(
-  String.encodeAtWithBom(emojis, String.UTF32_BE, buf, 51),
+  String.encodeAtWithBom(emojis, String.UTF32_BE, Bytes.make(500), 51),
   String.UTF32_BE,
   51,
   300
 ) ==
   emojis
-Bytes.clear(buf)
 assert String.decodeRange(
-  String.encodeAtWithBom(emojis, String.UTF32_LE, buf, 51),
+  String.encodeAtWithBom(emojis, String.UTF32_LE, Bytes.make(500), 51),
   String.UTF32_LE,
   51,
   300

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -75,7 +75,10 @@ let getSize = ptr => WasmI32.load(ptr, _SIZE_OFFSET)
  */
 @unsafe
 provide let make = (size: Number) => {
-  let bytes = allocateBytes(coerceNumberToWasmI32(size))
+  from WasmI32 use { add as (+) }
+  let size = coerceNumberToWasmI32(size)
+  let bytes = allocateBytes(size)
+  Memory.fill(bytes + 8n, 0n, size)
   WasmI32.toGrain(bytes): Bytes
 }
 


### PR DESCRIPTION
This change ensures we always provide a zeroed byte array from `Bytes.make`.

Closes #1723 