### PR TITLE
fix(compiler): Provide full module interface in intermediate wasm files

### DIFF
--- a/compiler/src/codegen/transl_anf.re
+++ b/compiler/src/codegen/transl_anf.re
@@ -1004,9 +1004,10 @@ let transl_signature = (~functions, ~imports, signature) => {
         switch (decl.md_type) {
         | TModIdent(_)
         | TModAlias(_) => decl
-        | TModSignature(_) when Option.is_some(decl.md_filepath) => decl
         | TModSignature(signature) => {
             ...decl,
+            // This module will provide all exports for all submodules
+            md_filepath: None,
             md_type:
               TModSignature(
                 List.map(

--- a/compiler/test/suites/modules.re
+++ b/compiler/test/suites/modules.re
@@ -126,4 +126,44 @@ describe("modules", ({test, testSkip}) => {
     "nestedModules",
     "hello from foo\nhello from bar\n[2, 3, 4]\n9\n[> 2, 3, 4]\nfalse\nfoo\n",
   );
+  test("reprovided_module", ({expect}) => {
+    let name = "reprovided_module";
+    let outfile = wasmfile(name);
+    ignore @@
+    compile(
+      ~hook=Grain.Compile.stop_after_object_file_emitted,
+      name,
+      {|
+      module ReprovidedSimple
+
+      include "simpleModule"
+      provide { Simple }
+      |},
+    );
+    let ic = open_in_bin(outfile);
+    let sections = Grain_utils.Wasm_utils.get_wasm_sections(ic);
+    close_in(ic);
+    let export_sections =
+      List.find_map(
+        (sec: Grain_utils.Wasm_utils.wasm_bin_section) =>
+          switch (sec) {
+          | {sec_type: Export(exports)} => Some(exports)
+          | _ => None
+          },
+        sections,
+      );
+    expect.option(export_sections).toBeSome();
+    expect.list(Option.get(export_sections)).toContainEqual((
+      WasmFunction,
+      "Simple.Simple.func",
+    ));
+    expect.list(Option.get(export_sections)).toContainEqual((
+      WasmGlobal,
+      "GRAIN$EXPORT$Simple.Simple.func",
+    ));
+    expect.list(Option.get(export_sections)).toContainEqual((
+      WasmGlobal,
+      "GRAIN$EXPORT$Simple.Simple.foo",
+    ));
+  });
 });

--- a/compiler/test/test-libs/simpleModule.gr
+++ b/compiler/test/test-libs/simpleModule.gr
@@ -1,0 +1,6 @@
+module Simple
+
+provide module Simple {
+  provide let foo = 5
+  provide let func = () => 5
+}


### PR DESCRIPTION
This PR fixes an issue where a module on the include path that re-provided other included modules could not be compiled as a part of a project. 

Previously, a module re-export was just a pointer to the original module. Now, the intermediate module provides the full interface. This incurs no runtime cost, but compilation may be a tad slower due to the indirection.