### PR TITLE
chore(compiler): Add singleton constructor to expressions and patterns

### DIFF
--- a/compiler/src/formatting/format.re
+++ b/compiler/src/formatting/format.re
@@ -1489,6 +1489,10 @@ and print_pattern =
           false,
         );
       };
+    | PPatConstruct(location, PPatConstrSingleton) => (
+        Doc.concat([print_ident(location.txt)]),
+        false,
+      )
     | PPatConstruct(location, PPatConstrRecord(patternlocs, closedflag)) => (
         Doc.concat([
           print_ident(location.txt),
@@ -3629,7 +3633,7 @@ and print_expression_inner =
         PExpConstrTuple(expressions),
       ) =>
       Doc.text("[]")
-    | PExpConstruct({txt: id}, PExpConstrTuple([])) => print_ident(id)
+    | PExpConstruct({txt: id}, PExpConstrSingleton) => print_ident(id)
     | PExpConstruct(constr, PExpConstrTuple(expressions)) =>
       let comments_in_expression =
         Comment_utils.get_comments_inside_location(

--- a/compiler/src/parsing/ast_helper.re
+++ b/compiler/src/parsing/ast_helper.re
@@ -197,6 +197,8 @@ module Pattern = {
   let constant = (~loc=?, a) => mk(~loc?, PPatConstant(a));
   let constraint_ = (~loc=?, a, b) => mk(~loc?, PPatConstraint(a, b));
   let construct = (~loc, a, b) => mk(~loc, PPatConstruct(a, b));
+  let singleton_construct = (~loc, a) =>
+    construct(~loc, a, PPatConstrSingleton);
   let tuple_construct = (~loc, a, b) =>
     construct(~loc, a, PPatConstrTuple(b));
   let record_construct = (~loc, a, b) => {
@@ -337,6 +339,8 @@ module Expression = {
     mk(~loc?, ~attributes?, PExpApp(a, b));
   let construct = (~loc, ~attributes=?, a, b) =>
     mk(~loc, ~attributes?, PExpConstruct(a, b));
+  let singleton_construct = (~loc, ~attributes=?, a) =>
+    construct(~loc, ~attributes?, a, PExpConstrSingleton);
   let tuple_construct = (~loc, ~attributes=?, a, b) =>
     construct(~loc, ~attributes?, a, PExpConstrTuple(b));
   let record_construct = (~loc, ~attributes=?, a, b) => {

--- a/compiler/src/parsing/ast_helper.rei
+++ b/compiler/src/parsing/ast_helper.rei
@@ -115,6 +115,7 @@ module Pattern: {
   let constant: (~loc: loc=?, constant) => pattern;
   let constraint_: (~loc: loc=?, pattern, parsed_type) => pattern;
   let construct: (~loc: loc, id, constructor_pattern) => pattern;
+  let singleton_construct: (~loc: loc, id) => pattern;
   let tuple_construct: (~loc: loc, id, list(pattern)) => pattern;
   let record_construct:
     (~loc: loc, id, list((option((id, pattern)), Asttypes.closed_flag))) =>
@@ -233,6 +234,9 @@ module Expression: {
     expression;
   let construct:
     (~loc: loc, ~attributes: attributes=?, id, constructor_expression) =>
+    expression;
+  let singleton_construct:
+    (~loc: loc, ~attributes: attributes=?, Location.loc(Identifier.t)) =>
     expression;
   let tuple_construct:
     (~loc: loc, ~attributes: attributes=?, id, list(expression)) => expression;

--- a/compiler/src/parsing/ast_mapper.re
+++ b/compiler/src/parsing/ast_mapper.re
@@ -149,6 +149,7 @@ module E = {
         ~attributes,
         map_identifier(sub, id),
         switch (e) {
+        | PExpConstrSingleton => PExpConstrSingleton
         | PExpConstrTuple(el) =>
           PExpConstrTuple(List.map(sub.expr(sub), el))
         | PExpConstrRecord(es) =>
@@ -232,6 +233,7 @@ module P = {
             ),
             c,
           )
+        | PPatConstrSingleton => PPatConstrSingleton
         },
       )
     | PPatOr(p1, p2) => or_(~loc, sub.pat(sub, p1), sub.pat(sub, p2))

--- a/compiler/src/parsing/parser.mly
+++ b/compiler/src/parsing/parser.mly
@@ -262,7 +262,7 @@ pattern:
   | lbrace record_patterns rbrace { Pattern.record ~loc:(to_loc $loc) $2 }
   | qualified_uid lparen patterns rparen { Pattern.tuple_construct ~loc:(to_loc $loc) $1 $3 }
   | qualified_uid lbrace record_patterns rbrace { Pattern.record_construct ~loc:(to_loc $loc) $1 $3 }
-  | qualified_uid { Pattern.tuple_construct ~loc:(to_loc $loc) $1 [] }
+  | qualified_uid { Pattern.singleton_construct ~loc:(to_loc $loc) $1 }
   | lbrack rbrack { Pattern.list ~loc:(to_loc $loc) [] }
   | lbrack lseparated_nonempty_list(comma, list_item_pat) comma? rbrack { Pattern.list ~loc:(to_loc $loc) $2 }
   | pattern PIPE opt_eols pattern %prec PIPE { Pattern.or_ ~loc:(to_loc $loc) $1 $4 }
@@ -416,7 +416,7 @@ rcaret_rcaret_op:
 construct_expr:
   | qualified_uid lparen lseparated_list(comma, expr) comma? rparen { Expression.tuple_construct ~loc:(to_loc $loc) $1 $3 }
   | qualified_uid lbrace lseparated_nonempty_list(comma, record_field) comma? rbrace { Expression.record_construct ~loc:(to_loc $loc) $1 $3 }
-  | qualified_uid %prec LPAREN { Expression.tuple_construct ~loc:(to_loc $loc) $1 [] }
+  | qualified_uid %prec LPAREN { Expression.singleton_construct ~loc:(to_loc $loc) $1 }
 
 // These are all inlined to carry over their precedence.
 %inline infix_op:

--- a/compiler/src/parsing/parsetree.re
+++ b/compiler/src/parsing/parsetree.re
@@ -165,7 +165,8 @@ type pattern_desc =
 [@deriving (sexp, yojson)]
 and constructor_pattern =
   | PPatConstrRecord(list((loc(Identifier.t), pattern)), closed_flag)
-  | PPatConstrTuple(list(pattern)) // Empty list used to represent singleton constructors
+  | PPatConstrTuple(list(pattern))
+  | PPatConstrSingleton
 
 [@deriving (sexp, yojson)]
 and pattern = {
@@ -523,6 +524,7 @@ and expression_desc =
 and constructor_expression =
   | PExpConstrTuple(list(expression))
   | PExpConstrRecord(list((loc(Identifier.t), expression)))
+  | PExpConstrSingleton
 
 /** let-binding form */
 

--- a/compiler/src/parsing/parsetree_iter.re
+++ b/compiler/src/parsing/parsetree_iter.re
@@ -312,6 +312,7 @@ and iter_expression =
     switch (e) {
     | PExpConstrTuple(el) => iter_expressions(hooks, el)
     | PExpConstrRecord(es) => iter_record_fields(hooks, es)
+    | PExpConstrSingleton => ()
     };
   | PExpBlock(el) => iter_expressions(hooks, el)
   | PExpNull => ()
@@ -414,6 +415,7 @@ and iter_pattern = (hooks, {ppat_desc: desc, ppat_loc: loc} as pat) => {
   | PPatConstruct(id, p) =>
     iter_ident(hooks, id);
     switch (p) {
+    | PPatConstrSingleton => ()
     | PPatConstrTuple(pl) => iter_patterns(hooks, pl)
     | PPatConstrRecord(fs, _) => iter_record_patterns(hooks, fs)
     };

--- a/compiler/src/parsing/well_formedness.re
+++ b/compiler/src/parsing/well_formedness.re
@@ -613,6 +613,7 @@ let provided_multiple_times = (errs, super) => {
         )
       | PPatConstrTuple(pats) =>
         List.fold_left(extract_bindings, binds, pats)
+      | PPatConstrSingleton => []
       }
     | PPatOr(pat1, pat2) =>
       extract_bindings([], pat1) @ extract_bindings(binds, pat2)

--- a/compiler/src/typed/typecore.re
+++ b/compiler/src/typed/typecore.re
@@ -1746,6 +1746,7 @@ and type_construct = (env, loc, lid, sarg, ty_expected_explained, attrs) => {
   let {ty: ty_expected, explanation} = ty_expected_explained;
   let (sargs, is_record_cstr) =
     switch (sarg) {
+    | PExpConstrSingleton => ([], false)
     | PExpConstrTuple(sargs) => (sargs, false)
     | PExpConstrRecord(rfs) => (
         [

--- a/compiler/src/typed/typepat.re
+++ b/compiler/src/typed/typepat.re
@@ -51,7 +51,8 @@ let iter_ppat = (f, p) =>
   switch (p.ppat_desc) {
   | PPatAny
   | PPatVar(_)
-  | PPatConstant(_) => ()
+  | PPatConstant(_)
+  | PPatConstruct(_, PPatConstrSingleton) => ()
   | PPatTuple(lst) => List.iter(f, lst)
   | PPatArray(lst) => List.iter(f, lst)
   | PPatRecord(fs, _)
@@ -744,6 +745,7 @@ and type_pat_aux =
   | PPatConstruct(lid, sarg) =>
     let (sargs, is_record_pat) =
       switch (sarg) {
+      | PPatConstrSingleton => ([], false)
       | PPatConstrTuple(sargs) => (sargs, false)
       | PPatConstrRecord(rfs, c) =>
         let desc =

--- a/compiler/test/suites/blocks.re
+++ b/compiler/test/suites/blocks.re
@@ -16,12 +16,11 @@ describe("blocks", ({test}) => {
           statements: [
             Toplevel.expr(
               Expression.block([
-                Expression.tuple_construct(
+                Expression.singleton_construct(
                   ~loc=Location.dummy_loc,
                   Location.mknoloc(
                     Identifier.IdentName(Location.mknoloc("Foo")),
                   ),
-                  [],
                 ),
               ]),
             ),


### PR DESCRIPTION
This adds Singleton constructors on `constructor_pattern` and `constructor_expression` types. While rewriting the formatter, I found that we used empty lists to indicate this but that seems weird when they are formatted differently than tuples.