### PR TITLE
chore(stdlib): Remove debugging code

### DIFF
--- a/compiler/test/runner.re
+++ b/compiler/test/runner.re
@@ -204,6 +204,18 @@ let makeSnapshotRunner = (~config_fn=?, test, name, prog) => {
   });
 };
 
+let makeFilesizeRunner = (test, ~config_fn=?, name, prog, size) => {
+  test(name, ({expect}) => {
+    Config.preserve_all_configs(() => {
+      ignore @@ compile(~config_fn?, name, module_header ++ prog);
+      let ic = open_in_bin(wasmfile(name));
+      let filesize = in_channel_length(ic);
+      close_in(ic);
+      expect.int(filesize).toBe(size);
+    })
+  });
+};
+
 let makeSnapshotFileRunner = (test, name, filename) => {
   test(
     name,

--- a/compiler/test/suites/basic_functionality.re
+++ b/compiler/test/suites/basic_functionality.re
@@ -8,9 +8,14 @@ describe("basic functionality", ({test, testSkip}) => {
   let assertSnapshot = makeSnapshotRunner(test);
   let assertSnapshotFile = makeSnapshotFileRunner(test);
   let assertCompileError = makeCompileErrorRunner(test);
+  let assertFilesize = makeFilesizeRunner(test);
   let assertParse = makeParseRunner(test);
   let assertRun = makeRunner(test_or_skip);
   let assertRunError = makeErrorRunner(test_or_skip);
+  let smallestFileConfig = () => {
+    Grain_utils.Config.elide_type_info := true;
+    Grain_utils.Config.profile := Some(Grain_utils.Config.Release);
+  };
 
   assertSnapshot("nil", "");
   assertSnapshot("forty", "let x = 40; x");
@@ -296,5 +301,12 @@ describe("basic functionality", ({test, testSkip}) => {
         },
       )
     )
+  );
+
+  assertFilesize(
+    ~config_fn=smallestFileConfig,
+    "smallest_grain_program",
+    "",
+    5056,
   );
 });

--- a/compiler/test/suites/basic_functionality.re
+++ b/compiler/test/suites/basic_functionality.re
@@ -307,6 +307,6 @@ describe("basic functionality", ({test, testSkip}) => {
     ~config_fn=smallestFileConfig,
     "smallest_grain_program",
     "",
-    5056,
+    5033,
   );
 });

--- a/stdlib/runtime/gc.gr
+++ b/stdlib/runtime/gc.gr
@@ -41,103 +41,9 @@ primitive unbox = "@unbox"
 
 exception DecRefError
 
-let decimalCount32Dummy = (n: WasmI32) => 0n
-let utoa32BufferedDummy = (a: WasmI32, b: WasmI32, c: WasmI32) => void
-
-// When these boxes are backpatched, the reference count of each function will
-// fall to zero which would cause them to be freed. We can't free anything that
-// got allocated in runtime mode (since that memory space is not managed by the
-// GC, so here we prevent that by manually setting a higher refcount.
-WasmI32.store(WasmI32.fromGrain(decimalCount32Dummy) - 8n, 2n, 0n)
-WasmI32.store(WasmI32.fromGrain(utoa32BufferedDummy) - 8n, 2n, 0n)
-
-provide let decimalCount32 = box(decimalCount32Dummy)
-provide let utoa32Buffered = box(utoa32BufferedDummy)
-
 let mut _DEBUG = false
 
 let _HEADER_SIZE = 8n
-
-/*
-//Debugging functions:
-foreign wasm fd_sync : (WasmI32) -> WasmI32 from "wasi_snapshot_preview1"
-
-// incRef debug messages: "decRef: 0xNNNNNN (prev count: nn)\n"
-let _INCREF_DEBUG_STR_1 = "incRef: 0x"
-let _INCREF_DEBUG_STR_2 = " (prev count: "
-let _INCREF_DEBUG_STR_3 = "; tag: "
-let _INCREF_DEBUG_STR_4 = ")\n"
-
-// decRef debug messages: "decRef: 0xNNNNNN (prev count: nn)\n"
-let _DECREF_DEBUG_STR_1 = "decRef: 0x"
-let _DECREF_DEBUG_STR_2 = " (prev count: "
-let _DECREF_DEBUG_STR_3 = "; ignoreZeros: true)\n"
-let _DECREF_DEBUG_STR_4 = "; ignoreZeros: false)\n"
-
-let logIncRef = (userPtr: WasmI32, refCount: WasmI32) => {
-  let ptrDecimals = WasmI32.shrU(31n - WasmI32.clz(userPtr), 2n) + 1n
-  let ptrStr = Malloc.malloc(ptrDecimals)
-  unbox(utoa32Buffered)(ptrStr, userPtr, 16n)
-  let refCountDecimals = unbox(decimalCount32)(refCount)
-  let refCountStr = Malloc.malloc(refCountDecimals)
-  unbox(utoa32Buffered)(refCountStr, refCount, 10n)
-  let tag = WasmI32.load(userPtr, 0n)
-  let tagDecimals = unbox(decimalCount32)(tag)
-  let tagStr = Malloc.malloc(tagDecimals)
-  unbox(utoa32Buffered)(tagStr, tag, 10n)
-  let iov = Malloc.malloc((8n * 5n) + 4n)
-  let written = iov + (8n * 7n)
-  WasmI32.store(iov, WasmI32.fromGrain(_INCREF_DEBUG_STR_1) + 8n, 0n)
-  WasmI32.store(iov, WasmI32.load(WasmI32.fromGrain(_INCREF_DEBUG_STR_1), 4n), 4n)
-  WasmI32.store(iov, ptrStr, 8n)
-  WasmI32.store(iov, ptrDecimals, 12n)
-  WasmI32.store(iov, WasmI32.fromGrain(_INCREF_DEBUG_STR_2) + 8n, 16n)
-  WasmI32.store(iov, WasmI32.load(WasmI32.fromGrain(_INCREF_DEBUG_STR_2), 4n), 20n)
-  WasmI32.store(iov, refCountStr, 24n)
-  WasmI32.store(iov, refCountDecimals, 28n)
-  WasmI32.store(iov, WasmI32.fromGrain(_INCREF_DEBUG_STR_3) + 8n, 32n)
-  WasmI32.store(iov, WasmI32.load(WasmI32.fromGrain(_INCREF_DEBUG_STR_3), 4n), 36n)
-  WasmI32.store(iov, tagStr, 40n)
-  WasmI32.store(iov, tagDecimals, 44n)
-  WasmI32.store(iov, WasmI32.fromGrain(_INCREF_DEBUG_STR_4) + 8n, 48n)
-  WasmI32.store(iov, WasmI32.load(WasmI32.fromGrain(_INCREF_DEBUG_STR_4), 4n), 52n)
-  fd_write(1n, iov, 7n, written)
-  fd_sync(1n)
-  Malloc.free(ptrStr)
-  Malloc.free(refCountStr)
-}
-
-let logDecRef = (userPtr: WasmI32, refCount: WasmI32, ignoreZeros) => {
-  let ptrDecimals = WasmI32.shrU(31n - WasmI32.clz(userPtr), 2n) + 1n
-  let ptrStr = Malloc.malloc(ptrDecimals)
-  unbox(utoa32Buffered)(ptrStr, userPtr, 16n)
-  let refCountDecimals = unbox(decimalCount32)(refCount)
-  let refCountStr = Malloc.malloc(refCountDecimals)
-  unbox(utoa32Buffered)(refCountStr, refCount, 10n)
-  let iov = Malloc.malloc((8n * 5n) + 4n)
-  let written = iov + (8n * 5n)
-  WasmI32.store(iov, WasmI32.fromGrain(_DECREF_DEBUG_STR_1) + 8n, 0n)
-  WasmI32.store(iov, WasmI32.load(WasmI32.fromGrain(_DECREF_DEBUG_STR_1), 4n), 4n)
-  WasmI32.store(iov, ptrStr, 8n)
-  WasmI32.store(iov, ptrDecimals, 12n)
-  WasmI32.store(iov, WasmI32.fromGrain(_DECREF_DEBUG_STR_2) + 8n, 16n)
-  WasmI32.store(iov, WasmI32.load(WasmI32.fromGrain(_DECREF_DEBUG_STR_2), 4n), 20n)
-  WasmI32.store(iov, refCountStr, 24n)
-  WasmI32.store(iov, refCountDecimals, 28n)
-  if (ignoreZeros) {
-    WasmI32.store(iov, WasmI32.fromGrain(_DECREF_DEBUG_STR_3) + 8n, 32n)
-    WasmI32.store(iov, WasmI32.load(WasmI32.fromGrain(_DECREF_DEBUG_STR_3), 4n), 36n)
-  } else {
-    WasmI32.store(iov, WasmI32.fromGrain(_DECREF_DEBUG_STR_4) + 8n, 32n)
-    WasmI32.store(iov, WasmI32.load(WasmI32.fromGrain(_DECREF_DEBUG_STR_4), 4n), 36n)
-  }
-  fd_write(1n, iov, 5n, written)
-  fd_sync(1n)
-  Malloc.free(ptrStr)
-  Malloc.free(refCountStr)
-}
-
-*/
 
 let getRefCount = (userPtr: WasmI32) => {
   WasmI32.load(userPtr - _HEADER_SIZE, 0n)
@@ -258,22 +164,3 @@ decRefChildren = (userPtr: WasmI32) => {
 }
 
 provide let decRef = userPtr => decRef(userPtr, false)
-
-// For debugging:
-
-// provide let getRefCount = (value) => {
-//   let userPtr = WasmI32.fromGrain(value)
-//   let ret = if (WasmI32.eqz(userPtr & Tags._GRAIN_GENERIC_TAG_MASK) && WasmI32.ne(userPtr, 0n)) {
-//     WasmI32.toGrain((getRefCount(userPtr) * 2n) + 1n) : Number
-//   } else {
-//     0
-//   }
-//   decRef(userPtr)
-//   ret
-// }
-
-// provide let rec setDebug = (enabled: Bool) => {
-//   _DEBUG = enabled
-//   decRef(WasmI32.fromGrain(setDebug))
-//   void
-// }

--- a/stdlib/runtime/gc.md
+++ b/stdlib/runtime/gc.md
@@ -6,18 +6,6 @@ title: GC
 
 Functions and constants included in the GC module.
 
-### GC.**decimalCount32**
-
-```grain
-decimalCount32 : Box<WasmI32 -> WasmI32>
-```
-
-### GC.**utoa32Buffered**
-
-```grain
-utoa32Buffered : Box<(WasmI32, WasmI32, WasmI32) -> Void>
-```
-
 ### GC.**malloc**
 
 ```grain

--- a/stdlib/runtime/numberUtils.gr
+++ b/stdlib/runtime/numberUtils.gr
@@ -1479,5 +1479,6 @@ provide let dtoa = value => {
   WasmI32.toGrain(str): String
 }
 
-Memory.utoa32Buffered := utoa32Buffered
-Memory.decimalCount32 := decimalCount32
+// These lines can be uncommented for debugging memory.gr
+// Memory.utoa32Buffered := utoa32Buffered
+// Memory.decimalCount32 := decimalCount32

--- a/stdlib/runtime/numberUtils.gr
+++ b/stdlib/runtime/numberUtils.gr
@@ -1478,7 +1478,3 @@ provide let dtoa = value => {
   }
   WasmI32.toGrain(str): String
 }
-
-// These lines can be uncommented for debugging memory.gr
-// Memory.utoa32Buffered := utoa32Buffered
-// Memory.decimalCount32 := decimalCount32

--- a/stdlib/runtime/unsafe/memory.gr
+++ b/stdlib/runtime/unsafe/memory.gr
@@ -2,7 +2,7 @@
 module Memory
 
 include "runtime/gc" as GC
-from GC use { malloc, free, incRef, decRef, utoa32Buffered, decimalCount32 }
+from GC use { malloc, free, incRef, decRef }
 include "runtime/unsafe/wasmi32" as WasmI32
 from WasmI32 use {
   add as (+),
@@ -13,7 +13,7 @@ from WasmI32 use {
   ltU as (<),
 }
 
-provide { malloc, free, incRef, decRef, utoa32Buffered, decimalCount32 }
+provide { malloc, free, incRef, decRef }
 
 provide let copy = (dest, src, n) => {
   let mut dest = dest

--- a/stdlib/runtime/unsafe/memory.md
+++ b/stdlib/runtime/unsafe/memory.md
@@ -30,18 +30,6 @@ incRef : WasmI32 -> WasmI32
 decRef : WasmI32 -> WasmI32
 ```
 
-### Memory.**utoa32Buffered**
-
-```grain
-utoa32Buffered : Box<(WasmI32, WasmI32, WasmI32) -> Void>
-```
-
-### Memory.**decimalCount32**
-
-```grain
-decimalCount32 : Box<WasmI32 -> WasmI32>
-```
-
 ### Memory.**copy**
 
 ```grain


### PR DESCRIPTION
This removes an unnecessary dependency for some Grain programs, allowing them to save some file size. This is particularly helpful for running in runtimes with limited memory, like wasm4.

This change makes the smallest Grain program `module Main` when compiled with `--elide-type-info` and `--release` 5056 bytes.

There is one other change necessary to make this program truly a no-op (< 100 bytes) but that hasn't been deemed necessary at this time.