### PR TITLE
fea(stdlib): Add comparison operators to char stdlib

### DIFF
--- a/compiler/test/stdlib/char.test.gr
+++ b/compiler/test/stdlib/char.test.gr
@@ -54,3 +54,35 @@ while (!done) {
   Char.code(chars[charPosition])
   charPosition += 1
 }
+
+// <
+from Char use { (<) }
+assert 'a' < 'z'
+assert 'a' < 'b'
+assert 'A' < 'Z'
+assert !('z' < 'a')
+
+// <=
+from Char use { (<=) }
+assert 'a' <= 'z'
+assert 'a' <= 'b'
+assert 'A' <= 'Z'
+assert !('z' <= 'a')
+assert 'z' <= 'z'
+assert 'Z' <= 'Z'
+
+// >
+from Char use { (>) }
+assert 'z' > 'a'
+assert 'b' > 'a'
+assert 'Z' > 'A'
+assert !('a' > 'b')
+
+// >=
+from Char use { (>=) }
+assert 'z' >= 'a'
+assert 'b' >= 'a'
+assert 'Z' >= 'A'
+assert !('a' >= 'b')
+assert 'a' >= 'a'
+assert 'B' >= 'B'

--- a/stdlib/char.gr
+++ b/stdlib/char.gr
@@ -203,7 +203,7 @@ provide let toString = (char: Char) => {
  */
 @unsafe
 provide let (<) = (x: Char, y: Char) => {
-  from WasmI32 use { ltU as (<) }
+  from WasmI32 use { (<) }
   let x = WasmI32.fromGrain(x)
   let y = WasmI32.fromGrain(y)
   x < y
@@ -220,7 +220,7 @@ provide let (<) = (x: Char, y: Char) => {
  */
 @unsafe
 provide let (<=) = (x: Char, y: Char) => {
-  from WasmI32 use { leU as (<=) }
+  from WasmI32 use { (<=) }
   let x = WasmI32.fromGrain(x)
   let y = WasmI32.fromGrain(y)
   x <= y
@@ -237,7 +237,7 @@ provide let (<=) = (x: Char, y: Char) => {
  */
 @unsafe
 provide let (>) = (x: Char, y: Char) => {
-  from WasmI32 use { gtU as (>) }
+  from WasmI32 use { (>) }
   let x = WasmI32.fromGrain(x)
   let y = WasmI32.fromGrain(y)
   x > y
@@ -254,7 +254,7 @@ provide let (>) = (x: Char, y: Char) => {
  */
 @unsafe
 provide let (>=) = (x: Char, y: Char) => {
-  from WasmI32 use { geU as (>=) }
+  from WasmI32 use { (>=) }
   let x = WasmI32.fromGrain(x)
   let y = WasmI32.fromGrain(y)
   x >= y

--- a/stdlib/char.gr
+++ b/stdlib/char.gr
@@ -193,7 +193,7 @@ provide let toString = (char: Char) => {
 }
 
 /**
- * Checks if the first value is less than the second value by Unicode scalar value.
+ * Checks if the first character is less than the second character by Unicode scalar value.
  *
  * @param x: The first value
  * @param y: The second value
@@ -210,7 +210,7 @@ provide let (<) = (x: Char, y: Char) => {
 }
 
 /**
- * Checks if the first value is less than or equal to the second value by Unicode scalar value.
+ * Checks if the first character is less than or equal to the second character by Unicode scalar value.
  *
  * @param x: The first value
  * @param y: The second value
@@ -227,7 +227,7 @@ provide let (<=) = (x: Char, y: Char) => {
 }
 
 /**
- * Checks if the first value is greater than the second value by Unicode scalar value.
+ * Checks if the first character is greater than the second character by Unicode scalar value.
  *
  * @param x: The first value
  * @param y: The second value
@@ -244,7 +244,7 @@ provide let (>) = (x: Char, y: Char) => {
 }
 
 /**
- * Checks if the first value is greater than or equal to the second value by Unicode scalar value.
+ * Checks if the first character is greater than or equal to the second character by Unicode scalar value.
  *
  * @param x: The first value
  * @param y: The second value

--- a/stdlib/char.gr
+++ b/stdlib/char.gr
@@ -195,9 +195,9 @@ provide let toString = (char: Char) => {
 /**
  * Checks if the first character is less than the second character by Unicode scalar value.
  *
- * @param x: The first value
- * @param y: The second value
- * @returns `true` if the first value is less than the second value or `false` otherwise
+ * @param x: The first character
+ * @param y: The second character
+ * @returns `true` if the first character is less than the second character or `false` otherwise
  *
  * @since v0.6.0
  */
@@ -212,9 +212,9 @@ provide let (<) = (x: Char, y: Char) => {
 /**
  * Checks if the first character is less than or equal to the second character by Unicode scalar value.
  *
- * @param x: The first value
- * @param y: The second value
- * @returns `true` if the first value is less than or equal to the second value or `false` otherwise
+ * @param x: The first character
+ * @param y: The second character
+ * @returns `true` if the first character is less than or equal to the second character or `false` otherwise
  *
  * @since v0.6.0
  */
@@ -229,9 +229,9 @@ provide let (<=) = (x: Char, y: Char) => {
 /**
  * Checks if the first character is greater than the second character by Unicode scalar value.
  *
- * @param x: The first value
- * @param y: The second value
- * @returns `true` if the first value is greater than the second value or `false` otherwise
+ * @param x: The first character
+ * @param y: The second character
+ * @returns `true` if the first character is greater than the second character or `false` otherwise
  *
  * @since v0.6.0
  */
@@ -246,9 +246,9 @@ provide let (>) = (x: Char, y: Char) => {
 /**
  * Checks if the first character is greater than or equal to the second character by Unicode scalar value.
  *
- * @param x: The first value
- * @param y: The second value
- * @returns `true` if the first value is greater than or equal to the second value or `false` otherwise
+ * @param x: The first character
+ * @param y: The second character
+ * @returns `true` if the first character is greater than or equal to the second character or `false` otherwise
  *
  * @since v0.6.0
  */

--- a/stdlib/char.gr
+++ b/stdlib/char.gr
@@ -193,7 +193,7 @@ provide let toString = (char: Char) => {
 }
 
 /**
- * Checks if the first value is less than the second value.
+ * Checks if the first value is less than the second value by Unicode scalar value.
  *
  * @param x: The first value
  * @param y: The second value
@@ -210,7 +210,7 @@ provide let (<) = (x: Char, y: Char) => {
 }
 
 /**
- * Checks if the first value is less than or equal to the second value.
+ * Checks if the first value is less than or equal to the second value by Unicode scalar value.
  *
  * @param x: The first value
  * @param y: The second value
@@ -227,7 +227,7 @@ provide let (<=) = (x: Char, y: Char) => {
 }
 
 /**
- * Checks if the first value is greater than the second value.
+ * Checks if the first value is greater than the second value by Unicode scalar value.
  *
  * @param x: The first value
  * @param y: The second value
@@ -244,7 +244,7 @@ provide let (>) = (x: Char, y: Char) => {
 }
 
 /**
- * Checks if the first value is greater than or equal to the second value.
+ * Checks if the first value is greater than or equal to the second value by Unicode scalar value.
  *
  * @param x: The first value
  * @param y: The second value

--- a/stdlib/char.gr
+++ b/stdlib/char.gr
@@ -191,3 +191,71 @@ provide let toString = (char: Char) => {
 
   result
 }
+
+/**
+ * Checks if the first value is less than the second value.
+ *
+ * @param x: The first value
+ * @param y: The second value
+ * @returns `true` if the first value is less than the second value or `false` otherwise
+ *
+ * @since v0.6.0
+ */
+@unsafe
+provide let (<) = (x: Char, y: Char) => {
+  from WasmI32 use { ltU as (<) }
+  let x = WasmI32.fromGrain(x)
+  let y = WasmI32.fromGrain(y)
+  x < y
+}
+
+/**
+ * Checks if the first value is less than or equal to the second value.
+ *
+ * @param x: The first value
+ * @param y: The second value
+ * @returns `true` if the first value is less than or equal to the second value or `false` otherwise
+ *
+ * @since v0.6.0
+ */
+@unsafe
+provide let (<=) = (x: Char, y: Char) => {
+  from WasmI32 use { leU as (<=) }
+  let x = WasmI32.fromGrain(x)
+  let y = WasmI32.fromGrain(y)
+  x <= y
+}
+
+/**
+ * Checks if the first value is greater than the second value.
+ *
+ * @param x: The first value
+ * @param y: The second value
+ * @returns `true` if the first value is greater than the second value or `false` otherwise
+ *
+ * @since v0.6.0
+ */
+@unsafe
+provide let (>) = (x: Char, y: Char) => {
+  from WasmI32 use { gtU as (>) }
+  let x = WasmI32.fromGrain(x)
+  let y = WasmI32.fromGrain(y)
+  x > y
+}
+
+/**
+ * Checks if the first value is greater than or equal to the second value.
+ *
+ * @param x: The first value
+ * @param y: The second value
+ * @returns `true` if the first value is greater than or equal to the second value or `false` otherwise
+ *
+ * @since v0.6.0
+ */
+@unsafe
+provide let (>=) = (x: Char, y: Char) => {
+  from WasmI32 use { geU as (>=) }
+  let x = WasmI32.fromGrain(x)
+  let y = WasmI32.fromGrain(y)
+  x >= y
+}

--- a/stdlib/char.md
+++ b/stdlib/char.md
@@ -221,10 +221,10 @@ No other changes yet.
 </details>
 
 ```grain
-(<) : (Char, Char) -> Bool
+(<) : (x: Char, y: Char) -> Bool
 ```
 
-Checks if the first value is less than the second value.
+Checks if the first value is less than the second value by Unicode scalar value.
 
 Parameters:
 
@@ -247,10 +247,10 @@ No other changes yet.
 </details>
 
 ```grain
-(<=) : (Char, Char) -> Bool
+(<=) : (x: Char, y: Char) -> Bool
 ```
 
-Checks if the first value is less than or equal to the second value.
+Checks if the first value is less than or equal to the second value by Unicode scalar value.
 
 Parameters:
 
@@ -273,10 +273,10 @@ No other changes yet.
 </details>
 
 ```grain
-(>) : (Char, Char) -> Bool
+(>) : (x: Char, y: Char) -> Bool
 ```
 
-Checks if the first value is greater than the second value.
+Checks if the first value is greater than the second value by Unicode scalar value.
 
 Parameters:
 
@@ -299,10 +299,10 @@ No other changes yet.
 </details>
 
 ```grain
-(>=) : (Char, Char) -> Bool
+(>=) : (x: Char, y: Char) -> Bool
 ```
 
-Checks if the first value is greater than or equal to the second value.
+Checks if the first value is greater than or equal to the second value by Unicode scalar value.
 
 Parameters:
 

--- a/stdlib/char.md
+++ b/stdlib/char.md
@@ -213,3 +213,107 @@ Returns:
 |----|-----------|
 |`String`|A string containing the given character|
 
+### Char.**(<)**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+(<) : (Char, Char) -> Bool
+```
+
+Checks if the first value is less than the second value.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`x`|`Char`|The first value|
+|`y`|`Char`|The second value|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Bool`|`true` if the first value is less than the second value or `false` otherwise|
+
+### Char.**(<=)**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+(<=) : (Char, Char) -> Bool
+```
+
+Checks if the first value is less than or equal to the second value.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`x`|`Char`|The first value|
+|`y`|`Char`|The second value|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Bool`|`true` if the first value is less than or equal to the second value or `false` otherwise|
+
+### Char.**(>)**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+(>) : (Char, Char) -> Bool
+```
+
+Checks if the first value is greater than the second value.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`x`|`Char`|The first value|
+|`y`|`Char`|The second value|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Bool`|`true` if the first value is greater than the second value or `false` otherwise|
+
+### Char.**(>=)**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+(>=) : (Char, Char) -> Bool
+```
+
+Checks if the first value is greater than or equal to the second value.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`x`|`Char`|The first value|
+|`y`|`Char`|The second value|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Bool`|`true` if the first value is greater than or equal to the second value or `false` otherwise|
+

--- a/stdlib/char.md
+++ b/stdlib/char.md
@@ -230,14 +230,14 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`x`|`Char`|The first value|
-|`y`|`Char`|The second value|
+|`x`|`Char`|The first character|
+|`y`|`Char`|The second character|
 
 Returns:
 
 |type|description|
 |----|-----------|
-|`Bool`|`true` if the first value is less than the second value or `false` otherwise|
+|`Bool`|`true` if the first character is less than the second character or `false` otherwise|
 
 ### Char.**(<=)**
 
@@ -256,14 +256,14 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`x`|`Char`|The first value|
-|`y`|`Char`|The second value|
+|`x`|`Char`|The first character|
+|`y`|`Char`|The second character|
 
 Returns:
 
 |type|description|
 |----|-----------|
-|`Bool`|`true` if the first value is less than or equal to the second value or `false` otherwise|
+|`Bool`|`true` if the first character is less than or equal to the second character or `false` otherwise|
 
 ### Char.**(>)**
 
@@ -282,14 +282,14 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`x`|`Char`|The first value|
-|`y`|`Char`|The second value|
+|`x`|`Char`|The first character|
+|`y`|`Char`|The second character|
 
 Returns:
 
 |type|description|
 |----|-----------|
-|`Bool`|`true` if the first value is greater than the second value or `false` otherwise|
+|`Bool`|`true` if the first character is greater than the second character or `false` otherwise|
 
 ### Char.**(>=)**
 
@@ -308,12 +308,12 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`x`|`Char`|The first value|
-|`y`|`Char`|The second value|
+|`x`|`Char`|The first character|
+|`y`|`Char`|The second character|
 
 Returns:
 
 |type|description|
 |----|-----------|
-|`Bool`|`true` if the first value is greater than or equal to the second value or `false` otherwise|
+|`Bool`|`true` if the first character is greater than or equal to the second character or `false` otherwise|
 

--- a/stdlib/char.md
+++ b/stdlib/char.md
@@ -224,7 +224,7 @@ No other changes yet.
 (<) : (x: Char, y: Char) -> Bool
 ```
 
-Checks if the first value is less than the second value by Unicode scalar value.
+Checks if the first character is less than the second character by Unicode scalar value.
 
 Parameters:
 
@@ -250,7 +250,7 @@ No other changes yet.
 (<=) : (x: Char, y: Char) -> Bool
 ```
 
-Checks if the first value is less than or equal to the second value by Unicode scalar value.
+Checks if the first character is less than or equal to the second character by Unicode scalar value.
 
 Parameters:
 
@@ -276,7 +276,7 @@ No other changes yet.
 (>) : (x: Char, y: Char) -> Bool
 ```
 
-Checks if the first value is greater than the second value by Unicode scalar value.
+Checks if the first character is greater than the second character by Unicode scalar value.
 
 Parameters:
 
@@ -302,7 +302,7 @@ No other changes yet.
 (>=) : (x: Char, y: Char) -> Bool
 ```
 
-Checks if the first value is greater than or equal to the second value by Unicode scalar value.
+Checks if the first character is greater than or equal to the second character by Unicode scalar value.
 
 Parameters:
 


### PR DESCRIPTION
This pr adds comparison operators to the `char` stdlib.

This is blocked on #1734 beacuse currently the imports from the wasm library are using the names rather then the operators.