### PR TITLE
chore(compiler): Remove `PExpNull` and `TExpNull`

### DIFF
--- a/compiler/src/formatting/debug.re
+++ b/compiler/src/formatting/debug.re
@@ -90,8 +90,6 @@ let debug_expression = (expr: Parsetree.expression) => {
   | PExpAssign(expression, expression1) =>
     print_loc("PExpAssign", expr.pexp_loc)
   | PExpUse(module_, items) => print_loc("PExpUse", expr.pexp_loc)
-  | /** Used for modules without body expressions */ PExpNull =>
-    print_loc("PExpNull", expr.pexp_loc)
   };
 };
 let debug_pattern = (pat: Parsetree.pattern) => {

--- a/compiler/src/formatting/format.re
+++ b/compiler/src/formatting/format.re
@@ -3846,7 +3846,6 @@ and print_expression_inner =
         Doc.space,
         use,
       ]);
-    | /** Used for modules without body expressions */ PExpNull => Doc.nil
     };
 
   expression_doc;

--- a/compiler/src/middle_end/linearize.re
+++ b/compiler/src/middle_end/linearize.re
@@ -264,8 +264,7 @@ let rec transl_imm =
     | Left(imm) => (imm, [])
     | Right((name, cexprs)) => (Imm.id(~loc, ~env, name), cexprs)
     }
-  | TExpUse(_)
-  | TExpNull => (Imm.const(~loc, ~env, Const_void), [])
+  | TExpUse(_) => (Imm.const(~loc, ~env, Const_void), [])
   | TExpPrim0(op) =>
     let tmp = gensym("prim0");
     (

--- a/compiler/src/parsing/ast_helper.re
+++ b/compiler/src/parsing/ast_helper.re
@@ -437,8 +437,6 @@ module Expression = {
       };
     {...list, pexp_loc: loc};
   };
-  let null = (~loc=?, ~attributes=?, ()) =>
-    mk(~loc?, ~attributes?, PExpNull);
 
   let ignore = e =>
     switch (e.pexp_desc) {

--- a/compiler/src/parsing/ast_helper.rei
+++ b/compiler/src/parsing/ast_helper.rei
@@ -247,7 +247,6 @@ module Expression: {
     expression;
   let block:
     (~loc: loc=?, ~attributes: attributes=?, list(expression)) => expression;
-  let null: (~loc: loc=?, ~attributes: attributes=?, unit) => expression;
   let ignore: expression => expression;
 };
 

--- a/compiler/src/parsing/ast_mapper.re
+++ b/compiler/src/parsing/ast_mapper.re
@@ -157,7 +157,6 @@ module E = {
         },
       )
     | PExpBlock(el) => block(~loc, ~attributes, List.map(sub.expr(sub), el))
-    | PExpNull => null(~loc, ~attributes, ())
     | PExpConstraint(e, t) =>
       constraint_(~loc, ~attributes, sub.expr(sub, e), sub.typ(sub, t))
     | PExpUse(id, u) =>

--- a/compiler/src/parsing/parsetree.re
+++ b/compiler/src/parsing/parsetree.re
@@ -517,8 +517,6 @@ and expression_desc =
   | PExpBlock(list(expression))
   | PExpBoxAssign(expression, expression)
   | PExpAssign(expression, expression)
-  | /** Used for modules without body expressions */
-    PExpNull
 
 [@deriving (sexp, yojson)]
 and constructor_expression =

--- a/compiler/src/parsing/parsetree_iter.re
+++ b/compiler/src/parsing/parsetree_iter.re
@@ -315,7 +315,6 @@ and iter_expression =
     | PExpConstrSingleton => ()
     };
   | PExpBlock(el) => iter_expressions(hooks, el)
-  | PExpNull => ()
   };
   hooks.leave_expression(expr);
 }

--- a/compiler/src/typed/typecore.re
+++ b/compiler/src/typed/typecore.re
@@ -1568,15 +1568,6 @@ and type_expect_ =
       exp_type: instance(env, Builtin_types.type_void),
       exp_env: newenv,
     });
-  | PExpNull =>
-    rue({
-      exp_desc: TExpNull,
-      exp_loc: loc,
-      exp_extra: [],
-      exp_attributes: attributes,
-      exp_type: instance(env, Builtin_types.type_void),
-      exp_env: env,
-    })
   };
 }
 

--- a/compiler/src/typed/typecore.re
+++ b/compiler/src/typed/typecore.re
@@ -601,8 +601,7 @@ let rec is_nonexpansive = exp =>
   switch (exp.exp_desc) {
   | TExpIdent(_)
   | TExpConstant(_)
-  | TExpLambda(_)
-  | TExpNull => true
+  | TExpLambda(_) => true
   | TExpTuple(es) => List.for_all(is_nonexpansive, es)
   | TExpLet(rec_flag, Immutable, binds) =>
     List.for_all(vb => is_nonexpansive(vb.vb_expr), binds)

--- a/compiler/src/typed/typedtree.re
+++ b/compiler/src/typed/typedtree.re
@@ -500,7 +500,6 @@ and expression_desc =
       constructor_expression,
     )
   | TExpBlock(list(expression))
-  | TExpNull
 
 and constructor_expression =
   | TExpConstrTuple(list(expression))

--- a/compiler/src/typed/typedtree.rei
+++ b/compiler/src/typed/typedtree.rei
@@ -468,7 +468,6 @@ and expression_desc =
       constructor_expression,
     )
   | TExpBlock(list(expression))
-  | TExpNull
 
 and constructor_expression =
   | TExpConstrTuple(list(expression))

--- a/compiler/src/typed/typedtreeIter.re
+++ b/compiler/src/typed/typedtreeIter.re
@@ -202,7 +202,6 @@ module MakeIterator =
       exp_extra,
     );
     switch (exp_desc) {
-    | TExpNull
     | TExpUse(_)
     | TExpIdent(_)
     | TExpConstant(_) => ()

--- a/compiler/src/typed/typedtreeMap.re
+++ b/compiler/src/typed/typedtreeMap.re
@@ -204,7 +204,6 @@ module MakeMap =
     let exp_extra = List.map(map_exp_extra, exp.exp_extra);
     let exp_desc =
       switch (exp.exp_desc) {
-      | TExpNull
       | TExpUse(_)
       | TExpIdent(_)
       | TExpConstant(_) => exp.exp_desc


### PR DESCRIPTION
This pr removes `PEXPNULL` and `TEXPNULL` from the ast. given they are no longer used.

Closes: #1719 