### PR TITLE
chore(stdlib)!: Replace `parseInt` error strings with structured error enum

### DIFF
--- a/compiler/src/typed/oprint.re
+++ b/compiler/src/typed/oprint.re
@@ -673,8 +673,7 @@ and print_out_sig_item = ppf =>
         | Otyp_abstract
         | Otyp_tuple(_)
         | Otyp_constr(_, _) => "type"
-        | Otyp_manifest(_, _) =>
-          failwith("NYI: Otyp_manifest pretty-printer")
+        | Otyp_manifest(_, _) => ""
         | Otyp_object(_, _) => failwith("NYI: Otyp_object pretty-printer")
         | Otyp_stuff(_) => failwith("NYI: Otyp_stuff pretty-printer")
         | Otyp_var(_, _) => failwith("NYI: Otyp_var pretty-printer")

--- a/compiler/src/typed/oprint.re
+++ b/compiler/src/typed/oprint.re
@@ -660,8 +660,8 @@ and print_out_sig_item = ppf =>
       //   | Orec_first => "type"
       //   | Orec_next => "and"
       //   };
-      let kwd =
-        switch (td.otype_type) {
+      let rec resolve_kwd = out_type => {
+        switch (out_type) {
         | Otyp_record(_) => "record"
         | Otyp_sum(_) => "enum"
         | Otyp_variant(_, _, _, _) =>
@@ -673,7 +673,7 @@ and print_out_sig_item = ppf =>
         | Otyp_abstract
         | Otyp_tuple(_)
         | Otyp_constr(_, _) => "type"
-        | Otyp_manifest(_, _) => ""
+        | Otyp_manifest(_, original_type) => resolve_kwd(original_type)
         | Otyp_object(_, _) => failwith("NYI: Otyp_object pretty-printer")
         | Otyp_stuff(_) => failwith("NYI: Otyp_stuff pretty-printer")
         | Otyp_var(_, _) => failwith("NYI: Otyp_var pretty-printer")
@@ -682,6 +682,10 @@ and print_out_sig_item = ppf =>
         | Otyp_attribute(_, _) =>
           failwith("NYI: Otyp_attribute pretty-printer")
         };
+      };
+
+      let kwd = resolve_kwd(td.otype_type);
+
       print_out_type_decl(kwd, ppf, td);
     }
   | Osig_value(vd) => {
@@ -734,17 +738,11 @@ and print_out_type_decl = (kwd, ppf, td) => {
       )
     };
 
-  let print_manifest = ppf =>
-    fun
-    | Otyp_manifest(ty, _) => fprintf(ppf, " =@ %a", out_type^, ty)
-    | _ => ();
-
-  let print_name_params = ppf =>
-    fprintf(ppf, "%s %t%a", kwd, type_defined, print_manifest, td.otype_type);
+  let print_name_params = ppf => fprintf(ppf, "%s %t", kwd, type_defined);
 
   let ty =
     switch (td.otype_type) {
-    | Otyp_manifest(_, ty) => ty
+    | Otyp_manifest(_, original_type) => original_type
     | _ => td.otype_type
     };
 

--- a/compiler/test/stdlib/number.test.gr
+++ b/compiler/test/stdlib/number.test.gr
@@ -627,7 +627,7 @@ assert Result.isErr(Number.parseInt("10", 2/3))
 
 // Number.parse
 // These tests primarily focus on rational parsing
-assert Number.parse("") == Err("Invalid input")
+assert Result.isErr(Number.parse(""))
 assert Number.parse("42") == Ok(42)
 assert Number.parse("123.45") == Ok(123.45)
 assert Number.parse("1/1") == Ok(1)
@@ -639,9 +639,9 @@ assert Number.parse("-3/-9") == Ok(1/3)
 assert Number.parse("0x3/-9") == Ok(-1/3)
 assert Number.parse("3/-0x9") == Ok(-1/3)
 assert Number.parse("9223372036854775808/27_670_116_110_564_327_424") == Ok(1/3)
-assert Number.parse("1/2/") == Err("Invalid digit in input")
-assert Number.parse("1/") == Err("Invalid input")
-assert Number.parse("1//") == Err("Invalid digit in input")
+assert Result.isErr(Number.parse("1/2/"))
+assert Result.isErr(Number.parse("1/"))
+assert Result.isErr(Number.parse("1//"))
 
 // Number.sign
 assert Number.sign(-10000) == -1

--- a/compiler/test/stdlib/number.test.gr
+++ b/compiler/test/stdlib/number.test.gr
@@ -624,6 +624,18 @@ assert Result.isErr(Number.parseInt("zzzzz", 37))
 assert Result.isErr(Number.parseInt("zzzzz", 9223372036854775807))
 assert Result.isErr(Number.parseInt("10", 1.23))
 assert Result.isErr(Number.parseInt("10", 2/3))
+assert match (Number.parseInt("zzzzz", 10)) {
+  Err(Number.PraseIntInvalidDigit) => true,
+  _ => false,
+}
+assert match (Number.parseInt("", 10)) {
+  Err(Number.PraseIntEmptyString) => true,
+  _ => false,
+}
+assert match (Number.parseInt("10", 2/3)) {
+  Err(Number.ParseIntInvalidRadix) => true,
+  _ => false,
+}
 
 // Number.parse
 // These tests primarily focus on rational parsing

--- a/compiler/test/stdlib/number.test.gr
+++ b/compiler/test/stdlib/number.test.gr
@@ -625,11 +625,11 @@ assert Result.isErr(Number.parseInt("zzzzz", 9223372036854775807))
 assert Result.isErr(Number.parseInt("10", 1.23))
 assert Result.isErr(Number.parseInt("10", 2/3))
 assert match (Number.parseInt("zzzzz", 10)) {
-  Err(Number.PraseIntInvalidDigit) => true,
+  Err(Number.ParseIntInvalidDigit) => true,
   _ => false,
 }
 assert match (Number.parseInt("", 10)) {
-  Err(Number.PraseIntEmptyString) => true,
+  Err(Number.ParseIntEmptyString) => true,
   _ => false,
 }
 assert match (Number.parseInt("10", 2/3)) {

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -570,14 +570,14 @@ provide let isClose = (a, b, relativeTolerance=1e-9, absoluteTolerance=0.0) => {
  *
  * @param string: The string to parse
  * @param radix: The number system base to use when parsing the input string
- * @returns `Ok(value)` containing the parsed number on a successful parse or `Err(msg)` containing a parseInt exception
+ * @returns `Ok(value)` containing the parsed number on a successful parse or `Err(err)` containing a variant of `ParseIntError`
  *
  * @example Number.parseInt("1", radix=10) == Ok(1)
  * @example Number.parseInt("-1", radix=10) == Ok(-1)
  * @example Number.parseInt("0xf0", radix=16) == Ok(0x0f0)
  *
  * @since v0.4.5
- * @history v0.6.0: Switched from a string-based error message to a parseInt error type
+ * @history v0.6.0: Switched from a string-based error message to a structured error enum
  */
 provide let parseInt = Atoi.parseInt
 

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -49,9 +49,17 @@ from "runtime/atof/parse" include Parse as Atof
 from "runtime/unsafe/tags" include Tags
 from "runtime/exception" include Exception
 
-from Atoi use { type ParseIntError }
+from Atoi use {
+  exception PraseIntEmptyString,
+  exception PraseIntInvalidDigit,
+  exception ParseIntInvalidRadix,
+}
 
-provide { type ParseIntError }
+provide {
+  exception PraseIntEmptyString,
+  exception PraseIntInvalidDigit,
+  exception ParseIntInvalidRadix,
+}
 /**
  * Pi represented as a Number value.
  *
@@ -570,13 +578,14 @@ provide let isClose = (a, b, relativeTolerance=1e-9, absoluteTolerance=0.0) => {
  *
  * @param string: The string to parse
  * @param radix: The number system base to use when parsing the input string
- * @returns `Ok(value)` containing the parsed number on a successful parse or `Err(msg)` containing an error message string otherwise
+ * @returns `Ok(value)` containing the parsed number on a successful parse or `Err(msg)` containing a parseInt exception
  *
  * @example Number.parseInt("1", radix=10) == Ok(1)
  * @example Number.parseInt("-1", radix=10) == Ok(-1)
  * @example Number.parseInt("0xf0", radix=16) == Ok(0x0f0)
  *
  * @since v0.4.5
+ * @history v0.6.0: Switched from a string based error message to a custom exception
  */
 provide let parseInt = Atoi.parseInt
 

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -50,14 +50,14 @@ from "runtime/unsafe/tags" include Tags
 from "runtime/exception" include Exception
 
 from Atoi use {
-  exception PraseIntEmptyString,
-  exception PraseIntInvalidDigit,
+  exception ParseIntEmptyString,
+  exception ParseIntInvalidDigit,
   exception ParseIntInvalidRadix,
 }
 
 provide {
-  exception PraseIntEmptyString,
-  exception PraseIntInvalidDigit,
+  exception ParseIntEmptyString,
+  exception ParseIntInvalidDigit,
   exception ParseIntInvalidRadix,
 }
 /**

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -49,7 +49,7 @@ from "runtime/atof/parse" include Parse as Atof
 from "runtime/unsafe/tags" include Tags
 from "runtime/exception" include Exception
 
-from Atoi use {
+use Atoi.{
   exception ParseIntEmptyString,
   exception ParseIntInvalidDigit,
   exception ParseIntInvalidRadix,

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -49,6 +49,9 @@ from "runtime/atof/parse" include Parse as Atof
 from "runtime/unsafe/tags" include Tags
 from "runtime/exception" include Exception
 
+from Atoi use { type ParseIntError }
+
+provide { type ParseIntError }
 /**
  * Pi represented as a Number value.
  *

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -49,17 +49,9 @@ from "runtime/atof/parse" include Parse as Atof
 from "runtime/unsafe/tags" include Tags
 from "runtime/exception" include Exception
 
-use Atoi.{
-  exception ParseIntEmptyString,
-  exception ParseIntInvalidDigit,
-  exception ParseIntInvalidRadix,
-}
+use Atoi.{ type ParseIntError }
 
-provide {
-  exception ParseIntEmptyString,
-  exception ParseIntInvalidDigit,
-  exception ParseIntInvalidRadix,
-}
+provide { type ParseIntError }
 /**
  * Pi represented as a Number value.
  *
@@ -585,7 +577,7 @@ provide let isClose = (a, b, relativeTolerance=1e-9, absoluteTolerance=0.0) => {
  * @example Number.parseInt("0xf0", radix=16) == Ok(0x0f0)
  *
  * @since v0.4.5
- * @history v0.6.0: Switched from a string based error message to a custom exception
+ * @history v0.6.0: Switched from a string-based error message to a parseInt error type
  */
 provide let parseInt = Atoi.parseInt
 

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -37,6 +37,22 @@ Infinity
 NaN
 ```
 
+## Types
+
+Type declarations included in the Number module.
+
+### Number.**ParseIntError**
+
+```grain
+enum ParseIntError {
+  EmptyString,
+  InvalidDigit,
+  InvalidRadix,
+}
+```
+
+Represents an error that can occur when parsing ints.
+
 ## Values
 
 Functions and constants included in the Number module.
@@ -1097,7 +1113,8 @@ No other changes yet.
 </details>
 
 ```grain
-parseInt : (string: String, radix: Number) => Result<Number, Exception>
+parseInt :
+  (string: String, radix: Number) => Result<Number, Atoi.ParseIntError>
 ```
 
 Parses a string representation of an integer into a `Number` using the
@@ -1119,7 +1136,7 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`Result<Number, Exception>`|`Ok(value)` containing the parsed number on a successful parse or `Err(msg)` containing an error message string otherwise|
+|`Result<Number, Atoi.ParseIntError>`|`Ok(value)` containing the parsed number on a successful parse or `Err(msg)` containing an error message string otherwise|
 
 Examples:
 
@@ -1183,7 +1200,7 @@ No other changes yet.
 </details>
 
 ```grain
-parse : (input: String) => Result<Number, Exception>
+parse : (input: String) => Result<Number, Atoi.ParseIntError>
 ```
 
 Parses a string representation of an integer, float, or rational into a `Number`.
@@ -1199,7 +1216,7 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`Result<Number, Exception>`|`Ok(value)` containing the parsed number on a successful parse or `Err(msg)` containing an error message string otherwise|
+|`Result<Number, Atoi.ParseIntError>`|`Ok(value)` containing the parsed number on a successful parse or `Err(msg)` containing an error message string otherwise|
 
 Examples:
 

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -1114,13 +1114,14 @@ Number.isClose(4, 4.1, relativeTolerance=0.024) == false
 <tr><th>version</th><th>changes</th></tr>
 </thead>
 <tbody>
-<tr><td><code>next</code></td><td>Switched from a string based error message to a custom exception</td></tr>
+<tr><td><code>next</code></td><td>Switched from a string-based error message to a parseInt error type</td></tr>
 </tbody>
 </table>
 </details>
 
 ```grain
-parseInt : (string: String, radix: Number) => Result<Number, Exception>
+parseInt :
+  (string: String, radix: Number) => Result<Number, Atoi.ParseIntError>
 ```
 
 Parses a string representation of an integer into a `Number` using the
@@ -1142,7 +1143,7 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`Result<Number, Exception>`|`Ok(value)` containing the parsed number on a successful parse or `Err(msg)` containing a parseInt exception|
+|`Result<Number, Atoi.ParseIntError>`|`Ok(value)` containing the parsed number on a successful parse or `Err(msg)` containing a parseInt exception|
 
 Examples:
 
@@ -1206,7 +1207,7 @@ No other changes yet.
 </details>
 
 ```grain
-parse : (input: String) => Result<Number, Exception>
+parse : (input: String) => Result<Number, Atoi.ParseIntError>
 ```
 
 Parses a string representation of an integer, float, or rational into a `Number`.
@@ -1222,7 +1223,7 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`Result<Number, Exception>`|`Ok(value)` containing the parsed number on a successful parse or `Err(msg)` containing an error message string otherwise|
+|`Result<Number, Atoi.ParseIntError>`|`Ok(value)` containing the parsed number on a successful parse or `Err(msg)` containing an error message string otherwise|
 
 Examples:
 

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -1107,14 +1107,20 @@ Number.isClose(4, 4.1, relativeTolerance=0.024) == false
 
 ### Number.**parseInt**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.4.5</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>0.4.5</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>next</code></td><td>Switched from a string based error message to a custom exception</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
-parseInt :
-  (string: String, radix: Number) => Result<Number, Atoi.ParseIntError>
+parseInt : (string: String, radix: Number) => Result<Number, Exception>
 ```
 
 Parses a string representation of an integer into a `Number` using the
@@ -1136,7 +1142,7 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`Result<Number, Atoi.ParseIntError>`|`Ok(value)` containing the parsed number on a successful parse or `Err(msg)` containing an error message string otherwise|
+|`Result<Number, Exception>`|`Ok(value)` containing the parsed number on a successful parse or `Err(msg)` containing a parseInt exception|
 
 Examples:
 
@@ -1200,7 +1206,7 @@ No other changes yet.
 </details>
 
 ```grain
-parse : (input: String) => Result<Number, Atoi.ParseIntError>
+parse : (input: String) => Result<Number, Exception>
 ```
 
 Parses a string representation of an integer, float, or rational into a `Number`.
@@ -1216,7 +1222,7 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`Result<Number, Atoi.ParseIntError>`|`Ok(value)` containing the parsed number on a successful parse or `Err(msg)` containing an error message string otherwise|
+|`Result<Number, Exception>`|`Ok(value)` containing the parsed number on a successful parse or `Err(msg)` containing an error message string otherwise|
 
 Examples:
 

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -1114,7 +1114,7 @@ Number.isClose(4, 4.1, relativeTolerance=0.024) == false
 <tr><th>version</th><th>changes</th></tr>
 </thead>
 <tbody>
-<tr><td><code>next</code></td><td>Switched from a string-based error message to a parseInt error type</td></tr>
+<tr><td><code>next</code></td><td>Switched from a string-based error message to a structured error enum</td></tr>
 </tbody>
 </table>
 </details>
@@ -1143,7 +1143,7 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`Result<Number, Atoi.ParseIntError>`|`Ok(value)` containing the parsed number on a successful parse or `Err(msg)` containing a parseInt exception|
+|`Result<Number, Atoi.ParseIntError>`|`Ok(value)` containing the parsed number on a successful parse or `Err(err)` containing a variant of `ParseIntError`|
 
 Examples:
 

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -43,15 +43,40 @@ Type declarations included in the Number module.
 
 ### Number.**ParseIntError**
 
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
 ```grain
 enum ParseIntError {
-  EmptyString,
-  InvalidDigit,
-  InvalidRadix,
+  ParseIntEmptyString,
+  ParseIntInvalidDigit,
+  ParseIntInvalidRadix,
 }
 ```
 
-Represents an error that can occur when parsing ints.
+Represents an error that occurred trying to parse an integer.
+
+Variants:
+
+```grain
+ParseIntEmptyString
+```
+
+Represents an error caused by trying to parse an empty string.
+
+```grain
+ParseIntInvalidDigit
+```
+
+Represents an error caused by trying to parse a string with an invalid character.
+
+```grain
+ParseIntInvalidRadix
+```
+
+Represents an error caused by trying to parse with an invalid radix.
 
 ## Values
 

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -1097,7 +1097,7 @@ No other changes yet.
 </details>
 
 ```grain
-parseInt : (string: String, radix: Number) => Result<Number, String>
+parseInt : (string: String, radix: Number) => Result<Number, Exception>
 ```
 
 Parses a string representation of an integer into a `Number` using the
@@ -1119,7 +1119,7 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`Result<Number, String>`|`Ok(value)` containing the parsed number on a successful parse or `Err(msg)` containing an error message string otherwise|
+|`Result<Number, Exception>`|`Ok(value)` containing the parsed number on a successful parse or `Err(msg)` containing an error message string otherwise|
 
 Examples:
 
@@ -1183,7 +1183,7 @@ No other changes yet.
 </details>
 
 ```grain
-parse : (input: String) => Result<Number, String>
+parse : (input: String) => Result<Number, Exception>
 ```
 
 Parses a string representation of an integer, float, or rational into a `Number`.
@@ -1199,7 +1199,7 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`Result<Number, String>`|`Ok(value)` containing the parsed number on a successful parse or `Err(msg)` containing an error message string otherwise|
+|`Result<Number, Exception>`|`Ok(value)` containing the parsed number on a successful parse or `Err(msg)` containing an error message string otherwise|
 
 Examples:
 

--- a/stdlib/runtime/atoi/parse.gr
+++ b/stdlib/runtime/atoi/parse.gr
@@ -21,13 +21,23 @@ from "runtime/numbers" include Numbers
 use Numbers.{ reducedInteger }
 
 /**
- * Represents an error that can occur when parsing ints.
+ * Represents an error caused by trying to parse an empty string.
+ *
+ * @since v0.6.0
  */
-provide enum ParseIntError {
-  EmptyString,
-  InvalidDigit,
-  InvalidRadix,
-}
+provide exception PraseIntEmptyString
+/**
+ * Represents an error caused by trying to parse a string with an invalid character.
+ *
+ * @since v0.6.0
+ */
+provide exception PraseIntInvalidDigit
+/**
+ * Represents an error caused by trying to parse with an invalid radix.
+ *
+ * @since v0.6.0
+ */
+provide exception ParseIntInvalidRadix
 
 primitive (&&) = "@and"
 primitive (||) = "@or"
@@ -67,11 +77,11 @@ provide let parseInt = (string: String, radix: Number) => {
     radix < WasmI32.fromGrain(2) ||
     radix > WasmI32.fromGrain(36)
   ) {
-    return Err(InvalidRadix)
+    return Err(ParseIntInvalidRadix)
   }
 
   if (WasmI32.eqz(strLen)) {
-    return Err(EmptyString)
+    return Err(PraseIntEmptyString)
   }
 
   let mut char = WasmI32.load8U(offset, 0n)
@@ -132,12 +142,12 @@ provide let parseInt = (string: String, radix: Number) => {
       c when c - _CHAR_A < 26n => digit = char - _CHAR_A + 10n,
       c when c - _CHAR_a < 26n => digit = char - _CHAR_a + 10n,
       _ => {
-        return Err(InvalidDigit)
+        return Err(PraseIntInvalidDigit)
       },
     }
 
     if (digit >= WasmI32.wrapI64(radix)) {
-      return Err(InvalidDigit)
+      return Err(PraseIntInvalidDigit)
     }
 
     let digit = WasmI64.extendI32U(digit)
@@ -183,7 +193,7 @@ provide let parseInt = (string: String, radix: Number) => {
   }
   use WasmI64.{ (*) }
   // TODO: Verify this is suitable for handling "_"
-  if (WasmI32.eqz(sawDigit)) return Err(InvalidDigit)
+  if (WasmI32.eqz(sawDigit)) return Err(PraseIntInvalidDigit)
 
   if (WasmI32.eqz(isBigInt)) {
     let value = if (negative) value else value * -1N

--- a/stdlib/runtime/atoi/parse.gr
+++ b/stdlib/runtime/atoi/parse.gr
@@ -20,9 +20,14 @@ from "runtime/bigint" include Bigint as BI
 from "runtime/numbers" include Numbers
 use Numbers.{ reducedInteger }
 
-provide exception EmptyString
-provide exception InvalidDigit
-provide exception InvalidRadix
+/**
+ * Represents an error that can occur when parsing ints.
+ */
+provide enum ParseIntError {
+  EmptyString,
+  InvalidDigit,
+  InvalidRadix,
+}
 
 primitive (&&) = "@and"
 primitive (||) = "@or"

--- a/stdlib/runtime/atoi/parse.gr
+++ b/stdlib/runtime/atoi/parse.gr
@@ -25,13 +25,13 @@ use Numbers.{ reducedInteger }
  *
  * @since v0.6.0
  */
-provide exception PraseIntEmptyString
+provide exception ParseIntEmptyString
 /**
  * Represents an error caused by trying to parse a string with an invalid character.
  *
  * @since v0.6.0
  */
-provide exception PraseIntInvalidDigit
+provide exception ParseIntInvalidDigit
 /**
  * Represents an error caused by trying to parse with an invalid radix.
  *
@@ -81,7 +81,7 @@ provide let parseInt = (string: String, radix: Number) => {
   }
 
   if (WasmI32.eqz(strLen)) {
-    return Err(PraseIntEmptyString)
+    return Err(ParseIntEmptyString)
   }
 
   let mut char = WasmI32.load8U(offset, 0n)
@@ -142,12 +142,12 @@ provide let parseInt = (string: String, radix: Number) => {
       c when c - _CHAR_A < 26n => digit = char - _CHAR_A + 10n,
       c when c - _CHAR_a < 26n => digit = char - _CHAR_a + 10n,
       _ => {
-        return Err(PraseIntInvalidDigit)
+        return Err(ParseIntInvalidDigit)
       },
     }
 
     if (digit >= WasmI32.wrapI64(radix)) {
-      return Err(PraseIntInvalidDigit)
+      return Err(ParseIntInvalidDigit)
     }
 
     let digit = WasmI64.extendI32U(digit)
@@ -193,7 +193,7 @@ provide let parseInt = (string: String, radix: Number) => {
   }
   use WasmI64.{ (*) }
   // TODO: Verify this is suitable for handling "_"
-  if (WasmI32.eqz(sawDigit)) return Err(PraseIntInvalidDigit)
+  if (WasmI32.eqz(sawDigit)) return Err(ParseIntInvalidDigit)
 
   if (WasmI32.eqz(isBigInt)) {
     let value = if (negative) value else value * -1N

--- a/stdlib/runtime/atoi/parse.gr
+++ b/stdlib/runtime/atoi/parse.gr
@@ -20,6 +20,10 @@ from "runtime/bigint" include Bigint as BI
 from "runtime/numbers" include Numbers
 use Numbers.{ reducedInteger }
 
+provide exception EmptyString
+provide exception InvalidDigit
+provide exception InvalidRadix
+
 primitive (&&) = "@and"
 primitive (||) = "@or"
 
@@ -58,11 +62,11 @@ provide let parseInt = (string: String, radix: Number) => {
     radix < WasmI32.fromGrain(2) ||
     radix > WasmI32.fromGrain(36)
   ) {
-    return Err("Radix must be an integer between 2 and 36")
+    return Err(InvalidRadix)
   }
 
   if (WasmI32.eqz(strLen)) {
-    return Err("Invalid input")
+    return Err(EmptyString)
   }
 
   let mut char = WasmI32.load8U(offset, 0n)
@@ -123,12 +127,12 @@ provide let parseInt = (string: String, radix: Number) => {
       c when c - _CHAR_A < 26n => digit = char - _CHAR_A + 10n,
       c when c - _CHAR_a < 26n => digit = char - _CHAR_a + 10n,
       _ => {
-        return Err("Invalid digit in input")
+        return Err(InvalidDigit)
       },
     }
 
     if (digit >= WasmI32.wrapI64(radix)) {
-      return Err("Invalid digit in input")
+      return Err(InvalidDigit)
     }
 
     let digit = WasmI64.extendI32U(digit)
@@ -174,7 +178,7 @@ provide let parseInt = (string: String, radix: Number) => {
   }
   use WasmI64.{ (*) }
   // TODO: Verify this is suitable for handling "_"
-  if (WasmI32.eqz(sawDigit)) return Err("Invalid digit in input")
+  if (WasmI32.eqz(sawDigit)) return Err(InvalidDigit)
 
   if (WasmI32.eqz(isBigInt)) {
     let value = if (negative) value else value * -1N

--- a/stdlib/runtime/atoi/parse.gr
+++ b/stdlib/runtime/atoi/parse.gr
@@ -21,23 +21,24 @@ from "runtime/numbers" include Numbers
 use Numbers.{ reducedInteger }
 
 /**
- * Represents an error caused by trying to parse an empty string.
+ * Represents an error that occurred trying to parse an integer.
  *
  * @since v0.6.0
  */
-provide exception ParseIntEmptyString
-/**
- * Represents an error caused by trying to parse a string with an invalid character.
- *
- * @since v0.6.0
- */
-provide exception ParseIntInvalidDigit
-/**
- * Represents an error caused by trying to parse with an invalid radix.
- *
- * @since v0.6.0
- */
-provide exception ParseIntInvalidRadix
+provide enum ParseIntError {
+  /**
+   * Represents an error caused by trying to parse an empty string.
+   */
+  ParseIntEmptyString,
+  /**
+   * Represents an error caused by trying to parse a string with an invalid character.
+   */
+  ParseIntInvalidDigit,
+  /**
+   * Represents an error caused by trying to parse with an invalid radix.
+   */
+  ParseIntInvalidRadix,
+}
 
 primitive (&&) = "@and"
 primitive (||) = "@or"

--- a/stdlib/runtime/atoi/parse.md
+++ b/stdlib/runtime/atoi/parse.md
@@ -2,6 +2,47 @@
 title: Parse
 ---
 
+## Types
+
+Type declarations included in the Parse module.
+
+### Parse.**ParseIntError**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+enum ParseIntError {
+  ParseIntEmptyString,
+  ParseIntInvalidDigit,
+  ParseIntInvalidRadix,
+}
+```
+
+Represents an error that occurred trying to parse an integer.
+
+Variants:
+
+```grain
+ParseIntEmptyString
+```
+
+Represents an error caused by trying to parse an empty string.
+
+```grain
+ParseIntInvalidDigit
+```
+
+Represents an error caused by trying to parse a string with an invalid character.
+
+```grain
+ParseIntInvalidRadix
+```
+
+Represents an error caused by trying to parse with an invalid radix.
+
 ## Values
 
 Functions and constants included in the Parse module.
@@ -9,6 +50,6 @@ Functions and constants included in the Parse module.
 ### Parse.**parseInt**
 
 ```grain
-parseInt : (string: String, radix: Number) => Result<Number, Exception>
+parseInt : (string: String, radix: Number) => Result<Number, ParseIntError>
 ```
 

--- a/stdlib/runtime/atoi/parse.md
+++ b/stdlib/runtime/atoi/parse.md
@@ -9,6 +9,6 @@ Functions and constants included in the Parse module.
 ### Parse.**parseInt**
 
 ```grain
-parseInt : (string: String, radix: Number) => Result<Number, String>
+parseInt : (string: String, radix: Number) => Result<Number, Exception>
 ```
 

--- a/stdlib/runtime/atoi/parse.md
+++ b/stdlib/runtime/atoi/parse.md
@@ -2,22 +2,6 @@
 title: Parse
 ---
 
-## Types
-
-Type declarations included in the Parse module.
-
-### Parse.**ParseIntError**
-
-```grain
-enum ParseIntError {
-  EmptyString,
-  InvalidDigit,
-  InvalidRadix,
-}
-```
-
-Represents an error that can occur when parsing ints.
-
 ## Values
 
 Functions and constants included in the Parse module.
@@ -25,6 +9,6 @@ Functions and constants included in the Parse module.
 ### Parse.**parseInt**
 
 ```grain
-parseInt : (string: String, radix: Number) => Result<Number, ParseIntError>
+parseInt : (string: String, radix: Number) => Result<Number, Exception>
 ```
 

--- a/stdlib/runtime/atoi/parse.md
+++ b/stdlib/runtime/atoi/parse.md
@@ -2,6 +2,22 @@
 title: Parse
 ---
 
+## Types
+
+Type declarations included in the Parse module.
+
+### Parse.**ParseIntError**
+
+```grain
+enum ParseIntError {
+  EmptyString,
+  InvalidDigit,
+  InvalidRadix,
+}
+```
+
+Represents an error that can occur when parsing ints.
+
 ## Values
 
 Functions and constants included in the Parse module.
@@ -9,6 +25,6 @@ Functions and constants included in the Parse module.
 ### Parse.**parseInt**
 
 ```grain
-parseInt : (string: String, radix: Number) => Result<Number, Exception>
+parseInt : (string: String, radix: Number) => Result<Number, ParseIntError>
 ```
 


### PR DESCRIPTION
This makes `parseInt` use an exception in the `err` case.

On a note though until #1053 is fixed I dont know if it makes sense to make this change as you lose the ability to pattern match on the individual cases without importing the exceptions directly from the runtime which we dont want users doing.

That could still make it in before 0.6 so this pr is up for that and also just in case we want to move forward on this anyways.

This has been blocked by: #1758   or #1759  either one would work to get this moving.

Closes: #1057