### PR TITLE
feat(stdlib)!: Add `print` suffix default argument

### DIFF
--- a/compiler/test/__snapshots__/basic_functionality.122e74b0.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.122e74b0.0.snapshot
@@ -1,9 +1,9 @@
-basic functionality › complex2
+basic functionality › print_line_ending1
 (module
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
- (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_genv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_genv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_genv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
@@ -12,11 +12,9 @@ basic functionality › complex2
  (import \"_genv\" \"metadataPtr\" (global $metadataPtr_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1116 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1113 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1116 (param i32 i32 i32) (result i32)))
  (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1113 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (memory $0 0)
@@ -34,15 +32,37 @@ basic functionality › complex2
   (local $5 f64)
   (local $6 i32)
   (local $7 i32)
-  (block $compile_block.6
+  (block $compile_block.7
    (block $compile_store.3
     (local.set $6
-     (block $allocate_adt.1 (result i32)
+     (block $allocate_string.1 (result i32)
       (i32.store
        (local.tee $0
         (call $malloc_0
          (global.get $GRAIN$EXPORT$malloc_0)
-         (i32.const 20)
+         (i32.const 8)
+        )
+       )
+       (i32.const 1)
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (i32.const 0)
+      )
+      (local.get $0)
+     )
+    )
+    (block $do_backpatches.2
+    )
+   )
+   (block $compile_store.6
+    (local.set $7
+     (block $allocate_adt.4 (result i32)
+      (i32.store
+       (local.tee $0
+        (call $malloc_0
+         (global.get $GRAIN$EXPORT$malloc_0)
+         (i32.const 24)
         )
        )
        (i32.const 2)
@@ -57,30 +77,20 @@ basic functionality › complex2
       )
       (i32.store offset=12
        (local.get $0)
-       (i32.const 3)
+       (i32.const 1)
       )
       (i32.store offset=16
        (local.get $0)
-       (i32.const 0)
+       (i32.const 1)
+      )
+      (i32.store offset=20
+       (local.get $0)
+       (local.get $6)
       )
       (local.get $0)
      )
     )
-    (block $do_backpatches.2
-    )
-   )
-   (block $compile_store.5
-    (local.set $7
-     (call $+_1116
-      (call $incRef_0
-       (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $+_1116)
-      )
-      (i32.const 5)
-      (i32.const 7)
-     )
-    )
-    (block $do_backpatches.4
+    (block $do_backpatches.5
     )
    )
    (return_call $print_1113
@@ -88,8 +98,8 @@ basic functionality › complex2
      (global.get $GRAIN$EXPORT$incRef_0)
      (global.get $print_1113)
     )
+    (i32.const 3)
     (local.get $7)
-    (local.get $6)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.1f787365.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1f787365.0.snapshot
@@ -3,16 +3,19 @@ basic functionality › orshort2
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_genv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_genv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_genv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"_genv\" \"runtimeHeapStart\" (global $runtimeHeapStart_0 i32))
  (import \"_genv\" \"runtimeHeapNextPtr\" (global $runtimeHeapNextPtr_0 (mut i32)))
  (import \"_genv\" \"metadataPtr\" (global $metadataPtr_0 i32))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1113 (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1113 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1113 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (memory $0 0)
  (elem $elem (global.get $relocBase_0))
@@ -27,7 +30,42 @@ basic functionality › orshort2
   (local $3 i64)
   (local $4 f32)
   (local $5 f64)
-  (block $compile_block.1 (result i32)
+  (local $6 i32)
+  (block $compile_block.4 (result i32)
+   (block $compile_store.3
+    (local.set $6
+     (block $allocate_adt.1 (result i32)
+      (i32.store
+       (local.tee $0
+        (call $malloc_0
+         (global.get $GRAIN$EXPORT$malloc_0)
+         (i32.const 20)
+        )
+       )
+       (i32.const 2)
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (i32.const 501102191)
+      )
+      (i32.store offset=8
+       (local.get $0)
+       (i32.const 7)
+      )
+      (i32.store offset=12
+       (local.get $0)
+       (i32.const 3)
+      )
+      (i32.store offset=16
+       (local.get $0)
+       (i32.const 0)
+      )
+      (local.get $0)
+     )
+    )
+    (block $do_backpatches.2
+    )
+   )
    (drop
     (call $print_1113
      (call $incRef_0
@@ -35,6 +73,7 @@ basic functionality › orshort2
       (global.get $print_1113)
      )
      (i32.const 3)
+     (local.get $6)
     )
    )
    (i32.const 2147483646)

--- a/compiler/test/__snapshots__/basic_functionality.52ca8e0e.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.52ca8e0e.0.snapshot
@@ -4,6 +4,7 @@ basic functionality › func_shadow
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_genv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_genv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_genv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
@@ -17,7 +18,7 @@ basic functionality › func_shadow
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1118 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1118 (param i32 i32 i32) (result i32)))
  (global $foo_1115 (mut i32) (i32.const 0))
  (global $foo_1113 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
@@ -122,7 +123,9 @@ basic functionality › func_shadow
   (local $5 f64)
   (local $6 i32)
   (local $7 i32)
-  (block $compile_block.15
+  (local $8 i32)
+  (local $9 i32)
+  (block $compile_block.21
    (block $compile_store.8
     (global.set $foo_1113
      (i32.const 0)
@@ -130,8 +133,42 @@ basic functionality › func_shadow
     (block $do_backpatches.7
     )
    )
-   (block $compile_store.10
+   (block $compile_store.11
     (local.set $6
+     (block $allocate_adt.9 (result i32)
+      (i32.store
+       (local.tee $0
+        (call $malloc_0
+         (global.get $GRAIN$EXPORT$malloc_0)
+         (i32.const 20)
+        )
+       )
+       (i32.const 2)
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (i32.const 501102191)
+      )
+      (i32.store offset=8
+       (local.get $0)
+       (i32.const 7)
+      )
+      (i32.store offset=12
+       (local.get $0)
+       (i32.const 3)
+      )
+      (i32.store offset=16
+       (local.get $0)
+       (i32.const 0)
+      )
+      (local.get $0)
+     )
+    )
+    (block $do_backpatches.10
+    )
+   )
+   (block $compile_store.13
+    (local.set $7
      (call $foo_1113
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
@@ -139,7 +176,7 @@ basic functionality › func_shadow
       )
      )
     )
-    (block $do_backpatches.9
+    (block $do_backpatches.12
     )
    )
    (drop
@@ -148,18 +185,53 @@ basic functionality › func_shadow
       (global.get $GRAIN$EXPORT$incRef_0)
       (global.get $print_1118)
      )
+     (local.get $7)
      (local.get $6)
     )
    )
-   (block $compile_store.12
+   (block $compile_store.15
     (global.set $foo_1115
      (i32.const 0)
     )
-    (block $do_backpatches.11
+    (block $do_backpatches.14
     )
    )
-   (block $compile_store.14
-    (local.set $7
+   (block $compile_store.18
+    (local.set $8
+     (block $allocate_adt.16 (result i32)
+      (i32.store
+       (local.tee $0
+        (call $malloc_0
+         (global.get $GRAIN$EXPORT$malloc_0)
+         (i32.const 20)
+        )
+       )
+       (i32.const 2)
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (i32.const 501102191)
+      )
+      (i32.store offset=8
+       (local.get $0)
+       (i32.const 7)
+      )
+      (i32.store offset=12
+       (local.get $0)
+       (i32.const 3)
+      )
+      (i32.store offset=16
+       (local.get $0)
+       (i32.const 0)
+      )
+      (local.get $0)
+     )
+    )
+    (block $do_backpatches.17
+    )
+   )
+   (block $compile_store.20
+    (local.set $9
      (call $foo_1115
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
@@ -167,7 +239,7 @@ basic functionality › func_shadow
       )
      )
     )
-    (block $do_backpatches.13
+    (block $do_backpatches.19
     )
    )
    (return_call $print_1118
@@ -175,7 +247,8 @@ basic functionality › func_shadow
      (global.get $GRAIN$EXPORT$incRef_0)
      (global.get $print_1118)
     )
-    (local.get $7)
+    (local.get $9)
+    (local.get $8)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.711a4824.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.711a4824.0.snapshot
@@ -4,6 +4,7 @@ basic functionality › pattern_match_unsafe_wasm
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_genv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_genv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_genv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
@@ -17,7 +18,7 @@ basic functionality › pattern_match_unsafe_wasm
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1125 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1125 (param i32 i32 i32) (result i32)))
  (global $test_1113 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (memory $0 0)
@@ -107,9 +108,16 @@ basic functionality › pattern_match_unsafe_wasm
   (local $13 i32)
   (local $14 i32)
   (local $15 i32)
-  (block $compile_block.51 (result i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (block $compile_block.72 (result i32)
    (block $compile_store.6
-    (local.set $9
+    (local.set $16
      (i32.or
       (i32.shl
        (i32.eq
@@ -125,10 +133,10 @@ basic functionality › pattern_match_unsafe_wasm
     )
    )
    (block $compile_store.30
-    (local.set $10
+    (local.set $17
      (if (result i32)
       (i32.shr_u
-       (local.get $9)
+       (local.get $16)
        (i32.const 31)
       )
       (block $compile_block.7 (result i32)
@@ -136,7 +144,7 @@ basic functionality › pattern_match_unsafe_wasm
       )
       (block $compile_block.28 (result i32)
        (block $compile_store.9
-        (local.set $11
+        (local.set $18
          (i32.or
           (i32.shl
            (i32.eq
@@ -153,7 +161,7 @@ basic functionality › pattern_match_unsafe_wasm
        )
        (if (result i32)
         (i32.shr_u
-         (local.get $11)
+         (local.get $18)
          (i32.const 31)
         )
         (block $compile_block.10 (result i32)
@@ -161,7 +169,7 @@ basic functionality › pattern_match_unsafe_wasm
         )
         (block $compile_block.27 (result i32)
          (block $compile_store.12
-          (local.set $12
+          (local.set $19
            (i32.or
             (i32.shl
              (i32.eq
@@ -178,7 +186,7 @@ basic functionality › pattern_match_unsafe_wasm
          )
          (if (result i32)
           (i32.shr_u
-           (local.get $12)
+           (local.get $19)
            (i32.const 31)
           )
           (block $compile_block.13 (result i32)
@@ -186,7 +194,7 @@ basic functionality › pattern_match_unsafe_wasm
           )
           (block $compile_block.26 (result i32)
            (block $compile_store.15
-            (local.set $13
+            (local.set $20
              (i32.or
               (i32.shl
                (i32.eq
@@ -203,7 +211,7 @@ basic functionality › pattern_match_unsafe_wasm
            )
            (if (result i32)
             (i32.shr_u
-             (local.get $13)
+             (local.get $20)
              (i32.const 31)
             )
             (block $compile_block.16 (result i32)
@@ -211,7 +219,7 @@ basic functionality › pattern_match_unsafe_wasm
             )
             (block $compile_block.25 (result i32)
              (block $compile_store.18
-              (local.set $14
+              (local.set $21
                (i32.or
                 (i32.shl
                  (i32.eq
@@ -228,7 +236,7 @@ basic functionality › pattern_match_unsafe_wasm
              )
              (if (result i32)
               (i32.shr_u
-               (local.get $14)
+               (local.get $21)
                (i32.const 31)
               )
               (block $compile_block.19 (result i32)
@@ -236,7 +244,7 @@ basic functionality › pattern_match_unsafe_wasm
               )
               (block $compile_block.24 (result i32)
                (block $compile_store.21
-                (local.set $15
+                (local.set $22
                  (i32.or
                   (i32.shl
                    (i32.eq
@@ -253,7 +261,7 @@ basic functionality › pattern_match_unsafe_wasm
                )
                (if (result i32)
                 (i32.shr_u
-                 (local.get $15)
+                 (local.get $22)
                  (i32.const 31)
                 )
                 (block $compile_block.22 (result i32)
@@ -300,24 +308,58 @@ basic functionality › pattern_match_unsafe_wasm
                        (br_table $switch.32_branch_1 $switch.32_branch_2 $switch.32_branch_3 $switch.32_branch_4 $switch.32_branch_5 $switch.32_branch_6 $switch.32_branch_7 $switch.32_default $switch.32_default
                         (i32.const 0)
                         (i32.shr_s
-                         (local.get $10)
+                         (local.get $17)
                          (i32.const 1)
                         )
                        )
                       )
                      )
                      (br $switch.32_outer
-                      (block $compile_block.50 (result i32)
+                      (block $compile_block.71 (result i32)
                        (unreachable)
                       )
                      )
                     )
                    )
                    (br $switch.32_outer
-                    (block $compile_block.49
-                     (block $compile_store.47
-                      (local.set $8
-                       (block $allocate_string.45 (result i32)
+                    (block $compile_block.70
+                     (block $compile_store.65
+                      (local.set $14
+                       (block $allocate_adt.63 (result i32)
+                        (i32.store
+                         (local.tee $2
+                          (call $malloc_0
+                           (global.get $GRAIN$EXPORT$malloc_0)
+                           (i32.const 20)
+                          )
+                         )
+                         (i32.const 2)
+                        )
+                        (i32.store offset=4
+                         (local.get $2)
+                         (i32.const 501102191)
+                        )
+                        (i32.store offset=8
+                         (local.get $2)
+                         (i32.const 7)
+                        )
+                        (i32.store offset=12
+                         (local.get $2)
+                         (i32.const 3)
+                        )
+                        (i32.store offset=16
+                         (local.get $2)
+                         (i32.const 0)
+                        )
+                        (local.get $2)
+                       )
+                      )
+                      (block $do_backpatches.64
+                      )
+                     )
+                     (block $compile_store.68
+                      (local.set $15
+                       (block $allocate_string.66 (result i32)
                         (i32.store
                          (local.tee $2
                           (call $malloc_0
@@ -338,10 +380,10 @@ basic functionality › pattern_match_unsafe_wasm
                         (local.get $2)
                        )
                       )
-                      (block $do_backpatches.46
+                      (block $do_backpatches.67
                       )
                      )
-                     (block $cleanup.48
+                     (block $cleanup.69
                       (drop
                        (call $decRef_0
                         (global.get $GRAIN$EXPORT$decRef_0)
@@ -354,15 +396,50 @@ basic functionality › pattern_match_unsafe_wasm
                        (global.get $GRAIN$EXPORT$incRef_0)
                        (global.get $print_1125)
                       )
-                      (local.get $8)
+                      (local.get $15)
+                      (local.get $14)
                      )
                     )
                    )
                   )
                  )
                  (br $switch.32_outer
-                  (block $compile_block.44
-                   (block $cleanup.43
+                  (block $compile_block.62
+                   (block $compile_store.60
+                    (local.set $13
+                     (block $allocate_adt.58 (result i32)
+                      (i32.store
+                       (local.tee $2
+                        (call $malloc_0
+                         (global.get $GRAIN$EXPORT$malloc_0)
+                         (i32.const 20)
+                        )
+                       )
+                       (i32.const 2)
+                      )
+                      (i32.store offset=4
+                       (local.get $2)
+                       (i32.const 501102191)
+                      )
+                      (i32.store offset=8
+                       (local.get $2)
+                       (i32.const 7)
+                      )
+                      (i32.store offset=12
+                       (local.get $2)
+                       (i32.const 3)
+                      )
+                      (i32.store offset=16
+                       (local.get $2)
+                       (i32.const 0)
+                      )
+                      (local.get $2)
+                     )
+                    )
+                    (block $do_backpatches.59
+                    )
+                   )
+                   (block $cleanup.61
                     (drop
                      (call $decRef_0
                       (global.get $GRAIN$EXPORT$decRef_0)
@@ -376,14 +453,49 @@ basic functionality › pattern_match_unsafe_wasm
                      (global.get $print_1125)
                     )
                     (i32.const 13)
+                    (local.get $13)
                    )
                   )
                  )
                 )
                )
                (br $switch.32_outer
-                (block $compile_block.42
-                 (block $cleanup.41
+                (block $compile_block.57
+                 (block $compile_store.55
+                  (local.set $12
+                   (block $allocate_adt.53 (result i32)
+                    (i32.store
+                     (local.tee $2
+                      (call $malloc_0
+                       (global.get $GRAIN$EXPORT$malloc_0)
+                       (i32.const 20)
+                      )
+                     )
+                     (i32.const 2)
+                    )
+                    (i32.store offset=4
+                     (local.get $2)
+                     (i32.const 501102191)
+                    )
+                    (i32.store offset=8
+                     (local.get $2)
+                     (i32.const 7)
+                    )
+                    (i32.store offset=12
+                     (local.get $2)
+                     (i32.const 3)
+                    )
+                    (i32.store offset=16
+                     (local.get $2)
+                     (i32.const 0)
+                    )
+                    (local.get $2)
+                   )
+                  )
+                  (block $do_backpatches.54
+                  )
+                 )
+                 (block $cleanup.56
                   (drop
                    (call $decRef_0
                     (global.get $GRAIN$EXPORT$decRef_0)
@@ -397,14 +509,49 @@ basic functionality › pattern_match_unsafe_wasm
                    (global.get $print_1125)
                   )
                   (i32.const 11)
+                  (local.get $12)
                  )
                 )
                )
               )
              )
              (br $switch.32_outer
-              (block $compile_block.40
-               (block $cleanup.39
+              (block $compile_block.52
+               (block $compile_store.50
+                (local.set $11
+                 (block $allocate_adt.48 (result i32)
+                  (i32.store
+                   (local.tee $2
+                    (call $malloc_0
+                     (global.get $GRAIN$EXPORT$malloc_0)
+                     (i32.const 20)
+                    )
+                   )
+                   (i32.const 2)
+                  )
+                  (i32.store offset=4
+                   (local.get $2)
+                   (i32.const 501102191)
+                  )
+                  (i32.store offset=8
+                   (local.get $2)
+                   (i32.const 7)
+                  )
+                  (i32.store offset=12
+                   (local.get $2)
+                   (i32.const 3)
+                  )
+                  (i32.store offset=16
+                   (local.get $2)
+                   (i32.const 0)
+                  )
+                  (local.get $2)
+                 )
+                )
+                (block $do_backpatches.49
+                )
+               )
+               (block $cleanup.51
                 (drop
                  (call $decRef_0
                   (global.get $GRAIN$EXPORT$decRef_0)
@@ -418,14 +565,49 @@ basic functionality › pattern_match_unsafe_wasm
                  (global.get $print_1125)
                 )
                 (i32.const 9)
+                (local.get $11)
                )
               )
              )
             )
            )
            (br $switch.32_outer
-            (block $compile_block.38
-             (block $cleanup.37
+            (block $compile_block.47
+             (block $compile_store.45
+              (local.set $10
+               (block $allocate_adt.43 (result i32)
+                (i32.store
+                 (local.tee $2
+                  (call $malloc_0
+                   (global.get $GRAIN$EXPORT$malloc_0)
+                   (i32.const 20)
+                  )
+                 )
+                 (i32.const 2)
+                )
+                (i32.store offset=4
+                 (local.get $2)
+                 (i32.const 501102191)
+                )
+                (i32.store offset=8
+                 (local.get $2)
+                 (i32.const 7)
+                )
+                (i32.store offset=12
+                 (local.get $2)
+                 (i32.const 3)
+                )
+                (i32.store offset=16
+                 (local.get $2)
+                 (i32.const 0)
+                )
+                (local.get $2)
+               )
+              )
+              (block $do_backpatches.44
+              )
+             )
+             (block $cleanup.46
               (drop
                (call $decRef_0
                 (global.get $GRAIN$EXPORT$decRef_0)
@@ -439,14 +621,49 @@ basic functionality › pattern_match_unsafe_wasm
                (global.get $print_1125)
               )
               (i32.const 7)
+              (local.get $10)
              )
             )
            )
           )
          )
          (br $switch.32_outer
-          (block $compile_block.36
-           (block $cleanup.35
+          (block $compile_block.42
+           (block $compile_store.40
+            (local.set $9
+             (block $allocate_adt.38 (result i32)
+              (i32.store
+               (local.tee $2
+                (call $malloc_0
+                 (global.get $GRAIN$EXPORT$malloc_0)
+                 (i32.const 20)
+                )
+               )
+               (i32.const 2)
+              )
+              (i32.store offset=4
+               (local.get $2)
+               (i32.const 501102191)
+              )
+              (i32.store offset=8
+               (local.get $2)
+               (i32.const 7)
+              )
+              (i32.store offset=12
+               (local.get $2)
+               (i32.const 3)
+              )
+              (i32.store offset=16
+               (local.get $2)
+               (i32.const 0)
+              )
+              (local.get $2)
+             )
+            )
+            (block $do_backpatches.39
+            )
+           )
+           (block $cleanup.41
             (drop
              (call $decRef_0
               (global.get $GRAIN$EXPORT$decRef_0)
@@ -460,14 +677,49 @@ basic functionality › pattern_match_unsafe_wasm
              (global.get $print_1125)
             )
             (i32.const 5)
+            (local.get $9)
            )
           )
          )
         )
        )
        (br $switch.32_outer
-        (block $compile_block.34
-         (block $cleanup.33
+        (block $compile_block.37
+         (block $compile_store.35
+          (local.set $8
+           (block $allocate_adt.33 (result i32)
+            (i32.store
+             (local.tee $2
+              (call $malloc_0
+               (global.get $GRAIN$EXPORT$malloc_0)
+               (i32.const 20)
+              )
+             )
+             (i32.const 2)
+            )
+            (i32.store offset=4
+             (local.get $2)
+             (i32.const 501102191)
+            )
+            (i32.store offset=8
+             (local.get $2)
+             (i32.const 7)
+            )
+            (i32.store offset=12
+             (local.get $2)
+             (i32.const 3)
+            )
+            (i32.store offset=16
+             (local.get $2)
+             (i32.const 0)
+            )
+            (local.get $2)
+           )
+          )
+          (block $do_backpatches.34
+          )
+         )
+         (block $cleanup.36
           (drop
            (call $decRef_0
             (global.get $GRAIN$EXPORT$decRef_0)
@@ -481,6 +733,7 @@ basic functionality › pattern_match_unsafe_wasm
            (global.get $print_1125)
           )
           (i32.const 3)
+          (local.get $8)
          )
         )
        )
@@ -506,12 +759,12 @@ basic functionality › pattern_match_unsafe_wasm
   (local $3 i64)
   (local $4 f32)
   (local $5 f64)
-  (block $compile_block.54
-   (block $compile_store.53
+  (block $compile_block.75
+   (block $compile_store.74
     (global.set $test_1113
      (i32.const 0)
     )
-    (block $do_backpatches.52
+    (block $do_backpatches.73
     )
    )
    (return_call $test_1113

--- a/compiler/test/__snapshots__/basic_functionality.7d0640b4.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.7d0640b4.0.snapshot
@@ -1,20 +1,22 @@
 basic functionality › if_one_sided2
 (module
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
- (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_genv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_genv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_genv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"_genv\" \"runtimeHeapStart\" (global $runtimeHeapStart_0 i32))
  (import \"_genv\" \"runtimeHeapNextPtr\" (global $runtimeHeapNextPtr_0 (mut i32)))
  (import \"_genv\" \"metadataPtr\" (global $metadataPtr_0 i32))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1117 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$>\" (global $>_1114 (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1117 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1117 (param i32 i32 i32) (result i32)))
  (import \"GRAIN$MODULE$pervasives\" \">\" (func $>_1114 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (memory $0 0)
@@ -31,9 +33,10 @@ basic functionality › if_one_sided2
   (local $4 f32)
   (local $5 f64)
   (local $6 i32)
-  (block $compile_block.5 (result i32)
+  (local $7 i32)
+  (block $compile_block.8 (result i32)
    (block $compile_store.2
-    (local.set $6
+    (local.set $7
      (call $>_1114
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
@@ -48,19 +51,54 @@ basic functionality › if_one_sided2
    )
    (if (result i32)
     (i32.shr_u
-     (local.get $6)
+     (local.get $7)
      (i32.const 31)
     )
-    (block $compile_block.3
+    (block $compile_block.6
+     (block $compile_store.5
+      (local.set $6
+       (block $allocate_adt.3 (result i32)
+        (i32.store
+         (local.tee $0
+          (call $malloc_0
+           (global.get $GRAIN$EXPORT$malloc_0)
+           (i32.const 20)
+          )
+         )
+         (i32.const 2)
+        )
+        (i32.store offset=4
+         (local.get $0)
+         (i32.const 501102191)
+        )
+        (i32.store offset=8
+         (local.get $0)
+         (i32.const 7)
+        )
+        (i32.store offset=12
+         (local.get $0)
+         (i32.const 3)
+        )
+        (i32.store offset=16
+         (local.get $0)
+         (i32.const 0)
+        )
+        (local.get $0)
+       )
+      )
+      (block $do_backpatches.4
+      )
+     )
      (return_call $print_1117
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
        (global.get $print_1117)
       )
       (i32.const 11)
+      (local.get $6)
      )
     )
-    (block $compile_block.4 (result i32)
+    (block $compile_block.7 (result i32)
      (i32.const 1879048190)
     )
    )

--- a/compiler/test/__snapshots__/basic_functionality.b07cc734.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.b07cc734.0.snapshot
@@ -1,20 +1,22 @@
 basic functionality › if_one_sided
 (module
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
- (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_genv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_genv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_genv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"_genv\" \"runtimeHeapStart\" (global $runtimeHeapStart_0 i32))
  (import \"_genv\" \"runtimeHeapNextPtr\" (global $runtimeHeapNextPtr_0 (mut i32)))
  (import \"_genv\" \"metadataPtr\" (global $metadataPtr_0 i32))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1117 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$<\" (global $<_1114 (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1117 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1117 (param i32 i32 i32) (result i32)))
  (import \"GRAIN$MODULE$pervasives\" \"<\" (func $<_1114 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (memory $0 0)
@@ -31,9 +33,10 @@ basic functionality › if_one_sided
   (local $4 f32)
   (local $5 f64)
   (local $6 i32)
-  (block $compile_block.5 (result i32)
+  (local $7 i32)
+  (block $compile_block.8 (result i32)
    (block $compile_store.2
-    (local.set $6
+    (local.set $7
      (call $<_1114
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
@@ -48,19 +51,54 @@ basic functionality › if_one_sided
    )
    (if (result i32)
     (i32.shr_u
-     (local.get $6)
+     (local.get $7)
      (i32.const 31)
     )
-    (block $compile_block.3
+    (block $compile_block.6
+     (block $compile_store.5
+      (local.set $6
+       (block $allocate_adt.3 (result i32)
+        (i32.store
+         (local.tee $0
+          (call $malloc_0
+           (global.get $GRAIN$EXPORT$malloc_0)
+           (i32.const 20)
+          )
+         )
+         (i32.const 2)
+        )
+        (i32.store offset=4
+         (local.get $0)
+         (i32.const 501102191)
+        )
+        (i32.store offset=8
+         (local.get $0)
+         (i32.const 7)
+        )
+        (i32.store offset=12
+         (local.get $0)
+         (i32.const 3)
+        )
+        (i32.store offset=16
+         (local.get $0)
+         (i32.const 0)
+        )
+        (local.get $0)
+       )
+      )
+      (block $do_backpatches.4
+      )
+     )
      (return_call $print_1117
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
        (global.get $print_1117)
       )
       (i32.const 11)
+      (local.get $6)
      )
     )
-    (block $compile_block.4 (result i32)
+    (block $compile_block.7 (result i32)
      (i32.const 1879048190)
     )
    )

--- a/compiler/test/__snapshots__/basic_functionality.b836b89a.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.b836b89a.0.snapshot
@@ -1,7 +1,7 @@
 basic functionality › complex1
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
  (import \"_genv\" \"tbl\" (table $tbl 0 funcref))
@@ -10,14 +10,16 @@ basic functionality › complex1
  (import \"_genv\" \"runtimeHeapStart\" (global $runtimeHeapStart_0 i32))
  (import \"_genv\" \"runtimeHeapNextPtr\" (global $runtimeHeapNextPtr_0 (mut i32)))
  (import \"_genv\" \"metadataPtr\" (global $metadataPtr_0 i32))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1125 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1123 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1127 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$-\" (global $-_1125 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1120 (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1125 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1123 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1120 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1127 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"-\" (func $-_1125 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1120 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (memory $0 0)
  (elem $elem (global.get $relocBase_0))
@@ -33,7 +35,42 @@ basic functionality › complex1
   (local $4 f32)
   (local $5 f64)
   (local $6 i32)
-  (block $compile_block.3
+  (local $7 i32)
+  (block $compile_block.6
+   (block $compile_store.3
+    (local.set $6
+     (block $allocate_adt.1 (result i32)
+      (i32.store
+       (local.tee $0
+        (call $malloc_0
+         (global.get $GRAIN$EXPORT$malloc_0)
+         (i32.const 20)
+        )
+       )
+       (i32.const 2)
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (i32.const 501102191)
+      )
+      (i32.store offset=8
+       (local.get $0)
+       (i32.const 7)
+      )
+      (i32.store offset=12
+       (local.get $0)
+       (i32.const 3)
+      )
+      (i32.store offset=16
+       (local.get $0)
+       (i32.const 0)
+      )
+      (local.get $0)
+     )
+    )
+    (block $do_backpatches.2
+    )
+   )
    (drop
     (call $print_1120
      (call $incRef_0
@@ -41,29 +78,30 @@ basic functionality › complex1
       (global.get $print_1120)
      )
      (i32.const 7)
+     (local.get $6)
     )
    )
-   (block $compile_store.2
-    (local.set $6
-     (call $+_1125
+   (block $compile_store.5
+    (local.set $7
+     (call $+_1127
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $+_1125)
+       (global.get $+_1127)
       )
       (i32.const 9)
       (i32.const 5)
      )
     )
-    (block $do_backpatches.1
+    (block $do_backpatches.4
     )
    )
-   (return_call $-_1123
+   (return_call $-_1125
     (call $incRef_0
      (global.get $GRAIN$EXPORT$incRef_0)
-     (global.get $-_1123)
+     (global.get $-_1125)
     )
     (i32.const 7)
-    (local.get $6)
+    (local.get $7)
    )
   )
  )

--- a/compiler/test/__snapshots__/basic_functionality.c4090bb1.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c4090bb1.0.snapshot
@@ -1,9 +1,9 @@
 basic functionality › toplevel_statements
 (module
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
- (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_genv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_genv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_genv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
@@ -12,12 +12,12 @@ basic functionality › toplevel_statements
  (import \"_genv\" \"metadataPtr\" (global $metadataPtr_0 i32))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1123 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$+\" (global $+_1126 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1120 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1123 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1120 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"+\" (func $+_1126 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1120 (param i32 i32 i32) (result i32)))
  (global $five_1117 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (memory $0 0)
@@ -33,7 +33,46 @@ basic functionality › toplevel_statements
   (local $3 i64)
   (local $4 f32)
   (local $5 f64)
-  (block $compile_block.4 (result i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (block $compile_block.19 (result i32)
+   (block $compile_store.3
+    (local.set $6
+     (block $allocate_adt.1 (result i32)
+      (i32.store
+       (local.tee $0
+        (call $malloc_0
+         (global.get $GRAIN$EXPORT$malloc_0)
+         (i32.const 20)
+        )
+       )
+       (i32.const 2)
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (i32.const 501102191)
+      )
+      (i32.store offset=8
+       (local.get $0)
+       (i32.const 7)
+      )
+      (i32.store offset=12
+       (local.get $0)
+       (i32.const 3)
+      )
+      (i32.store offset=16
+       (local.get $0)
+       (i32.const 0)
+      )
+      (local.get $0)
+     )
+    )
+    (block $do_backpatches.2
+    )
+   )
    (drop
     (call $print_1120
      (call $incRef_0
@@ -41,6 +80,41 @@ basic functionality › toplevel_statements
       (global.get $print_1120)
      )
      (i32.const 3)
+     (local.get $6)
+    )
+   )
+   (block $compile_store.6
+    (local.set $7
+     (block $allocate_adt.4 (result i32)
+      (i32.store
+       (local.tee $0
+        (call $malloc_0
+         (global.get $GRAIN$EXPORT$malloc_0)
+         (i32.const 20)
+        )
+       )
+       (i32.const 2)
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (i32.const 501102191)
+      )
+      (i32.store offset=8
+       (local.get $0)
+       (i32.const 7)
+      )
+      (i32.store offset=12
+       (local.get $0)
+       (i32.const 3)
+      )
+      (i32.store offset=16
+       (local.get $0)
+       (i32.const 0)
+      )
+      (local.get $0)
+     )
+    )
+    (block $do_backpatches.5
     )
    )
    (drop
@@ -50,6 +124,41 @@ basic functionality › toplevel_statements
       (global.get $print_1120)
      )
      (i32.const 5)
+     (local.get $7)
+    )
+   )
+   (block $compile_store.9
+    (local.set $8
+     (block $allocate_adt.7 (result i32)
+      (i32.store
+       (local.tee $0
+        (call $malloc_0
+         (global.get $GRAIN$EXPORT$malloc_0)
+         (i32.const 20)
+        )
+       )
+       (i32.const 2)
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (i32.const 501102191)
+      )
+      (i32.store offset=8
+       (local.get $0)
+       (i32.const 7)
+      )
+      (i32.store offset=12
+       (local.get $0)
+       (i32.const 3)
+      )
+      (i32.store offset=16
+       (local.get $0)
+       (i32.const 0)
+      )
+      (local.get $0)
+     )
+    )
+    (block $do_backpatches.8
     )
    )
    (drop
@@ -59,20 +168,55 @@ basic functionality › toplevel_statements
       (global.get $print_1120)
      )
      (i32.const 7)
+     (local.get $8)
     )
    )
-   (block $compile_store.2
+   (block $compile_store.11
     (global.set $five_1117
-     (call $+_1123
+     (call $+_1126
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $+_1123)
+       (global.get $+_1126)
       )
       (i32.const 5)
       (i32.const 7)
      )
     )
-    (block $do_backpatches.1
+    (block $do_backpatches.10
+    )
+   )
+   (block $compile_store.14
+    (local.set $9
+     (block $allocate_adt.12 (result i32)
+      (i32.store
+       (local.tee $0
+        (call $malloc_0
+         (global.get $GRAIN$EXPORT$malloc_0)
+         (i32.const 20)
+        )
+       )
+       (i32.const 2)
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (i32.const 501102191)
+      )
+      (i32.store offset=8
+       (local.get $0)
+       (i32.const 7)
+      )
+      (i32.store offset=12
+       (local.get $0)
+       (i32.const 3)
+      )
+      (i32.store offset=16
+       (local.get $0)
+       (i32.const 0)
+      )
+      (local.get $0)
+     )
+    )
+    (block $do_backpatches.13
     )
    )
    (drop
@@ -82,6 +226,41 @@ basic functionality › toplevel_statements
       (global.get $print_1120)
      )
      (i32.const 9)
+     (local.get $9)
+    )
+   )
+   (block $compile_store.17
+    (local.set $10
+     (block $allocate_adt.15 (result i32)
+      (i32.store
+       (local.tee $0
+        (call $malloc_0
+         (global.get $GRAIN$EXPORT$malloc_0)
+         (i32.const 20)
+        )
+       )
+       (i32.const 2)
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (i32.const 501102191)
+      )
+      (i32.store offset=8
+       (local.get $0)
+       (i32.const 7)
+      )
+      (i32.store offset=12
+       (local.get $0)
+       (i32.const 3)
+      )
+      (i32.store offset=16
+       (local.get $0)
+       (i32.const 0)
+      )
+      (local.get $0)
+     )
+    )
+    (block $do_backpatches.16
     )
    )
    (drop
@@ -94,9 +273,10 @@ basic functionality › toplevel_statements
       (global.get $GRAIN$EXPORT$incRef_0)
       (global.get $five_1117)
      )
+     (local.get $10)
     )
    )
-   (block $allocate_string.3 (result i32)
+   (block $allocate_string.18 (result i32)
     (i32.store
      (local.tee $0
       (call $malloc_0

--- a/compiler/test/__snapshots__/basic_functionality.d6ca4146.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d6ca4146.0.snapshot
@@ -3,16 +3,19 @@ basic functionality › andshort1
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_genv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_genv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_genv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"_genv\" \"runtimeHeapStart\" (global $runtimeHeapStart_0 i32))
  (import \"_genv\" \"runtimeHeapNextPtr\" (global $runtimeHeapNextPtr_0 (mut i32)))
  (import \"_genv\" \"metadataPtr\" (global $metadataPtr_0 i32))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1113 (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1113 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1113 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (memory $0 0)
  (elem $elem (global.get $relocBase_0))
@@ -27,7 +30,42 @@ basic functionality › andshort1
   (local $3 i64)
   (local $4 f32)
   (local $5 f64)
-  (block $compile_block.1 (result i32)
+  (local $6 i32)
+  (block $compile_block.4 (result i32)
+   (block $compile_store.3
+    (local.set $6
+     (block $allocate_adt.1 (result i32)
+      (i32.store
+       (local.tee $0
+        (call $malloc_0
+         (global.get $GRAIN$EXPORT$malloc_0)
+         (i32.const 20)
+        )
+       )
+       (i32.const 2)
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (i32.const 501102191)
+      )
+      (i32.store offset=8
+       (local.get $0)
+       (i32.const 7)
+      )
+      (i32.store offset=12
+       (local.get $0)
+       (i32.const 3)
+      )
+      (i32.store offset=16
+       (local.get $0)
+       (i32.const 0)
+      )
+      (local.get $0)
+     )
+    )
+    (block $do_backpatches.2
+    )
+   )
    (drop
     (call $print_1113
      (call $incRef_0
@@ -35,6 +73,7 @@ basic functionality › andshort1
       (global.get $print_1113)
      )
      (i32.const 3)
+     (local.get $6)
     )
    )
    (i32.const 2147483646)

--- a/compiler/test/__snapshots__/basic_functionality.fe88cb04.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.fe88cb04.0.snapshot
@@ -4,6 +4,7 @@ basic functionality › func_shadow_and_indirect_call
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_genv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_genv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_genv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
@@ -17,14 +18,14 @@ basic functionality › func_shadow_and_indirect_call
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1121 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1121 (param i32 i32 i32) (result i32)))
  (global $foo_1119 (mut i32) (i32.const 0))
  (global $foo_1117 (mut i32) (i32.const 0))
  (global $foo_1115 (mut i32) (i32.const 0))
  (global $foo_1113 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 1))
  (memory $0 0)
- (elem $elem (global.get $relocBase_0) $func_1130)
+ (elem $elem (global.get $relocBase_0) $func_1133)
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
@@ -165,7 +166,7 @@ basic functionality › func_shadow_and_indirect_call
    )
   )
  )
- (func $func_1130 (param $0 i32) (result i32)
+ (func $func_1133 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -220,7 +221,10 @@ basic functionality › func_shadow_and_indirect_call
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (block $compile_block.32
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (block $compile_block.41
    (block $compile_store.18
     (global.set $foo_1113
      (i32.const 0)
@@ -228,8 +232,42 @@ basic functionality › func_shadow_and_indirect_call
     (block $do_backpatches.17
     )
    )
-   (block $compile_store.20
+   (block $compile_store.21
     (local.set $6
+     (block $allocate_adt.19 (result i32)
+      (i32.store
+       (local.tee $0
+        (call $malloc_0
+         (global.get $GRAIN$EXPORT$malloc_0)
+         (i32.const 20)
+        )
+       )
+       (i32.const 2)
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (i32.const 501102191)
+      )
+      (i32.store offset=8
+       (local.get $0)
+       (i32.const 7)
+      )
+      (i32.store offset=12
+       (local.get $0)
+       (i32.const 3)
+      )
+      (i32.store offset=16
+       (local.get $0)
+       (i32.const 0)
+      )
+      (local.get $0)
+     )
+    )
+    (block $do_backpatches.20
+    )
+   )
+   (block $compile_store.23
+    (local.set $7
      (call $foo_1113
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
@@ -237,35 +275,7 @@ basic functionality › func_shadow_and_indirect_call
       )
      )
     )
-    (block $do_backpatches.19
-    )
-   )
-   (drop
-    (call $print_1121
-     (call $incRef_0
-      (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $print_1121)
-     )
-     (local.get $6)
-    )
-   )
-   (block $compile_store.22
-    (global.set $foo_1115
-     (i32.const 0)
-    )
-    (block $do_backpatches.21
-    )
-   )
-   (block $compile_store.24
-    (local.set $7
-     (call $foo_1115
-      (call $incRef_0
-       (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $foo_1115)
-      )
-     )
-    )
-    (block $do_backpatches.23
+    (block $do_backpatches.22
     )
    )
    (drop
@@ -275,16 +285,80 @@ basic functionality › func_shadow_and_indirect_call
       (global.get $print_1121)
      )
      (local.get $7)
+     (local.get $6)
     )
    )
-   (block $compile_store.26
-    (global.set $foo_1117
+   (block $compile_store.25
+    (global.set $foo_1115
      (i32.const 0)
     )
-    (block $do_backpatches.25
+    (block $do_backpatches.24
     )
    )
    (block $compile_store.28
+    (local.set $8
+     (block $allocate_adt.26 (result i32)
+      (i32.store
+       (local.tee $0
+        (call $malloc_0
+         (global.get $GRAIN$EXPORT$malloc_0)
+         (i32.const 20)
+        )
+       )
+       (i32.const 2)
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (i32.const 501102191)
+      )
+      (i32.store offset=8
+       (local.get $0)
+       (i32.const 7)
+      )
+      (i32.store offset=12
+       (local.get $0)
+       (i32.const 3)
+      )
+      (i32.store offset=16
+       (local.get $0)
+       (i32.const 0)
+      )
+      (local.get $0)
+     )
+    )
+    (block $do_backpatches.27
+    )
+   )
+   (block $compile_store.30
+    (local.set $9
+     (call $foo_1115
+      (call $incRef_0
+       (global.get $GRAIN$EXPORT$incRef_0)
+       (global.get $foo_1115)
+      )
+     )
+    )
+    (block $do_backpatches.29
+    )
+   )
+   (drop
+    (call $print_1121
+     (call $incRef_0
+      (global.get $GRAIN$EXPORT$incRef_0)
+      (global.get $print_1121)
+     )
+     (local.get $9)
+     (local.get $8)
+    )
+   )
+   (block $compile_store.32
+    (global.set $foo_1117
+     (i32.const 0)
+    )
+    (block $do_backpatches.31
+    )
+   )
+   (block $compile_store.34
     (global.set $foo_1119
      (call $foo_1117
       (call $incRef_0
@@ -293,12 +367,46 @@ basic functionality › func_shadow_and_indirect_call
       )
      )
     )
-    (block $do_backpatches.27
+    (block $do_backpatches.33
     )
    )
-   (block $compile_store.31
-    (local.set $8
-     (block $call_lambda.29 (result i32)
+   (block $compile_store.37
+    (local.set $10
+     (block $allocate_adt.35 (result i32)
+      (i32.store
+       (local.tee $0
+        (call $malloc_0
+         (global.get $GRAIN$EXPORT$malloc_0)
+         (i32.const 20)
+        )
+       )
+       (i32.const 2)
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (i32.const 501102191)
+      )
+      (i32.store offset=8
+       (local.get $0)
+       (i32.const 7)
+      )
+      (i32.store offset=12
+       (local.get $0)
+       (i32.const 3)
+      )
+      (i32.store offset=16
+       (local.get $0)
+       (i32.const 0)
+      )
+      (local.get $0)
+     )
+    )
+    (block $do_backpatches.36
+    )
+   )
+   (block $compile_store.40
+    (local.set $11
+     (block $call_lambda.38 (result i32)
       (local.set $0
        (call $incRef_0
         (global.get $GRAIN$EXPORT$incRef_0)
@@ -313,7 +421,7 @@ basic functionality › func_shadow_and_indirect_call
       )
      )
     )
-    (block $do_backpatches.30
+    (block $do_backpatches.39
     )
    )
    (return_call $print_1121
@@ -321,7 +429,8 @@ basic functionality › func_shadow_and_indirect_call
      (global.get $GRAIN$EXPORT$incRef_0)
      (global.get $print_1121)
     )
-    (local.get $8)
+    (local.get $11)
+    (local.get $10)
    )
   )
  )

--- a/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
+++ b/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
@@ -3,6 +3,7 @@ enums › enum_recursive_data_definition
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_genv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_genv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_genv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
@@ -14,7 +15,7 @@ enums › enum_recursive_data_definition
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1129 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1129 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1129 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (memory $0 0)
  (elem $elem (global.get $relocBase_0))
@@ -38,7 +39,8 @@ enums › enum_recursive_data_definition
   (local $12 i32)
   (local $13 i32)
   (local $14 i32)
-  (block $compile_block.28
+  (local $15 i32)
+  (block $compile_block.31
    (block $compile_store.3
     (local.set $6
      (block $allocate_string.1 (result i32)
@@ -361,12 +363,47 @@ enums › enum_recursive_data_definition
     (block $do_backpatches.26
     )
    )
+   (block $compile_store.30
+    (local.set $15
+     (block $allocate_adt.28 (result i32)
+      (i32.store
+       (local.tee $0
+        (call $malloc_0
+         (global.get $GRAIN$EXPORT$malloc_0)
+         (i32.const 20)
+        )
+       )
+       (i32.const 2)
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (i32.const 501102191)
+      )
+      (i32.store offset=8
+       (local.get $0)
+       (i32.const 7)
+      )
+      (i32.store offset=12
+       (local.get $0)
+       (i32.const 3)
+      )
+      (i32.store offset=16
+       (local.get $0)
+       (i32.const 0)
+      )
+      (local.get $0)
+     )
+    )
+    (block $do_backpatches.29
+    )
+   )
    (return_call $print_1129
     (call $incRef_0
      (global.get $GRAIN$EXPORT$incRef_0)
      (global.get $print_1129)
     )
     (local.get $14)
+    (local.get $15)
    )
   )
  )

--- a/compiler/test/__snapshots__/includes.c0c0d5ca.0.snapshot
+++ b/compiler/test/__snapshots__/includes.c0c0d5ca.0.snapshot
@@ -3,18 +3,21 @@ includes › include_relative_path4
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_genv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_genv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_genv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"_genv\" \"runtimeHeapStart\" (global $runtimeHeapStart_0 i32))
  (import \"_genv\" \"runtimeHeapNextPtr\" (global $runtimeHeapNextPtr_0 (mut i32)))
  (import \"_genv\" \"metadataPtr\" (global $metadataPtr_0 i32))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$./bar/bar\" \"GRAIN$EXPORT$bar\" (global $bar_1118 (mut i32)))
+ (import \"GRAIN$MODULE$./bar/bar\" \"GRAIN$EXPORT$bar\" (global $bar_1119 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1116 (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$./bar/bar\" \"bar\" (func $bar_1118 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1116 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$./bar/bar\" \"bar\" (func $bar_1119 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1116 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (memory $0 0)
  (elem $elem (global.get $relocBase_0))
@@ -30,18 +33,53 @@ includes › include_relative_path4
   (local $4 f32)
   (local $5 f64)
   (local $6 i32)
-  (block $compile_block.3
-   (block $compile_store.2
+  (local $7 i32)
+  (block $compile_block.6
+   (block $compile_store.3
     (local.set $6
-     (call $bar_1118
+     (block $allocate_adt.1 (result i32)
+      (i32.store
+       (local.tee $0
+        (call $malloc_0
+         (global.get $GRAIN$EXPORT$malloc_0)
+         (i32.const 20)
+        )
+       )
+       (i32.const 2)
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (i32.const 501102191)
+      )
+      (i32.store offset=8
+       (local.get $0)
+       (i32.const 7)
+      )
+      (i32.store offset=12
+       (local.get $0)
+       (i32.const 3)
+      )
+      (i32.store offset=16
+       (local.get $0)
+       (i32.const 0)
+      )
+      (local.get $0)
+     )
+    )
+    (block $do_backpatches.2
+    )
+   )
+   (block $compile_store.5
+    (local.set $7
+     (call $bar_1119
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $bar_1118)
+       (global.get $bar_1119)
       )
       (i32.const 5)
      )
     )
-    (block $do_backpatches.1
+    (block $do_backpatches.4
     )
    )
    (return_call $print_1116
@@ -49,6 +87,7 @@ includes › include_relative_path4
      (global.get $GRAIN$EXPORT$incRef_0)
      (global.get $print_1116)
     )
+    (local.get $7)
     (local.get $6)
    )
   )

--- a/compiler/test/__snapshots__/pattern_matching.0fa61137.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0fa61137.0.snapshot
@@ -3,16 +3,19 @@ pattern matching › low_level_constant_match_2
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_genv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_genv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_genv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"_genv\" \"runtimeHeapStart\" (global $runtimeHeapStart_0 i32))
  (import \"_genv\" \"runtimeHeapNextPtr\" (global $runtimeHeapNextPtr_0 (mut i32)))
  (import \"_genv\" \"metadataPtr\" (global $metadataPtr_0 i32))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1116 (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1116 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1116 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (memory $0 0)
  (elem $elem (global.get $relocBase_0))
@@ -33,9 +36,44 @@ pattern matching › low_level_constant_match_2
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
-  (block $compile_block.25 (result i32)
-   (block $compile_store.2
+  (local $12 i32)
+  (block $compile_block.28 (result i32)
+   (block $compile_store.3
     (local.set $6
+     (block $allocate_adt.1 (result i32)
+      (i32.store
+       (local.tee $0
+        (call $malloc_0
+         (global.get $GRAIN$EXPORT$malloc_0)
+         (i32.const 20)
+        )
+       )
+       (i32.const 2)
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (i32.const 501102191)
+      )
+      (i32.store offset=8
+       (local.get $0)
+       (i32.const 7)
+      )
+      (i32.store offset=12
+       (local.get $0)
+       (i32.const 3)
+      )
+      (i32.store offset=16
+       (local.get $0)
+       (i32.const 0)
+      )
+      (local.get $0)
+     )
+    )
+    (block $do_backpatches.2
+    )
+   )
+   (block $compile_store.5
+    (local.set $7
      (select
       (i32.const -2)
       (i32.const 2147483646)
@@ -45,22 +83,22 @@ pattern matching › low_level_constant_match_2
       )
      )
     )
-    (block $do_backpatches.1
+    (block $do_backpatches.4
     )
    )
-   (block $compile_store.14
-    (local.set $7
+   (block $compile_store.17
+    (local.set $8
      (if (result i32)
       (i32.shr_u
-       (local.get $6)
+       (local.get $7)
        (i32.const 31)
       )
-      (block $compile_block.3 (result i32)
+      (block $compile_block.6 (result i32)
        (i32.const 1)
       )
-      (block $compile_block.12 (result i32)
-       (block $compile_store.5
-        (local.set $8
+      (block $compile_block.15 (result i32)
+       (block $compile_store.8
+        (local.set $9
          (select
           (i32.const -2)
           (i32.const 2147483646)
@@ -70,20 +108,20 @@ pattern matching › low_level_constant_match_2
           )
          )
         )
-        (block $do_backpatches.4
+        (block $do_backpatches.7
         )
        )
        (if (result i32)
         (i32.shr_u
-         (local.get $8)
+         (local.get $9)
          (i32.const 31)
         )
-        (block $compile_block.6 (result i32)
+        (block $compile_block.9 (result i32)
          (i32.const 3)
         )
-        (block $compile_block.11 (result i32)
-         (block $compile_store.8
-          (local.set $9
+        (block $compile_block.14 (result i32)
+         (block $compile_store.11
+          (local.set $10
            (select
             (i32.const -2)
             (i32.const 2147483646)
@@ -93,18 +131,18 @@ pattern matching › low_level_constant_match_2
             )
            )
           )
-          (block $do_backpatches.7
+          (block $do_backpatches.10
           )
          )
          (if (result i32)
           (i32.shr_u
-           (local.get $9)
+           (local.get $10)
            (i32.const 31)
           )
-          (block $compile_block.9 (result i32)
+          (block $compile_block.12 (result i32)
            (i32.const 5)
           )
-          (block $compile_block.10 (result i32)
+          (block $compile_block.13 (result i32)
            (i32.const 7)
           )
          )
@@ -113,82 +151,83 @@ pattern matching › low_level_constant_match_2
       )
      )
     )
-    (block $do_backpatches.13
+    (block $do_backpatches.16
     )
    )
-   (block $compile_store.22
-    (local.set $10
-     (block $switch.15_outer (result i32)
-      (block $switch.15_branch_0 (result i32)
+   (block $compile_store.25
+    (local.set $11
+     (block $switch.18_outer (result i32)
+      (block $switch.18_branch_0 (result i32)
        (drop
-        (block $switch.15_branch_1 (result i32)
+        (block $switch.18_branch_1 (result i32)
          (drop
-          (block $switch.15_branch_2 (result i32)
+          (block $switch.18_branch_2 (result i32)
            (drop
-            (block $switch.15_branch_3 (result i32)
+            (block $switch.18_branch_3 (result i32)
              (drop
-              (block $switch.15_branch_4 (result i32)
+              (block $switch.18_branch_4 (result i32)
                (drop
-                (block $switch.15_default (result i32)
-                 (br_table $switch.15_branch_1 $switch.15_branch_2 $switch.15_branch_3 $switch.15_branch_4 $switch.15_default $switch.15_default
+                (block $switch.18_default (result i32)
+                 (br_table $switch.18_branch_1 $switch.18_branch_2 $switch.18_branch_3 $switch.18_branch_4 $switch.18_default $switch.18_default
                   (i32.const 0)
                   (i32.shr_s
-                   (local.get $7)
+                   (local.get $8)
                    (i32.const 1)
                   )
                  )
                 )
                )
-               (br $switch.15_outer
-                (block $compile_block.20 (result i32)
+               (br $switch.18_outer
+                (block $compile_block.23 (result i32)
                  (unreachable)
                 )
                )
               )
              )
-             (br $switch.15_outer
-              (block $compile_block.19 (result i32)
+             (br $switch.18_outer
+              (block $compile_block.22 (result i32)
                (i32.const 2147483646)
               )
              )
             )
            )
-           (br $switch.15_outer
-            (block $compile_block.18 (result i32)
+           (br $switch.18_outer
+            (block $compile_block.21 (result i32)
              (i32.const 2147483646)
             )
            )
           )
          )
-         (br $switch.15_outer
-          (block $compile_block.17 (result i32)
+         (br $switch.18_outer
+          (block $compile_block.20 (result i32)
            (i32.const -2)
           )
          )
         )
        )
-       (br $switch.15_outer
-        (block $compile_block.16 (result i32)
+       (br $switch.18_outer
+        (block $compile_block.19 (result i32)
          (i32.const 2147483646)
         )
        )
       )
      )
     )
-    (block $do_backpatches.21
+    (block $do_backpatches.24
     )
    )
-   (block $compile_store.24
-    (local.set $11
+   (block $compile_store.27
+    (local.set $12
      (call $print_1116
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
        (global.get $print_1116)
       )
-      (local.get $10)
+      (local.get $11)
+      (local.get $6)
      )
     )
-    (block $do_backpatches.23
+    (block $do_backpatches.26
     )
    )
    (i32.const 1)

--- a/compiler/test/__snapshots__/pattern_matching.25930935.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.25930935.0.snapshot
@@ -3,16 +3,19 @@ pattern matching › low_level_constant_match_3
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_genv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_genv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_genv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"_genv\" \"runtimeHeapStart\" (global $runtimeHeapStart_0 i32))
  (import \"_genv\" \"runtimeHeapNextPtr\" (global $runtimeHeapNextPtr_0 (mut i32)))
  (import \"_genv\" \"metadataPtr\" (global $metadataPtr_0 i32))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1116 (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1116 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1116 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (memory $0 0)
  (elem $elem (global.get $relocBase_0))
@@ -33,9 +36,44 @@ pattern matching › low_level_constant_match_3
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
-  (block $compile_block.25 (result i32)
-   (block $compile_store.2
+  (local $12 i32)
+  (block $compile_block.28 (result i32)
+   (block $compile_store.3
     (local.set $6
+     (block $allocate_adt.1 (result i32)
+      (i32.store
+       (local.tee $0
+        (call $malloc_0
+         (global.get $GRAIN$EXPORT$malloc_0)
+         (i32.const 20)
+        )
+       )
+       (i32.const 2)
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (i32.const 501102191)
+      )
+      (i32.store offset=8
+       (local.get $0)
+       (i32.const 7)
+      )
+      (i32.store offset=12
+       (local.get $0)
+       (i32.const 3)
+      )
+      (i32.store offset=16
+       (local.get $0)
+       (i32.const 0)
+      )
+      (local.get $0)
+     )
+    )
+    (block $do_backpatches.2
+    )
+   )
+   (block $compile_store.5
+    (local.set $7
      (select
       (i32.const -2)
       (i32.const 2147483646)
@@ -45,22 +83,22 @@ pattern matching › low_level_constant_match_3
       )
      )
     )
-    (block $do_backpatches.1
+    (block $do_backpatches.4
     )
    )
-   (block $compile_store.14
-    (local.set $7
+   (block $compile_store.17
+    (local.set $8
      (if (result i32)
       (i32.shr_u
-       (local.get $6)
+       (local.get $7)
        (i32.const 31)
       )
-      (block $compile_block.3 (result i32)
+      (block $compile_block.6 (result i32)
        (i32.const 1)
       )
-      (block $compile_block.12 (result i32)
-       (block $compile_store.5
-        (local.set $8
+      (block $compile_block.15 (result i32)
+       (block $compile_store.8
+        (local.set $9
          (select
           (i32.const -2)
           (i32.const 2147483646)
@@ -70,20 +108,20 @@ pattern matching › low_level_constant_match_3
           )
          )
         )
-        (block $do_backpatches.4
+        (block $do_backpatches.7
         )
        )
        (if (result i32)
         (i32.shr_u
-         (local.get $8)
+         (local.get $9)
          (i32.const 31)
         )
-        (block $compile_block.6 (result i32)
+        (block $compile_block.9 (result i32)
          (i32.const 3)
         )
-        (block $compile_block.11 (result i32)
-         (block $compile_store.8
-          (local.set $9
+        (block $compile_block.14 (result i32)
+         (block $compile_store.11
+          (local.set $10
            (select
             (i32.const -2)
             (i32.const 2147483646)
@@ -93,18 +131,18 @@ pattern matching › low_level_constant_match_3
             )
            )
           )
-          (block $do_backpatches.7
+          (block $do_backpatches.10
           )
          )
          (if (result i32)
           (i32.shr_u
-           (local.get $9)
+           (local.get $10)
            (i32.const 31)
           )
-          (block $compile_block.9 (result i32)
+          (block $compile_block.12 (result i32)
            (i32.const 5)
           )
-          (block $compile_block.10 (result i32)
+          (block $compile_block.13 (result i32)
            (i32.const 7)
           )
          )
@@ -113,82 +151,83 @@ pattern matching › low_level_constant_match_3
       )
      )
     )
-    (block $do_backpatches.13
+    (block $do_backpatches.16
     )
    )
-   (block $compile_store.22
-    (local.set $10
-     (block $switch.15_outer (result i32)
-      (block $switch.15_branch_0 (result i32)
+   (block $compile_store.25
+    (local.set $11
+     (block $switch.18_outer (result i32)
+      (block $switch.18_branch_0 (result i32)
        (drop
-        (block $switch.15_branch_1 (result i32)
+        (block $switch.18_branch_1 (result i32)
          (drop
-          (block $switch.15_branch_2 (result i32)
+          (block $switch.18_branch_2 (result i32)
            (drop
-            (block $switch.15_branch_3 (result i32)
+            (block $switch.18_branch_3 (result i32)
              (drop
-              (block $switch.15_branch_4 (result i32)
+              (block $switch.18_branch_4 (result i32)
                (drop
-                (block $switch.15_default (result i32)
-                 (br_table $switch.15_branch_1 $switch.15_branch_2 $switch.15_branch_3 $switch.15_branch_4 $switch.15_default $switch.15_default
+                (block $switch.18_default (result i32)
+                 (br_table $switch.18_branch_1 $switch.18_branch_2 $switch.18_branch_3 $switch.18_branch_4 $switch.18_default $switch.18_default
                   (i32.const 0)
                   (i32.shr_s
-                   (local.get $7)
+                   (local.get $8)
                    (i32.const 1)
                   )
                  )
                 )
                )
-               (br $switch.15_outer
-                (block $compile_block.20 (result i32)
+               (br $switch.18_outer
+                (block $compile_block.23 (result i32)
                  (unreachable)
                 )
                )
               )
              )
-             (br $switch.15_outer
-              (block $compile_block.19 (result i32)
+             (br $switch.18_outer
+              (block $compile_block.22 (result i32)
                (i32.const 2147483646)
               )
              )
             )
            )
-           (br $switch.15_outer
-            (block $compile_block.18 (result i32)
+           (br $switch.18_outer
+            (block $compile_block.21 (result i32)
              (i32.const 2147483646)
             )
            )
           )
          )
-         (br $switch.15_outer
-          (block $compile_block.17 (result i32)
+         (br $switch.18_outer
+          (block $compile_block.20 (result i32)
            (i32.const -2)
           )
          )
         )
        )
-       (br $switch.15_outer
-        (block $compile_block.16 (result i32)
+       (br $switch.18_outer
+        (block $compile_block.19 (result i32)
          (i32.const 2147483646)
         )
        )
       )
      )
     )
-    (block $do_backpatches.21
+    (block $do_backpatches.24
     )
    )
-   (block $compile_store.24
-    (local.set $11
+   (block $compile_store.27
+    (local.set $12
      (call $print_1116
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
        (global.get $print_1116)
       )
-      (local.get $10)
+      (local.get $11)
+      (local.get $6)
      )
     )
-    (block $do_backpatches.23
+    (block $do_backpatches.26
     )
    )
    (i32.const 1)

--- a/compiler/test/__snapshots__/pattern_matching.9ffaa7a7.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.9ffaa7a7.0.snapshot
@@ -3,16 +3,19 @@ pattern matching › low_level_constant_match_4
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_genv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_genv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_genv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"_genv\" \"runtimeHeapStart\" (global $runtimeHeapStart_0 i32))
  (import \"_genv\" \"runtimeHeapNextPtr\" (global $runtimeHeapNextPtr_0 (mut i32)))
  (import \"_genv\" \"metadataPtr\" (global $metadataPtr_0 i32))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1116 (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1116 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1116 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (memory $0 0)
  (elem $elem (global.get $relocBase_0))
@@ -33,9 +36,44 @@ pattern matching › low_level_constant_match_4
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
-  (block $compile_block.25 (result i32)
-   (block $compile_store.2
+  (local $12 i32)
+  (block $compile_block.28 (result i32)
+   (block $compile_store.3
     (local.set $6
+     (block $allocate_adt.1 (result i32)
+      (i32.store
+       (local.tee $0
+        (call $malloc_0
+         (global.get $GRAIN$EXPORT$malloc_0)
+         (i32.const 20)
+        )
+       )
+       (i32.const 2)
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (i32.const 501102191)
+      )
+      (i32.store offset=8
+       (local.get $0)
+       (i32.const 7)
+      )
+      (i32.store offset=12
+       (local.get $0)
+       (i32.const 3)
+      )
+      (i32.store offset=16
+       (local.get $0)
+       (i32.const 0)
+      )
+      (local.get $0)
+     )
+    )
+    (block $do_backpatches.2
+    )
+   )
+   (block $compile_store.5
+    (local.set $7
      (select
       (i32.const -2)
       (i32.const 2147483646)
@@ -45,22 +83,22 @@ pattern matching › low_level_constant_match_4
       )
      )
     )
-    (block $do_backpatches.1
+    (block $do_backpatches.4
     )
    )
-   (block $compile_store.14
-    (local.set $7
+   (block $compile_store.17
+    (local.set $8
      (if (result i32)
       (i32.shr_u
-       (local.get $6)
+       (local.get $7)
        (i32.const 31)
       )
-      (block $compile_block.3 (result i32)
+      (block $compile_block.6 (result i32)
        (i32.const 1)
       )
-      (block $compile_block.12 (result i32)
-       (block $compile_store.5
-        (local.set $8
+      (block $compile_block.15 (result i32)
+       (block $compile_store.8
+        (local.set $9
          (select
           (i32.const -2)
           (i32.const 2147483646)
@@ -70,20 +108,20 @@ pattern matching › low_level_constant_match_4
           )
          )
         )
-        (block $do_backpatches.4
+        (block $do_backpatches.7
         )
        )
        (if (result i32)
         (i32.shr_u
-         (local.get $8)
+         (local.get $9)
          (i32.const 31)
         )
-        (block $compile_block.6 (result i32)
+        (block $compile_block.9 (result i32)
          (i32.const 3)
         )
-        (block $compile_block.11 (result i32)
-         (block $compile_store.8
-          (local.set $9
+        (block $compile_block.14 (result i32)
+         (block $compile_store.11
+          (local.set $10
            (select
             (i32.const -2)
             (i32.const 2147483646)
@@ -93,18 +131,18 @@ pattern matching › low_level_constant_match_4
             )
            )
           )
-          (block $do_backpatches.7
+          (block $do_backpatches.10
           )
          )
          (if (result i32)
           (i32.shr_u
-           (local.get $9)
+           (local.get $10)
            (i32.const 31)
           )
-          (block $compile_block.9 (result i32)
+          (block $compile_block.12 (result i32)
            (i32.const 5)
           )
-          (block $compile_block.10 (result i32)
+          (block $compile_block.13 (result i32)
            (i32.const 7)
           )
          )
@@ -113,82 +151,83 @@ pattern matching › low_level_constant_match_4
       )
      )
     )
-    (block $do_backpatches.13
+    (block $do_backpatches.16
     )
    )
-   (block $compile_store.22
-    (local.set $10
-     (block $switch.15_outer (result i32)
-      (block $switch.15_branch_0 (result i32)
+   (block $compile_store.25
+    (local.set $11
+     (block $switch.18_outer (result i32)
+      (block $switch.18_branch_0 (result i32)
        (drop
-        (block $switch.15_branch_1 (result i32)
+        (block $switch.18_branch_1 (result i32)
          (drop
-          (block $switch.15_branch_2 (result i32)
+          (block $switch.18_branch_2 (result i32)
            (drop
-            (block $switch.15_branch_3 (result i32)
+            (block $switch.18_branch_3 (result i32)
              (drop
-              (block $switch.15_branch_4 (result i32)
+              (block $switch.18_branch_4 (result i32)
                (drop
-                (block $switch.15_default (result i32)
-                 (br_table $switch.15_branch_1 $switch.15_branch_2 $switch.15_branch_3 $switch.15_branch_4 $switch.15_default $switch.15_default
+                (block $switch.18_default (result i32)
+                 (br_table $switch.18_branch_1 $switch.18_branch_2 $switch.18_branch_3 $switch.18_branch_4 $switch.18_default $switch.18_default
                   (i32.const 0)
                   (i32.shr_s
-                   (local.get $7)
+                   (local.get $8)
                    (i32.const 1)
                   )
                  )
                 )
                )
-               (br $switch.15_outer
-                (block $compile_block.20 (result i32)
+               (br $switch.18_outer
+                (block $compile_block.23 (result i32)
                  (unreachable)
                 )
                )
               )
              )
-             (br $switch.15_outer
-              (block $compile_block.19 (result i32)
+             (br $switch.18_outer
+              (block $compile_block.22 (result i32)
                (i32.const 2147483646)
               )
              )
             )
            )
-           (br $switch.15_outer
-            (block $compile_block.18 (result i32)
+           (br $switch.18_outer
+            (block $compile_block.21 (result i32)
              (i32.const 2147483646)
             )
            )
           )
          )
-         (br $switch.15_outer
-          (block $compile_block.17 (result i32)
+         (br $switch.18_outer
+          (block $compile_block.20 (result i32)
            (i32.const -2)
           )
          )
         )
        )
-       (br $switch.15_outer
-        (block $compile_block.16 (result i32)
+       (br $switch.18_outer
+        (block $compile_block.19 (result i32)
          (i32.const 2147483646)
         )
        )
       )
      )
     )
-    (block $do_backpatches.21
+    (block $do_backpatches.24
     )
    )
-   (block $compile_store.24
-    (local.set $11
+   (block $compile_store.27
+    (local.set $12
      (call $print_1116
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
        (global.get $print_1116)
       )
-      (local.get $10)
+      (local.get $11)
+      (local.get $6)
      )
     )
-    (block $do_backpatches.23
+    (block $do_backpatches.26
     )
    )
    (i32.const 1)

--- a/compiler/test/__snapshots__/pattern_matching.be46eb0e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.be46eb0e.0.snapshot
@@ -3,16 +3,19 @@ pattern matching › low_level_constant_match_1
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_genv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_genv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_genv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
  (import \"_genv\" \"runtimeHeapStart\" (global $runtimeHeapStart_0 i32))
  (import \"_genv\" \"runtimeHeapNextPtr\" (global $runtimeHeapNextPtr_0 (mut i32)))
  (import \"_genv\" \"metadataPtr\" (global $metadataPtr_0 i32))
+ (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$pervasives\" \"GRAIN$EXPORT$print\" (global $print_1116 (mut i32)))
+ (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1116 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1116 (param i32 i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (memory $0 0)
  (elem $elem (global.get $relocBase_0))
@@ -33,9 +36,44 @@ pattern matching › low_level_constant_match_1
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
-  (block $compile_block.25 (result i32)
-   (block $compile_store.2
+  (local $12 i32)
+  (block $compile_block.28 (result i32)
+   (block $compile_store.3
     (local.set $6
+     (block $allocate_adt.1 (result i32)
+      (i32.store
+       (local.tee $0
+        (call $malloc_0
+         (global.get $GRAIN$EXPORT$malloc_0)
+         (i32.const 20)
+        )
+       )
+       (i32.const 2)
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (i32.const 501102191)
+      )
+      (i32.store offset=8
+       (local.get $0)
+       (i32.const 7)
+      )
+      (i32.store offset=12
+       (local.get $0)
+       (i32.const 3)
+      )
+      (i32.store offset=16
+       (local.get $0)
+       (i32.const 0)
+      )
+      (local.get $0)
+     )
+    )
+    (block $do_backpatches.2
+    )
+   )
+   (block $compile_store.5
+    (local.set $7
      (i32.or
       (i32.shl
        (i32.eq
@@ -47,22 +85,22 @@ pattern matching › low_level_constant_match_1
       (i32.const 2147483646)
      )
     )
-    (block $do_backpatches.1
+    (block $do_backpatches.4
     )
    )
-   (block $compile_store.14
-    (local.set $7
+   (block $compile_store.17
+    (local.set $8
      (if (result i32)
       (i32.shr_u
-       (local.get $6)
+       (local.get $7)
        (i32.const 31)
       )
-      (block $compile_block.3 (result i32)
+      (block $compile_block.6 (result i32)
        (i32.const 1)
       )
-      (block $compile_block.12 (result i32)
-       (block $compile_store.5
-        (local.set $8
+      (block $compile_block.15 (result i32)
+       (block $compile_store.8
+        (local.set $9
          (i32.or
           (i32.shl
            (i32.eq
@@ -74,20 +112,20 @@ pattern matching › low_level_constant_match_1
           (i32.const 2147483646)
          )
         )
-        (block $do_backpatches.4
+        (block $do_backpatches.7
         )
        )
        (if (result i32)
         (i32.shr_u
-         (local.get $8)
+         (local.get $9)
          (i32.const 31)
         )
-        (block $compile_block.6 (result i32)
+        (block $compile_block.9 (result i32)
          (i32.const 3)
         )
-        (block $compile_block.11 (result i32)
-         (block $compile_store.8
-          (local.set $9
+        (block $compile_block.14 (result i32)
+         (block $compile_store.11
+          (local.set $10
            (i32.or
             (i32.shl
              (i32.eq
@@ -99,18 +137,18 @@ pattern matching › low_level_constant_match_1
             (i32.const 2147483646)
            )
           )
-          (block $do_backpatches.7
+          (block $do_backpatches.10
           )
          )
          (if (result i32)
           (i32.shr_u
-           (local.get $9)
+           (local.get $10)
            (i32.const 31)
           )
-          (block $compile_block.9 (result i32)
+          (block $compile_block.12 (result i32)
            (i32.const 5)
           )
-          (block $compile_block.10 (result i32)
+          (block $compile_block.13 (result i32)
            (i32.const 7)
           )
          )
@@ -119,82 +157,83 @@ pattern matching › low_level_constant_match_1
       )
      )
     )
-    (block $do_backpatches.13
+    (block $do_backpatches.16
     )
    )
-   (block $compile_store.22
-    (local.set $10
-     (block $switch.15_outer (result i32)
-      (block $switch.15_branch_0 (result i32)
+   (block $compile_store.25
+    (local.set $11
+     (block $switch.18_outer (result i32)
+      (block $switch.18_branch_0 (result i32)
        (drop
-        (block $switch.15_branch_1 (result i32)
+        (block $switch.18_branch_1 (result i32)
          (drop
-          (block $switch.15_branch_2 (result i32)
+          (block $switch.18_branch_2 (result i32)
            (drop
-            (block $switch.15_branch_3 (result i32)
+            (block $switch.18_branch_3 (result i32)
              (drop
-              (block $switch.15_branch_4 (result i32)
+              (block $switch.18_branch_4 (result i32)
                (drop
-                (block $switch.15_default (result i32)
-                 (br_table $switch.15_branch_1 $switch.15_branch_2 $switch.15_branch_3 $switch.15_branch_4 $switch.15_default $switch.15_default
+                (block $switch.18_default (result i32)
+                 (br_table $switch.18_branch_1 $switch.18_branch_2 $switch.18_branch_3 $switch.18_branch_4 $switch.18_default $switch.18_default
                   (i32.const 0)
                   (i32.shr_s
-                   (local.get $7)
+                   (local.get $8)
                    (i32.const 1)
                   )
                  )
                 )
                )
-               (br $switch.15_outer
-                (block $compile_block.20 (result i32)
+               (br $switch.18_outer
+                (block $compile_block.23 (result i32)
                  (unreachable)
                 )
                )
               )
              )
-             (br $switch.15_outer
-              (block $compile_block.19 (result i32)
+             (br $switch.18_outer
+              (block $compile_block.22 (result i32)
                (i32.const 2147483646)
               )
              )
             )
            )
-           (br $switch.15_outer
-            (block $compile_block.18 (result i32)
+           (br $switch.18_outer
+            (block $compile_block.21 (result i32)
              (i32.const 2147483646)
             )
            )
           )
          )
-         (br $switch.15_outer
-          (block $compile_block.17 (result i32)
+         (br $switch.18_outer
+          (block $compile_block.20 (result i32)
            (i32.const -2)
           )
          )
         )
        )
-       (br $switch.15_outer
-        (block $compile_block.16 (result i32)
+       (br $switch.18_outer
+        (block $compile_block.19 (result i32)
          (i32.const 2147483646)
         )
        )
       )
      )
     )
-    (block $do_backpatches.21
+    (block $do_backpatches.24
     )
    )
-   (block $compile_store.24
-    (local.set $11
+   (block $compile_store.27
+    (local.set $12
      (call $print_1116
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
        (global.get $print_1116)
       )
-      (local.get $10)
+      (local.get $11)
+      (local.get $6)
      )
     )
-    (block $do_backpatches.23
+    (block $do_backpatches.26
     )
    )
    (i32.const 1)

--- a/compiler/test/__snapshots__/provides.30cbc409.0.snapshot
+++ b/compiler/test/__snapshots__/provides.30cbc409.0.snapshot
@@ -3,6 +3,7 @@ provides › provide_start_function
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_genv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_genv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_genv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
@@ -16,7 +17,7 @@ provides › provide_start_function
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1117 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1117 (param i32 i32 i32) (result i32)))
  (global $_start_1113 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (memory $0 0)
@@ -34,10 +35,45 @@ provides › provide_start_function
   (local $5 f32)
   (local $6 f64)
   (local $7 i32)
-  (block $compile_block.5
+  (local $8 i32)
+  (block $compile_block.8
    (block $compile_store.3
     (local.set $7
-     (block $allocate_string.1 (result i32)
+     (block $allocate_adt.1 (result i32)
+      (i32.store
+       (local.tee $1
+        (call $malloc_0
+         (global.get $GRAIN$EXPORT$malloc_0)
+         (i32.const 20)
+        )
+       )
+       (i32.const 2)
+      )
+      (i32.store offset=4
+       (local.get $1)
+       (i32.const 501102191)
+      )
+      (i32.store offset=8
+       (local.get $1)
+       (i32.const 7)
+      )
+      (i32.store offset=12
+       (local.get $1)
+       (i32.const 3)
+      )
+      (i32.store offset=16
+       (local.get $1)
+       (i32.const 0)
+      )
+      (local.get $1)
+     )
+    )
+    (block $do_backpatches.2
+    )
+   )
+   (block $compile_store.6
+    (local.set $8
+     (block $allocate_string.4 (result i32)
       (i32.store
        (local.tee $1
         (call $malloc_0
@@ -62,10 +98,10 @@ provides › provide_start_function
       (local.get $1)
      )
     )
-    (block $do_backpatches.2
+    (block $do_backpatches.5
     )
    )
-   (block $cleanup.4
+   (block $cleanup.7
     (drop
      (call $decRef_0
       (global.get $GRAIN$EXPORT$decRef_0)
@@ -78,6 +114,7 @@ provides › provide_start_function
      (global.get $GRAIN$EXPORT$incRef_0)
      (global.get $print_1117)
     )
+    (local.get $8)
     (local.get $7)
    )
   )
@@ -90,10 +127,45 @@ provides › provide_start_function
   (local $4 f32)
   (local $5 f64)
   (local $6 i32)
-  (block $compile_block.11 (result i32)
-   (block $compile_store.8
+  (local $7 i32)
+  (block $compile_block.17 (result i32)
+   (block $compile_store.11
     (local.set $6
-     (block $allocate_string.6 (result i32)
+     (block $allocate_adt.9 (result i32)
+      (i32.store
+       (local.tee $0
+        (call $malloc_0
+         (global.get $GRAIN$EXPORT$malloc_0)
+         (i32.const 20)
+        )
+       )
+       (i32.const 2)
+      )
+      (i32.store offset=4
+       (local.get $0)
+       (i32.const 501102191)
+      )
+      (i32.store offset=8
+       (local.get $0)
+       (i32.const 7)
+      )
+      (i32.store offset=12
+       (local.get $0)
+       (i32.const 3)
+      )
+      (i32.store offset=16
+       (local.get $0)
+       (i32.const 0)
+      )
+      (local.get $0)
+     )
+    )
+    (block $do_backpatches.10
+    )
+   )
+   (block $compile_store.14
+    (local.set $7
+     (block $allocate_string.12 (result i32)
       (i32.store
        (local.tee $0
         (call $malloc_0
@@ -114,7 +186,7 @@ provides › provide_start_function
       (local.get $0)
      )
     )
-    (block $do_backpatches.7
+    (block $do_backpatches.13
     )
    )
    (drop
@@ -123,14 +195,15 @@ provides › provide_start_function
       (global.get $GRAIN$EXPORT$incRef_0)
       (global.get $print_1117)
      )
+     (local.get $7)
      (local.get $6)
     )
    )
-   (block $compile_store.10
+   (block $compile_store.16
     (global.set $_start_1113
      (i32.const 0)
     )
-    (block $do_backpatches.9
+    (block $do_backpatches.15
     )
    )
    (i32.const 1879048190)

--- a/compiler/test/__snapshots__/provides.82c10ab4.0.snapshot
+++ b/compiler/test/__snapshots__/provides.82c10ab4.0.snapshot
@@ -3,6 +3,7 @@ provides › provide12
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import \"_genv\" \"tbl\" (table $tbl 0 funcref))
  (import \"_genv\" \"relocBase\" (global $relocBase_0 i32))
  (import \"_genv\" \"moduleRuntimeId\" (global $moduleRuntimeId_0 i32))
@@ -17,7 +18,7 @@ provides › provide12
  (import \"GRAIN$MODULE$runtime/gc\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1200 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives\" \"print\" (func $print_1200 (param i32 i32 i32) (result i32)))
  (import \"GRAIN$MODULE$providedType\" \"apply\" (func $apply_1198 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 1))
  (memory $0 0)
@@ -34,11 +35,46 @@ provides › provide12
   (local $6 f32)
   (local $7 f64)
   (local $8 i32)
-  (block $closure_elements.11
-   (block $compile_block.10
-    (block $compile_store.8
+  (local $9 i32)
+  (block $closure_elements.17
+   (block $compile_block.16
+    (block $compile_store.11
      (local.set $8
-      (block $allocate_string.6 (result i32)
+      (block $allocate_adt.9 (result i32)
+       (i32.store
+        (local.tee $2
+         (call $malloc_0
+          (global.get $GRAIN$EXPORT$malloc_0)
+          (i32.const 20)
+         )
+        )
+        (i32.const 2)
+       )
+       (i32.store offset=4
+        (local.get $2)
+        (i32.const 501102191)
+       )
+       (i32.store offset=8
+        (local.get $2)
+        (i32.const 7)
+       )
+       (i32.store offset=12
+        (local.get $2)
+        (i32.const 3)
+       )
+       (i32.store offset=16
+        (local.get $2)
+        (i32.const 0)
+       )
+       (local.get $2)
+      )
+     )
+     (block $do_backpatches.10
+     )
+    )
+    (block $compile_store.14
+     (local.set $9
+      (block $allocate_string.12 (result i32)
        (i32.store
         (local.tee $2
          (call $malloc_0
@@ -59,10 +95,10 @@ provides › provide12
        (local.get $2)
       )
      )
-     (block $do_backpatches.7
+     (block $do_backpatches.13
      )
     )
-    (block $cleanup.9
+    (block $cleanup.15
      (drop
       (call $decRef_0
        (global.get $GRAIN$EXPORT$decRef_0)
@@ -81,6 +117,7 @@ provides › provide12
       (global.get $GRAIN$EXPORT$incRef_0)
       (global.get $print_1200)
      )
+     (local.get $9)
      (local.get $8)
     )
    )
@@ -94,10 +131,10 @@ provides › provide12
   (local $4 f32)
   (local $5 f64)
   (local $6 i32)
-  (block $compile_block.15
-   (block $compile_store.14
+  (block $compile_block.21
+   (block $compile_store.20
     (local.set $6
-     (block $allocate_closure.12 (result i32)
+     (block $allocate_closure.18 (result i32)
       (i32.store
        (local.tee $0
         (call $malloc_0
@@ -125,7 +162,7 @@ provides › provide12
       (local.get $0)
      )
     )
-    (block $do_backpatches.13
+    (block $do_backpatches.19
      (local.set $0
       (local.get $6)
      )

--- a/compiler/test/suites/basic_functionality.re
+++ b/compiler/test/suites/basic_functionality.re
@@ -50,6 +50,14 @@ describe("basic functionality", ({test, testSkip}) => {
   assertSnapshot("nan", "let x = NaN; x");
   assertRun("nan_2", "assert NaN != NaN", "");
 
+  assertSnapshot("print_line_ending1", "print(1, lineEnding=\"\")");
+  assertRun("print_line_ending2", "print(123, lineEnding=\"\")", "123");
+  assertRun(
+    "print_line_ending3",
+    "print(1, lineEnding=\"\"); print(2, lineEnding=\"    \"); print(\"3\", lineEnding=\"end\")",
+    "12    3end",
+  );
+
   assertSnapshot(
     "complex1",
     "\n    let x = 2 and y = 3 and z = if (true) { 4 } else { 5 };\n    if (true) {\n      print(y)\n      y - (z + x)\n    } else {\n      print(8)\n      8\n    }\n    ",

--- a/compiler/test/suites/basic_functionality.re
+++ b/compiler/test/suites/basic_functionality.re
@@ -50,11 +50,11 @@ describe("basic functionality", ({test, testSkip}) => {
   assertSnapshot("nan", "let x = NaN; x");
   assertRun("nan_2", "assert NaN != NaN", "");
 
-  assertSnapshot("print_line_ending1", "print(1, lineEnding=\"\")");
-  assertRun("print_line_ending2", "print(123, lineEnding=\"\")", "123");
+  assertSnapshot("print_line_ending1", "print(1, suffix=\"\")");
+  assertRun("print_line_ending2", "print(123, suffix=\"\")", "123");
   assertRun(
     "print_line_ending3",
-    "print(1, lineEnding=\"\"); print(2, lineEnding=\"    \"); print(\"3\", lineEnding=\"end\")",
+    "print(1, suffix=\"\"); print(2, suffix=\"    \"); print(\"3\", suffix=\"end\")",
     "12    3end",
   );
 

--- a/compiler/test/suites/optimizations.re
+++ b/compiler/test/suites/optimizations.re
@@ -68,7 +68,7 @@ describe("optimizations", ({test, testSkip}) => {
   );
   assertRun(
     "regression_no_elim_impure_call",
-    "let foo = (f) => { let g = f(5); 5 }; foo(print)",
+    "let foo = (f) => { let g = print(f(5)); 5 }; foo(toString)",
     "5\n",
   );
   assertAnf(

--- a/stdlib/pervasives.md
+++ b/stdlib/pervasives.md
@@ -861,7 +861,7 @@ No other changes yet.
 </details>
 
 ```grain
-print : (value: a, ?lineEnding: String) => Void
+print : (value: a, ?suffix: String) => Void
 ```
 
 Prints the given operand to the console. Works for any type. Internally, calls `toString`
@@ -873,7 +873,7 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`value`|`a`|The operand|
-|`?lineEnding`|`String`|The string to print after the argument|
+|`?suffix`|`String`|The string to print after the argument|
 
 ### Pervasives.**ignore**
 

--- a/stdlib/pervasives.md
+++ b/stdlib/pervasives.md
@@ -861,7 +861,7 @@ No other changes yet.
 </details>
 
 ```grain
-print : (value: a) => Void
+print : (value: a, ?lineEnding: String) => Void
 ```
 
 Prints the given operand to the console. Works for any type. Internally, calls `toString`
@@ -873,6 +873,7 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`value`|`a`|The operand|
+|`?lineEnding`|`String`|The string to print after the argument|
 
 ### Pervasives.**ignore**
 

--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -858,27 +858,27 @@ provide let toString = value => {
  * are provided from the module.
  *
  * @param value: The operand
+ * @param lineEnding: The string to print after the argument
  *
  * @since v0.1.0
  */
 @unsafe
-provide let print = value => {
+provide let print = (value, lineEnding="\n") => {
   // First convert the value to string, if it isn't one already.
   let valuePtr = WasmI32.fromGrain(value)
   let s = toString(value)
   let ptr = WasmI32.fromGrain(s)
-  // iov: [<ptr to string> <nbytes of string> <ptr to newline> <nbytes of newline>] (32 bytes)
-  // buf: <iov> <written> <newline char>
+  let lineEndingPtr = WasmI32.fromGrain(lineEnding)
+  // iov: [<ptr to string> <nbytes of string> <ptr to end sequence> <nbytes of end sequence>] (32 bytes)
+  // buf: <iov> <written>
   // fd_write(STDOUT (1), iov, len(iov), written)
-  let buf = Memory.malloc(37n)
+  let buf = Memory.malloc(36n)
   let iov = buf
   let written = buf + 32n
-  let lf = buf + 36n
   WasmI32.store(iov, ptr + 8n, 0n)
   WasmI32.store(iov, WasmI32.load(ptr, 4n), 4n)
-  WasmI32.store8(lf, 10n, 0n)
-  WasmI32.store(iov, lf, 8n)
-  WasmI32.store(iov, 1n, 12n)
+  WasmI32.store(iov, lineEndingPtr + 8n, 8n)
+  WasmI32.store(iov, WasmI32.load(lineEndingPtr, 4n), 12n)
   fd_write(1n, iov, 2n, written)
   Memory.free(buf)
   void

--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -858,17 +858,17 @@ provide let toString = value => {
  * are provided from the module.
  *
  * @param value: The operand
- * @param lineEnding: The string to print after the argument
+ * @param suffix: The string to print after the argument
  *
  * @since v0.1.0
  */
 @unsafe
-provide let print = (value, lineEnding="\n") => {
+provide let print = (value, suffix="\n") => {
   // First convert the value to string, if it isn't one already.
   let valuePtr = WasmI32.fromGrain(value)
   let s = toString(value)
   let ptr = WasmI32.fromGrain(s)
-  let lineEndingPtr = WasmI32.fromGrain(lineEnding)
+  let suffixPtr = WasmI32.fromGrain(suffix)
   // iov: [<ptr to string> <nbytes of string> <ptr to end sequence> <nbytes of end sequence>] (32 bytes)
   // buf: <iov> <written>
   // fd_write(STDOUT (1), iov, len(iov), written)
@@ -877,8 +877,8 @@ provide let print = (value, lineEnding="\n") => {
   let written = buf + 32n
   WasmI32.store(iov, ptr + 8n, 0n)
   WasmI32.store(iov, WasmI32.load(ptr, 4n), 4n)
-  WasmI32.store(iov, lineEndingPtr + 8n, 8n)
-  WasmI32.store(iov, WasmI32.load(lineEndingPtr, 4n), 12n)
+  WasmI32.store(iov, suffixPtr + 8n, 8n)
+  WasmI32.store(iov, WasmI32.load(suffixPtr, 4n), 12n)
   fd_write(1n, iov, 2n, written)
   Memory.free(buf)
   void

--- a/stdlib/runtime/string.md
+++ b/stdlib/runtime/string.md
@@ -72,7 +72,7 @@ No other changes yet.
 </details>
 
 ```grain
-print : (value: a) => Void
+print : (value: a, ?lineEnding: String) => Void
 ```
 
 Prints the given operand to the console. Works for any type. Internally, calls `toString`
@@ -84,4 +84,5 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`value`|`a`|The operand|
+|`?lineEnding`|`String`|The string to print after the argument|
 

--- a/stdlib/runtime/string.md
+++ b/stdlib/runtime/string.md
@@ -72,7 +72,7 @@ No other changes yet.
 </details>
 
 ```grain
-print : (value: a, ?lineEnding: String) => Void
+print : (value: a, ?suffix: String) => Void
 ```
 
 Prints the given operand to the console. Works for any type. Internally, calls `toString`
@@ -84,5 +84,5 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`value`|`a`|The operand|
-|`?lineEnding`|`String`|The string to print after the argument|
+|`?suffix`|`String`|The string to print after the argument|
 


### PR DESCRIPTION
Adds `suffix` argument to `print` (default `"\n"`). Enables printing without newline for instance
```
print(123, suffix="")
```