### PR TITLE
chore(stdlib)!: Update Operator `uint` operator Names

### DIFF
--- a/compiler/test/stdlib/uint16.test.gr
+++ b/compiler/test/stdlib/uint16.test.gr
@@ -12,12 +12,12 @@ from Uint16 use {
   (-),
   (*),
   (/),
-  (%),
+  rem as (%),
   (&),
   (|),
   (^),
   (<<),
-  (>>),
+  (>>>),
 }
 
 // Suppress warnings about using `fromNumber` on constants, since that's what we want to test.
@@ -70,9 +70,9 @@ assert 1uS << 1uS == 2uS
 assert 1uS << 16uS == 0uS
 assert 24uS << 1uS == 48uS
 
-assert 4uS >> 1uS == 2uS
-assert 4uS >> 2uS == 1uS
-assert 4uS >> 3uS == 0uS
+assert 4uS >>> 1uS == 2uS
+assert 4uS >>> 2uS == 1uS
+assert 4uS >>> 3uS == 0uS
 
 assert incr(0uS) == 1uS
 assert incr(0xffffuS) == 0uS

--- a/compiler/test/stdlib/uint32.test.gr
+++ b/compiler/test/stdlib/uint32.test.gr
@@ -12,7 +12,7 @@ from Uint32 use {
   (|),
   (^),
   (<<),
-  (>>),
+  (>>>),
   clz,
   ctz,
   popcnt,
@@ -55,11 +55,11 @@ assert 1ul << 3ul == 8ul
 assert 2ul << 63ul == 0ul
 assert 24ul << 1ul == 48ul
 
-assert 4ul >> 1ul == 2ul
-assert 4ul >> 2ul == 1ul
-assert 4ul >> 3ul == 0ul
-assert 1ul >> 63ul == 0ul
-assert 0xfffffffful >> 63ul == 1ul
+assert 4ul >>> 1ul == 2ul
+assert 4ul >>> 2ul == 1ul
+assert 4ul >>> 3ul == 0ul
+assert 1ul >>> 63ul == 0ul
+assert 0xfffffffful >>> 63ul == 1ul
 
 assert clz(0b11ul) == 30ul
 assert ctz(0b11000ul) == 3ul

--- a/compiler/test/stdlib/uint64.test.gr
+++ b/compiler/test/stdlib/uint64.test.gr
@@ -12,7 +12,7 @@ from Uint64 use {
   (|),
   (^),
   (<<),
-  (>>),
+  (>>>),
   clz,
   ctz,
   popcnt,
@@ -57,12 +57,12 @@ assert 1uL << 3uL == 8uL
 assert 2uL << 63uL == 0uL
 assert 24uL << 1uL == 48uL
 
-assert 4uL >> 1uL == 2uL
-assert 4uL >> 2uL == 1uL
-assert 4uL >> 3uL == 0uL
-assert 4uL >> 4uL == 0uL
-assert 24uL >> 1uL == 12uL
-assert 0xffffffffffffffffuL >> 63uL == 1uL
+assert 4uL >>> 1uL == 2uL
+assert 4uL >>> 2uL == 1uL
+assert 4uL >>> 3uL == 0uL
+assert 4uL >>> 4uL == 0uL
+assert 24uL >>> 1uL == 12uL
+assert 0xffffffffffffffffuL >>> 63uL == 1uL
 
 assert clz(0b11uL) == 62uL
 assert ctz(0b11000uL) == 3uL

--- a/compiler/test/stdlib/uint8.test.gr
+++ b/compiler/test/stdlib/uint8.test.gr
@@ -12,12 +12,12 @@ from Uint8 use {
   (-),
   (*),
   (/),
-  (%),
+  rem as (%),
   (&),
   (|),
   (^),
   (<<),
-  (>>),
+  (>>>),
 }
 
 // Suppress warnings about using `fromNumber` on constants, since that's what we want to test.
@@ -69,9 +69,9 @@ assert 1us << 1us == 2us
 assert 1us << 8us == 0us
 assert 24us << 1us == 48us
 
-assert 4us >> 1us == 2us
-assert 4us >> 2us == 1us
-assert 4us >> 3us == 0us
+assert 4us >>> 1us == 2us
+assert 4us >>> 2us == 1us
+assert 4us >>> 3us == 0us
 
 assert incr(0us) == 1us
 assert incr(0xffus) == 0us

--- a/stdlib/random.gr
+++ b/stdlib/random.gr
@@ -155,7 +155,7 @@ provide let nextUint32InRange = (random: Random, low: Uint32, high: Uint32) => {
   // Algorithm source: https://www.pcg-random.org/posts/bounded-rands.html#bitmask-with-rejection-unbiased-apples-method
   from Uint32 use *
   let range = high - low - 1ul
-  let mask = lnot(0ul) >> clz(range | 1ul)
+  let mask = lnot(0ul) >>> clz(range | 1ul)
   let mut x = nextUint32(random) & mask
   let mut iters = 0ul
   while (x > range) {
@@ -181,7 +181,7 @@ provide let nextUint64InRange = (random: Random, low: Uint64, high: Uint64) => {
   // Algorithm source: https://www.pcg-random.org/posts/bounded-rands.html#bitmask-with-rejection-unbiased-apples-method
   from Uint64 use *
   let range = high - low - 1uL
-  let mask = lnot(0uL) >> clz(range | 1uL)
+  let mask = lnot(0uL) >>> clz(range | 1uL)
   let mut x = nextUint64(random) & mask
   while (x > range) {
     x = nextUint64(random) & mask

--- a/stdlib/uint16.gr
+++ b/stdlib/uint16.gr
@@ -32,7 +32,7 @@ provide { fromNumber, toNumber }
  *
  * @param number: The value to convert
  * @returns The Int16 represented as a Uint16
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -158,7 +158,7 @@ provide let (/) = (x: Uint16, y: Uint16) => {
  * @since v0.6.0
  */
 @unsafe
-provide let (%) = (x: Uint16, y: Uint16) => {
+provide let rem = (x: Uint16, y: Uint16) => {
   let x = untagUint16(x)
   let y = untagUint16(y)
   let val = WasmI32.remU(x, y)
@@ -194,7 +194,7 @@ provide let (<<) = (value: Uint16, amount: Uint16) => {
  * @since v0.6.0
  */
 @unsafe
-provide let (>>) = (value: Uint16, amount: Uint16) => {
+provide let (>>>) = (value: Uint16, amount: Uint16) => {
   // Trick: do not shift `value` right, just correct tag afterwards
   let x = WasmI32.fromGrain(value)
   let y = untagUint16(amount)

--- a/stdlib/uint16.md
+++ b/stdlib/uint16.md
@@ -246,7 +246,7 @@ Returns:
 |----|-----------|
 |`Uint16`|The quotient of its operands|
 
-### Uint16.**(%)**
+### Uint16.**rem**
 
 <details disabled>
 <summary tabindex="-1">Added in <code>next</code></summary>
@@ -254,7 +254,7 @@ No other changes yet.
 </details>
 
 ```grain
-(%) : (Uint16, Uint16) -> Uint16
+rem : (Uint16, Uint16) -> Uint16
 ```
 
 Computes the remainder of the division of its operands using signed division.
@@ -298,7 +298,7 @@ Returns:
 |----|-----------|
 |`Uint16`|The shifted value|
 
-### Uint16.**(>>)**
+### Uint16.**(>>>)**
 
 <details disabled>
 <summary tabindex="-1">Added in <code>next</code></summary>
@@ -306,7 +306,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>>) : (Uint16, Uint16) -> Uint16
+(>>>) : (Uint16, Uint16) -> Uint16
 ```
 
 Shifts the bits of the value right by the given number of bits, preserving the sign bit.

--- a/stdlib/uint32.gr
+++ b/stdlib/uint32.gr
@@ -173,7 +173,7 @@ provide let (/) = (x: Uint32, y: Uint32) => {
  * @since v0.6.0
  */
 @unsafe
-provide let (%) = (x: Uint32, y: Uint32) => {
+provide let rem = (x: Uint32, y: Uint32) => {
   let xv = WasmI32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
   let yv = WasmI32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   let ptr = newUint32(WasmI32.remU(xv, yv))
@@ -241,7 +241,7 @@ provide let (<<) = (value: Uint32, amount: Uint32) => {
  * @since v0.6.0
  */
 @unsafe
-provide let (>>) = (value: Uint32, amount: Uint32) => {
+provide let (>>>) = (value: Uint32, amount: Uint32) => {
   let xv = WasmI32.load(WasmI32.fromGrain(value), _VALUE_OFFSET)
   let yv = WasmI32.load(WasmI32.fromGrain(amount), _VALUE_OFFSET)
   let ptr = newUint32(WasmI32.shrU(xv, yv))

--- a/stdlib/uint32.md
+++ b/stdlib/uint32.md
@@ -246,7 +246,7 @@ Returns:
 |----|-----------|
 |`Uint32`|The quotient of its operands|
 
-### Uint32.**(%)**
+### Uint32.**rem**
 
 <details disabled>
 <summary tabindex="-1">Added in <code>next</code></summary>
@@ -254,7 +254,7 @@ No other changes yet.
 </details>
 
 ```grain
-(%) : (Uint32, Uint32) -> Uint32
+rem : (Uint32, Uint32) -> Uint32
 ```
 
 Computes the remainder of the division of its operands.
@@ -350,7 +350,7 @@ Returns:
 |----|-----------|
 |`Uint32`|The shifted value|
 
-### Uint32.**(>>)**
+### Uint32.**(>>>)**
 
 <details disabled>
 <summary tabindex="-1">Added in <code>next</code></summary>
@@ -358,7 +358,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>>) : (Uint32, Uint32) -> Uint32
+(>>>) : (Uint32, Uint32) -> Uint32
 ```
 
 Shifts the bits of the value right by the given number of bits.

--- a/stdlib/uint64.gr
+++ b/stdlib/uint64.gr
@@ -172,7 +172,7 @@ provide let (/) = (x: Uint64, y: Uint64) => {
  * @since v0.6.0
  */
 @unsafe
-provide let (%) = (x: Uint64, y: Uint64) => {
+provide let rem = (x: Uint64, y: Uint64) => {
   let xv = WasmI64.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
   let yv = WasmI64.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   let ptr = newUint64(WasmI64.remU(xv, yv))
@@ -240,7 +240,7 @@ provide let (<<) = (value: Uint64, amount: Uint64) => {
  * @since v0.6.0
  */
 @unsafe
-provide let (>>) = (value: Uint64, amount: Uint64) => {
+provide let (>>>) = (value: Uint64, amount: Uint64) => {
   let xv = WasmI64.load(WasmI32.fromGrain(value), _VALUE_OFFSET)
   let yv = WasmI64.load(WasmI32.fromGrain(amount), _VALUE_OFFSET)
   let ptr = newUint64(WasmI64.shrU(xv, yv))

--- a/stdlib/uint64.md
+++ b/stdlib/uint64.md
@@ -246,7 +246,7 @@ Returns:
 |----|-----------|
 |`Uint64`|The quotient of its operands|
 
-### Uint64.**(%)**
+### Uint64.**rem**
 
 <details disabled>
 <summary tabindex="-1">Added in <code>next</code></summary>
@@ -254,7 +254,7 @@ No other changes yet.
 </details>
 
 ```grain
-(%) : (Uint64, Uint64) -> Uint64
+rem : (Uint64, Uint64) -> Uint64
 ```
 
 Computes the remainder of the division of its operands.
@@ -350,7 +350,7 @@ Returns:
 |----|-----------|
 |`Uint64`|The shifted value|
 
-### Uint64.**(>>)**
+### Uint64.**(>>>)**
 
 <details disabled>
 <summary tabindex="-1">Added in <code>next</code></summary>
@@ -358,7 +358,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>>) : (Uint64, Uint64) -> Uint64
+(>>>) : (Uint64, Uint64) -> Uint64
 ```
 
 Shifts the bits of the value right by the given number of bits.

--- a/stdlib/uint8.gr
+++ b/stdlib/uint8.gr
@@ -32,7 +32,7 @@ provide { fromNumber, toNumber }
  *
  * @param number: The value to convert
  * @returns The Int8 represented as a Uint8
- * 
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -158,7 +158,7 @@ provide let (/) = (x: Uint8, y: Uint8) => {
  * @since v0.6.0
  */
 @unsafe
-provide let (%) = (x: Uint8, y: Uint8) => {
+provide let rem = (x: Uint8, y: Uint8) => {
   let x = untagUint8(x)
   let y = untagUint8(y)
   let val = WasmI32.remU(x, y)
@@ -194,7 +194,7 @@ provide let (<<) = (value: Uint8, amount: Uint8) => {
  * @since v0.6.0
  */
 @unsafe
-provide let (>>) = (value: Uint8, amount: Uint8) => {
+provide let (>>>) = (value: Uint8, amount: Uint8) => {
   // Trick: do not shift `value` right, just correct tag afterwards
   let x = WasmI32.fromGrain(value)
   let y = untagUint8(amount)

--- a/stdlib/uint8.md
+++ b/stdlib/uint8.md
@@ -246,7 +246,7 @@ Returns:
 |----|-----------|
 |`Uint8`|The quotient of its operands|
 
-### Uint8.**(%)**
+### Uint8.**rem**
 
 <details disabled>
 <summary tabindex="-1">Added in <code>next</code></summary>
@@ -254,7 +254,7 @@ No other changes yet.
 </details>
 
 ```grain
-(%) : (Uint8, Uint8) -> Uint8
+rem : (Uint8, Uint8) -> Uint8
 ```
 
 Computes the remainder of the division of its operands using signed division.
@@ -298,7 +298,7 @@ Returns:
 |----|-----------|
 |`Uint8`|The shifted value|
 
-### Uint8.**(>>)**
+### Uint8.**(>>>)**
 
 <details disabled>
 <summary tabindex="-1">Added in <code>next</code></summary>
@@ -306,7 +306,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>>) : (Uint8, Uint8) -> Uint8
+(>>>) : (Uint8, Uint8) -> Uint8
 ```
 
 Shifts the bits of the value right by the given number of bits, preserving the sign bit.


### PR DESCRIPTION
This changes `>>` to `>>>` in the `uint` libs to reflect that they are unsighned. this also changes `%` to rem in the unsighned libs to better reflect that it is just returning the remainder.