### PR TITLE
chore(compiler): Cleanup reference to `wast`

### DIFF
--- a/compiler/src/compile.re
+++ b/compiler/src/compile.re
@@ -44,9 +44,6 @@ exception InlineFlagsError(Location.t, error);
 let default_output_filename = name =>
   Filepath.String.remove_extension(name) ++ ".gr.wasm";
 
-let default_assembly_filename = name =>
-  Filepath.String.remove_extension(name) ++ ".wast";
-
 let default_mashtree_filename = name =>
   Filepath.String.remove_extension(name) ++ ".mashtree";
 


### PR DESCRIPTION
This pr just removes a variable that I think was left over from a past change that reference a `.wast` file extension as its no longer used anywhere its probably good to be removed.