### PR TITLE
chore(ci): Convert CI workflows to reusable & apply various QoL changes

### DIFF
--- a/.github/workflows/build-js.yml
+++ b/.github/workflows/build-js.yml
@@ -1,0 +1,115 @@
+# This workflow exists to provide a way to dispatch a CI run for any
+# given ref on any of our OS targets. It can also be consumed in our
+# various other builds.
+name: (js) Build and test
+
+on:
+  workflow_dispatch:
+    inputs:
+      os:
+        description: "Operating system to run CI on"
+        required: true
+        default: "ubuntu-latest"
+        type: choice
+        options:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+  workflow_call:
+    inputs:
+      os:
+        type: string
+        required: true
+
+jobs:
+  build:
+    name: (js) Build and test
+    runs-on: ${{ inputs.os }}
+
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v3
+
+      - name: Setup node.js
+        uses: actions/setup-node@v3.6.0
+        with:
+          node-version: "16"
+          check-latest: true
+          cache: "npm"
+
+      - name: Install npm dependencies
+        run: |
+          npm ci
+
+      - name: Esy cache
+        id: esy-cache
+        uses: actions/cache/restore@v3
+        with:
+          path: compiler/_export
+          key: ${{ runner.os }}-esy-${{ hashFiles('compiler/esy.lock/index.json') }}
+
+      - name: Esy setup
+        # Don't crash the run if esy cache import fails - mostly happens on Windows
+        continue-on-error: true
+        run: |
+          npm run compiler prepare
+          npm run compiler import-dependencies
+
+      # Don't build native executables, only the JS builds
+      - name: Build compiler
+        run: |
+          npm run compiler build:js
+
+      - name: Run tests
+        run: |
+          npm run compiler test:js
+
+      # This will log a warning because we removed don't have a native exe files
+      - name: Build pkg binary for Windows
+        if: inputs.os == 'ubuntu-latest'
+        run: |
+          npm run cli build-pkg -- --target=win-x64
+          tar -cvf grain.tar -C pkg grain.exe
+
+      - name: Upload pkg binary for Windows
+        if: inputs.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v3
+        with:
+          path: ./grain.tar
+          name: grain-win-x64
+
+      # This will log a warning because we removed don't have a native exe files
+      - name: Build pkg binary for Mac
+        if: inputs.os == 'ubuntu-latest'
+        run: |
+          npm run cli build-pkg -- --target=mac-x64
+          tar -cvf grain.tar -C pkg grain
+
+      - name: Upload pkg binary for Mac
+        if: inputs.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v3
+        with:
+          path: ./grain.tar
+          name: grain-mac-x64
+
+      # This will log a warning because we removed don't have a native exe files
+      - name: Build pkg binary for Linux
+        if: inputs.os == 'ubuntu-latest'
+        run: |
+          npm run cli build-pkg -- --target=linux-x64
+          tar -cvf grain.tar -C pkg grain
+
+      - name: Upload pkg binary for Linux
+        if: inputs.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v3
+        with:
+          path: ./grain.tar
+          name: grain-linux-x64
+
+      # This is to test that we didn't actually introduce multivalue
+      # which might happen through a binaryen optimization
+      - name: Run NEAR smoketest
+        if: inputs.os != 'windows-latest'
+        run: |
+          npm run stdlib clean
+          npm run cli test

--- a/.github/workflows/build-js.yml
+++ b/.github/workflows/build-js.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           npm run compiler test:js
 
-      # This will log a warning because we removed don't have a native exe files
+      # This will log a warning because we didn't build the native exe files
       - name: Build pkg binary for Windows
         if: inputs.os == 'ubuntu-latest'
         run: |
@@ -78,7 +78,7 @@ jobs:
           path: ./grain.tar
           name: grain-win-x64
 
-      # This will log a warning because we removed don't have a native exe files
+      # This will log a warning because we didn't build the native exe files
       - name: Build pkg binary for Mac
         if: inputs.os == 'ubuntu-latest'
         run: |
@@ -92,7 +92,7 @@ jobs:
           path: ./grain.tar
           name: grain-mac-x64
 
-      # This will log a warning because we removed don't have a native exe files
+      # This will log a warning because we didn't build the native exe files
       - name: Build pkg binary for Linux
         if: inputs.os == 'ubuntu-latest'
         run: |

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -1,0 +1,124 @@
+# This workflow exists to provide a way to dispatch a CI run for any
+# given ref on any of our OS targets. It can also be consumed in our
+# various other builds.
+name: (native) Build and test
+
+on:
+  workflow_dispatch:
+    inputs:
+      os:
+        description: "Operating system to run CI on"
+        required: true
+        default: "ubuntu-latest"
+        type: choice
+        options:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+  workflow_call:
+    inputs:
+      os:
+        type: string
+        required: true
+
+jobs:
+  build:
+    name: (native) Build and test
+    runs-on: ${{ inputs.os }}
+
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v3
+
+      - name: Setup node.js
+        uses: actions/setup-node@v3.6.0
+        with:
+          node-version: "16"
+          check-latest: true
+          cache: "npm"
+
+      - name: Install npm dependencies
+        run: |
+          npm ci
+
+      - name: Esy cache
+        id: esy-cache
+        uses: actions/cache/restore@v3
+        with:
+          path: compiler/_export
+          key: ${{ runner.os }}-esy-${{ hashFiles('compiler/esy.lock/index.json') }}
+
+      - name: Esy setup
+        # Don't crash the run if esy cache import fails - mostly happens on Windows
+        continue-on-error: true
+        run: |
+          npm run compiler prepare
+          npm run compiler import-dependencies
+
+      - name: Build compiler
+        run: |
+          npm run compiler build
+
+      # Upload the artifacts before we run the tests so we
+      # can download to debug if tests fail in a weird way
+      - name: Upload native compiler artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: native-build-artifacts-${{ runner.os }}-${{ runner.arch }}
+          path: cli/bin/*.exe
+
+      - name: Run tests
+        run: |
+          npm run compiler test
+
+      - name: (compiler) Check parser error messages exhaustiveness
+        run: |
+          npm run compiler parser:check-errors
+
+      - name: (graindoc) Check parser error messages exhaustiveness
+        run: |
+          npm run compiler graindoc-parser:check-errors
+
+      # Check formatting last because building is more important
+      - name: (compiler) Check formatting
+        if: inputs.os != 'windows-latest'
+        run: |
+          npm run compiler check-format
+
+      - name: (js-runner) Check formatting
+        if: inputs.os != 'windows-latest'
+        run: |
+          npm run js-runner check-format
+
+      - name: (cli) Check formatting
+        if: inputs.os != 'windows-latest'
+        run: |
+          npm run cli check-format
+
+      # This is to test the CLI is working
+      - name: Log Grain version
+        run: |
+          grain -v
+
+      # If we have a working grain CLI, we can run graindoc on stdlib
+      - name: (stdlib) Check documentation
+        if: inputs.os != 'windows-latest'
+        run: |
+          grain doc stdlib -o stdlib --current-version=$(grain -v)
+          git diff --exit-code --name-only
+
+      # If we have a working grain CLI, we can run grainfmt on stdlib & tests
+      - name: (stdlib) Check formatting
+        if: inputs.os != 'windows-latest'
+        run: |
+          grain format stdlib -o stdlib
+          grain format compiler/test/stdlib -o compiler/test/stdlib
+          git diff --exit-code --name-only
+
+      # This is to test that we didn't actually introduce multivalue
+      # which might happen through a binaryen optimization
+      - name: Run NEAR smoketest
+        if: inputs.os != 'windows-latest'
+        run: |
+          npm run stdlib clean
+          npm run cli test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+# This workflow exists so a dependency cache can be built for a
+# single OS and then its native & js builds can be run in parallel.
+#
+# If we instead built the dependency cache with a matrix in `ci.yml`,
+# it'd block every build until all caches were built for all our targets.
+name: Build and test
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        type: string
+        required: true
+
+jobs:
+  dependencies:
+    name: Dependencies
+    uses: ./.github/workflows/dependencies.yml
+    with:
+      os: ${{ inputs.os }}
+
+  build-native:
+    name: (native) Build and test
+    needs: [dependencies]
+    uses: ./.github/workflows/build-native.yml
+    with:
+      os: ${{ inputs.os }}
+
+  build-js:
+    name: (js) Build and test
+    needs: [dependencies]
+    uses: ./.github/workflows/build-js.yml
+    with:
+      os: ${{ inputs.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node.js
         uses: actions/setup-node@v3.1.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,106 +1,19 @@
 name: Grain CI Workflow
+
 on: [push, pull_request]
 
 jobs:
   build:
-    name: Build and test
-    runs-on: ${{ matrix.os }}
-
+    name: Build and test on ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: ["16"]
+    uses: ./.github/workflows/build.yml
+    with:
+      os: ${{ matrix.os }}
 
-    steps:
-      - name: Checkout project
-        uses: actions/checkout@v3
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v3.1.1
-        with:
-          node-version: ${{ matrix.node-version }}
-          check-latest: true
-          cache: "npm"
-
-      # Adds `shx` globally for cross-platform shell commands
-      - name: Setup environment (All)
-        run: |
-          npm install -g shx
-
-      - name: Set up JS runner and CLI
-        run: |
-          npm ci
-
-      - name: Esy setup
-        run: |
-          npm run compiler prepare
-
-      - name: Esy cache
-        id: esy-cache
-        uses: actions/cache@v2
-        with:
-          path: compiler/_export
-          key: ${{ runner.os }}-esy-${{ hashFiles('compiler/esy.lock/index.json') }}
-
-      - name: Import esy cache
-        if: steps.esy-cache.outputs.cache-hit == 'true'
-        # Don't crash the run if esy cache import fails - mostly happens on Windows
-        continue-on-error: true
-        run: |
-          npm run compiler import-dependencies
-          shx rm -rf compiler/_export
-
-      - name: Build compiler
-        run: |
-          npm run compiler build
-
-      # Re-export dependencies if anything has changed or if it is the first time
-      - name: Build esy cache
-        if: steps.esy-cache.outputs.cache-hit != 'true'
-        run: |
-          npm run compiler export-dependencies
-
-      - name: Run tests (native)
-        run: |
-          npm run compiler test
-
-      # Windows still needs some fixes to run correctly in JS
-      - name: Run tests (js)
-        run: |
-          npm run compiler test:js
-
-      - name: Check parser error messages exhaustiveness
-        run: |
-          npm run compiler parser:check-errors
-          npm run compiler graindoc-parser:check-errors
-
-      # Formatting lint last because building is more important
-      - name: Run formatting lint
-        if: matrix.os != 'windows-latest'
-        run: |
-          npm run compiler check-format
-          npm run js-runner check-format
-          npm run cli check-format
-
-      # This is to test the CLI is working
-      - name: Log Grain version
-        run: |
-          grain -v
-
-      # If we have a working grain CLI, we can run grainfmt and graindoc on stdlib
-      - name: Check stdlib docs and formatting
-        if: matrix.os != 'windows-latest'
-        run: |
-          grain doc stdlib -o stdlib --current-version=$(grain -v)
-          grain format stdlib -o stdlib
-          grain format compiler/test/stdlib -o compiler/test/stdlib
-          git diff --exit-code --name-only
-
-      # This is to test that we didn't actually introduce multivalue
-      # which might happen through a binaryen optimization
-      - name: Run NEAR smoketest
-        if: matrix.os != 'windows-latest'
-        run: |
-          npm run stdlib clean
-          npm run cli test
+  test-pkg:
+    name: Test pkg binaries
+    needs: [build]
+    uses: ./.github/workflows/test-pkg.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,11 @@ name: Grain CI Workflow
 
 on: [push, pull_request]
 
+# This will cancel previous runs when a branch or PR is updated
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build and test on ${{ matrix.os }}

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,0 +1,47 @@
+name: Build dependencies
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        type: string
+        required: true
+
+jobs:
+  build_dependencies:
+    name: Create dependencies cache
+    runs-on: ${{ inputs.os }}
+
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v3
+
+      - name: Esy dependency cache
+        id: esy-cache
+        uses: actions/cache@v3
+        with:
+          path: compiler/_export
+          key: ${{ runner.os }}-esy-${{ hashFiles('compiler/esy.lock/index.json') }}
+          lookup-only: true
+
+      # We only need to setup node & npm dependencies if we don't have an esy cache because
+      # we won't run esy in that case and we can defer setting it up until building grain
+      - name: Setup node.js
+        if: steps.esy-cache.outputs.cache-hit != 'true'
+        uses: actions/setup-node@v3.6.0
+        with:
+          node-version: "16"
+          check-latest: true
+          cache: "npm"
+
+      - name: Install npm dependencies
+        if: steps.esy-cache.outputs.cache-hit != 'true'
+        run: |
+          npm ci
+
+      - name: Build esy dependencies
+        if: steps.esy-cache.outputs.cache-hit != 'true'
+        run: |
+          npm run compiler prepare
+          npm run compiler build-dependencies
+          npm run compiler export-dependencies

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,8 +19,8 @@ jobs:
     name: Push base Docker image to multiple registries
     runs-on: ubuntu-latest
     steps:
-      - name: Check out the repo
-        uses: actions/checkout@v2
+      - name: Checkout project
+        uses: actions/checkout@v3
 
       - name: Parse tag
         # This step converts Grain tags into standard semver, i.e. grain-v1.2.3 -> v1.2.3
@@ -99,8 +99,8 @@ jobs:
     name: Push slim Docker image to multiple registries
     runs-on: ubuntu-latest
     steps:
-      - name: Check out the repo
-        uses: actions/checkout@v2
+      - name: Checkout project
+        uses: actions/checkout@v3
 
       - name: Parse tag
         # This step converts Grain tags into standard semver, i.e. grain-v1.2.3 -> v1.2.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       js-runner_download_url: ${{ steps.js-runner-upload.outputs.browser_download_url }}
     steps:
       - name: Checkout project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Many of these steps are the same as building the compiler for tests
       - name: Setup Node.js

--- a/.github/workflows/test-pkg.yml
+++ b/.github/workflows/test-pkg.yml
@@ -1,0 +1,67 @@
+name: Test pkg binaries
+
+on: [workflow_call]
+
+jobs:
+  test-pkg:
+    name: Test pkg binary on ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux
+            os: ubuntu-latest
+          - name: mac
+            os: macos-latest
+          - name: win
+            os: windows-latest
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v3
+
+      - name: Fetch pkg binary
+        uses: actions/download-artifact@v3
+        with:
+          name: grain-${{ matrix.name }}-x64
+
+      - name: Untar download
+        run: |
+          tar -xvf grain.tar
+
+      # This is to test the CLI is working
+      - name: Log Grain version
+        if: matrix.os != 'windows-latest'
+        run: |
+          ./grain -v
+
+      - name: Log Grain version
+        if: matrix.os == 'windows-latest'
+        run: |
+          ./grain.exe -v
+
+      # If we have a working grain CLI, we can run graindoc on stdlib
+      - name: (stdlib) Check documentation
+        if: matrix.os != 'windows-latest'
+        run: |
+          ./grain doc stdlib -o stdlib --current-version=$(./grain -v)
+          git diff --exit-code --name-only
+
+      # If we have a working grain CLI, we can run grainfmt on stdlib & tests
+      - name: (stdlib) Check formatting
+        if: matrix.os != 'windows-latest'
+        run: |
+          ./grain format stdlib -o stdlib
+          ./grain format compiler/test/stdlib -o compiler/test/stdlib
+          git diff --exit-code --name-only
+
+      - name: Smoketest a program
+        if: matrix.os != 'windows-latest'
+        run: |
+          ./grain compiler/test/input/relativeIncludeLinking.gr
+
+      - name: Smoketest a program
+        if: matrix.os == 'windows-latest'
+        run: |
+          ./grain.exe compiler/test/input/relativeIncludeLinking.gr

--- a/compiler/package.json
+++ b/compiler/package.json
@@ -9,7 +9,8 @@
     "node": ">=16"
   },
   "devDependencies": {
-    "esy": "0.6.12"
+    "esy": "0.6.12",
+    "shx": "^0.3.4"
   },
   "scripts": {
     "link": "npm link",
@@ -37,6 +38,7 @@
     "graindoc-parser:update-errors": "esy b menhir src/diagnostics/graindoc_parser.mly --unused-tokens --update-errors src/diagnostics/graindoc_parser.messages > src/diagnostics/graindoc_parser.messages.generated && cp src/diagnostics/graindoc_parser.messages.generated src/diagnostics/graindoc_parser.messages",
     "graindoc-parser:check-errors": "npm run graindoc-parser:list-errors && esy b menhir src/diagnostics/graindoc_parser.mly --unused-tokens --compare-errors src/diagnostics/graindoc_parser.messages.generated --compare-errors src/diagnostics/graindoc_parser.messages",
     "import-dependencies": "esy import-dependencies _export",
+    "postimport-dependencies": "shx rm -rf _export",
     "export-dependencies": "esy export-dependencies",
     "build-dependencies": "esy build-dependencies"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,11 +19,11 @@
     },
     "cli": {
       "name": "@grain/cli",
-      "version": "0.4.7",
+      "version": "0.5.13",
       "license": "MIT",
       "dependencies": {
-        "@grain/js-runner": "^0.4.0",
-        "@grain/stdlib": "^0.4.6",
+        "@grain/js-runner": "0.5.13",
+        "@grain/stdlib": "0.5.13",
         "commander": "^8.1.0"
       },
       "bin": {
@@ -44,12 +44,13 @@
     },
     "compiler": {
       "name": "@grain/compiler",
-      "version": "0.4.6",
+      "version": "0.5.13",
       "bin": {
         "grainc": "_esy/default/build/install/default/bin/grainc"
       },
       "devDependencies": {
-        "esy": "0.6.12"
+        "esy": "0.6.12",
+        "shx": "^0.3.4"
       },
       "engines": {
         "node": ">=16"
@@ -57,7 +58,7 @@
     },
     "js-runner": {
       "name": "@grain/js-runner",
-      "version": "0.4.0",
+      "version": "0.5.13",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.15.0",
@@ -8597,6 +8598,60 @@
         "node": ">=8"
       }
     },
+    "node_modules/shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/shelljs/node_modules/interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/shelljs/node_modules/rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/shx": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
+      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.3",
+        "shelljs": "^0.8.5"
+      },
+      "bin": {
+        "shx": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -9925,7 +9980,7 @@
     },
     "stdlib": {
       "name": "@grain/stdlib",
-      "version": "0.4.6",
+      "version": "0.5.13",
       "license": "MIT",
       "devDependencies": {
         "del-cli": "^4.0.1"
@@ -10320,8 +10375,8 @@
     "@grain/cli": {
       "version": "file:cli",
       "requires": {
-        "@grain/js-runner": "^0.4.0",
-        "@grain/stdlib": "^0.4.6",
+        "@grain/js-runner": "0.5.13",
+        "@grain/stdlib": "0.5.13",
         "commander": "^8.1.0",
         "del-cli": "^4.0.1",
         "jest": "28.1.0",
@@ -10333,7 +10388,8 @@
     "@grain/compiler": {
       "version": "file:compiler",
       "requires": {
-        "esy": "0.6.12"
+        "esy": "0.6.12",
+        "shx": "^0.3.4"
       }
     },
     "@grain/js-runner": {
@@ -16436,6 +16492,44 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "devOptional": true
+    },
+    "shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "dependencies": {
+        "interpret": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+          "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+          "dev": true
+        },
+        "rechoir": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+          "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+          "dev": true,
+          "requires": {
+            "resolve": "^1.1.6"
+          }
+        }
+      }
+    },
+    "shx": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
+      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.3",
+        "shelljs": "^0.8.5"
+      }
     },
     "side-channel": {
       "version": "1.0.4",


### PR DESCRIPTION
Closes #1409

This updates the CI to use reusable workflows, which will allow us to construct more complex workflows (such as a nightly build). Some of the splitting is unintuitive so I tried to document why specific workflows exist.

The best thing about these changes are that built artifacts are attached to the workflow run, such as the native build executables and the pkg binaries, so we can use them later (see the test-pkg workflow) or download them to debug, etc.

I also took the opportunity to refactor a bit so it's easier to figure out what failed without having to look at logs.