### PR TITLE
fix(stdlib)!: Ensure `Array.fillRange` works with negative indexing & throws IndexOutOfBound

### DIFF
--- a/compiler/test/stdlib/array.test.gr
+++ b/compiler/test/stdlib/array.test.gr
@@ -221,6 +221,10 @@ let arr = [> 1, 2, 3]
 Array.fillRange(10, -3, -1, arr)
 assert arr == [> 10, 10, 3]
 
+let arr = [> 1, 2, 3]
+Array.fillRange(10, -3, -10, arr)
+assert arr == [> 10, 10, 10]
+
 // Array.product
 
 let arrA = [> 1, 2]

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -40,6 +40,18 @@ let checkLength = length => {
 }
 
 /**
+ * A simple helper function to convert a negative array index
+ * number to its positive positional equivalent.
+ */
+let wrapNegativeIndex = (arrLen, idx) => {
+  if (idx >= 0) {
+    idx
+  } else {
+    arrLen + idx
+  }
+}
+
+/**
  * Provides the length of the input array.
  *
  * @param array: The array to inspect
@@ -513,8 +525,14 @@ provide let fill = (value, array) => {
  */
 provide let fillRange = (value, start, stop, array) => {
   let length = length(array)
-  let startIndex = if (start < 0) length + start else start
-  let stopIndex = if (stop < 0) length + stop else stop
+  let startIndex = wrapNegativeIndex(length, start)
+  let stopIndex = wrapNegativeIndex(length, stop)
+  // Ensure we aren't working with an `stop` value that is too big
+  let stopIndex = if (stopIndex < 0 || stopIndex > length) {
+    length
+  } else {
+    stopIndex
+  }
 
   if (startIndex > length) {
     fail "The start index is outside the array"
@@ -524,11 +542,7 @@ provide let fillRange = (value, start, stop, array) => {
   }
 
   let mut index = startIndex
-  for (
-    let mut index = startIndex;
-    index < stopIndex && index < length;
-    index += 1
-  ) {
+  for (let mut index = startIndex; index < stopIndex; index += 1) {
     array[index] = value
   }
   void
@@ -882,18 +896,6 @@ provide let join = (separator: String, items: Array<String>) => {
   match (reduce(iter, None, items)) {
     None => "",
     Some(s) => s,
-  }
-}
-
-/**
- * A simple helper function to convert a negative array index
- * number to its positive positional equivalent.
- */
-let wrapNegativeIndex = (arrLen, idx) => {
-  if (idx >= 0) {
-    idx
-  } else {
-    arrLen + idx
   }
 }
 

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -527,7 +527,7 @@ provide let fillRange = (value, start, stop, array) => {
   let length = length(array)
   let startIndex = wrapNegativeIndex(length, start)
   let stopIndex = wrapNegativeIndex(length, stop)
-  // Ensure we aren't working with an `stop` value that is too big
+  // Ensure we aren't working with a `stop` value that is too big
   let stopIndex = if (stopIndex < 0 || stopIndex > length) {
     length
   } else {

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -518,8 +518,8 @@ provide let fill = (value, array) => {
  * @param stop: The (exclusive) index to end replacement
  * @param array: The array to update
  *
- * @throws Failure(String): When the start index is out of bounds
- * @throws Failure(String): When the start index is greater then the stop index
+ * @throws IndexOutOfBounds: When the start index is out of bounds
+ * @throws IndexOutOfBounds: When the start index is greater then the stop index
  *
  * @since v0.2.0
  */
@@ -535,10 +535,10 @@ provide let fillRange = (value, start, stop, array) => {
   }
 
   if (startIndex > length) {
-    fail "The start index is outside the array"
+    throw IndexOutOfBounds
   }
   if (startIndex > stopIndex) {
-    fail "The start index cannot be higher than the stop index"
+    throw IndexOutOfBounds
   }
 
   let mut index = startIndex

--- a/stdlib/array.md
+++ b/stdlib/array.md
@@ -718,7 +718,7 @@ Parameters:
 
 Throws:
 
-`Failure(String)`
+`IndexOutOfBounds`
 
 * When the start index is out of bounds
 * When the start index is greater then the stop index


### PR DESCRIPTION
This pr makes `Array.fillRange` work correctly with negative indexs.
This pr also corrects the `failure`s used to be actual exceptions.


Closes: #1521 