### PR TITLE
chore(compiler): Update cli version in package lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,11 +19,11 @@
     },
     "cli": {
       "name": "@grain/cli",
-      "version": "0.4.7",
+      "version": "0.5.13",
       "license": "MIT",
       "dependencies": {
-        "@grain/js-runner": "^0.4.0",
-        "@grain/stdlib": "^0.4.6",
+        "@grain/js-runner": "0.5.13",
+        "@grain/stdlib": "0.5.13",
         "commander": "^8.1.0"
       },
       "bin": {
@@ -44,7 +44,7 @@
     },
     "compiler": {
       "name": "@grain/compiler",
-      "version": "0.4.6",
+      "version": "0.5.13",
       "bin": {
         "grainc": "_esy/default/build/install/default/bin/grainc"
       },
@@ -57,7 +57,7 @@
     },
     "js-runner": {
       "name": "@grain/js-runner",
-      "version": "0.4.0",
+      "version": "0.5.13",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.15.0",
@@ -9925,7 +9925,7 @@
     },
     "stdlib": {
       "name": "@grain/stdlib",
-      "version": "0.4.6",
+      "version": "0.5.13",
       "license": "MIT",
       "devDependencies": {
         "del-cli": "^4.0.1"
@@ -10320,8 +10320,8 @@
     "@grain/cli": {
       "version": "file:cli",
       "requires": {
-        "@grain/js-runner": "^0.4.0",
-        "@grain/stdlib": "^0.4.6",
+        "@grain/js-runner": "0.5.13",
+        "@grain/stdlib": "0.5.13",
         "commander": "^8.1.0",
         "del-cli": "^4.0.1",
         "jest": "28.1.0",


### PR DESCRIPTION
For some reason the version of the cli in `package-lock` was back in `0.4` this pr just brings it up to `0.5.13`