### PR TITLE
feat(ci): Add builds for preview binaries

### DIFF
--- a/.github/workflows/build-js.yml
+++ b/.github/workflows/build-js.yml
@@ -8,18 +8,27 @@ on:
     inputs:
       os:
         description: "Operating system to run CI on"
+        type: choice
         required: true
         default: "ubuntu-latest"
-        type: choice
         options:
           - ubuntu-latest
           - macos-latest
           - windows-latest
+      ref:
+        description: "Git reference to checkout"
+        type: string
+        required: false
   workflow_call:
     inputs:
       os:
+        description: "Operating system to run CI on"
         type: string
         required: true
+      ref:
+        description: "Git reference to checkout"
+        type: string
+        required: false
 
 jobs:
   build:
@@ -29,6 +38,8 @@ jobs:
     steps:
       - name: Checkout project
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Setup node.js
         uses: actions/setup-node@v3.6.0

--- a/.github/workflows/build-js.yml
+++ b/.github/workflows/build-js.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       os:
-        description: "Operating system to run CI on"
+        description: Operating system to run CI on
         type: choice
         required: true
         default: "ubuntu-latest"
@@ -16,17 +16,17 @@ on:
           - macos-latest
           - windows-latest
       ref:
-        description: "Git reference to checkout"
+        description: Git reference to checkout
         type: string
         required: false
   workflow_call:
     inputs:
       os:
-        description: "Operating system to run CI on"
+        description: Operating system to run CI on
         type: string
         required: true
       ref:
-        description: "Git reference to checkout"
+        description: Git reference to checkout
         type: string
         required: false
 

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -8,18 +8,27 @@ on:
     inputs:
       os:
         description: "Operating system to run CI on"
+        type: choice
         required: true
         default: "ubuntu-latest"
-        type: choice
         options:
           - ubuntu-latest
           - macos-latest
           - windows-latest
+      ref:
+        description: "Git reference to checkout"
+        type: string
+        required: false
   workflow_call:
     inputs:
       os:
+        description: "Operating system to run CI on"
         type: string
         required: true
+      ref:
+        description: "Git reference to checkout"
+        type: string
+        required: false
 
 jobs:
   build:
@@ -29,6 +38,8 @@ jobs:
     steps:
       - name: Checkout project
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Setup node.js
         uses: actions/setup-node@v3.6.0

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       os:
-        description: "Operating system to run CI on"
+        description: Operating system to run CI on
         type: choice
         required: true
         default: "ubuntu-latest"
@@ -16,17 +16,17 @@ on:
           - macos-latest
           - windows-latest
       ref:
-        description: "Git reference to checkout"
+        description: Git reference to checkout
         type: string
         required: false
   workflow_call:
     inputs:
       os:
-        description: "Operating system to run CI on"
+        description: Operating system to run CI on
         type: string
         required: true
       ref:
-        description: "Git reference to checkout"
+        description: Git reference to checkout
         type: string
         required: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: Grain CI Workflow
 
+# This is to avoid unnecessary runs.
+# e.g. push AND pull_request against a PR or push against a tag from workflow runs
+# If you need CI to run, you can open a Draft PR to trigger the CI.
 on:
   push:
     branches: [main]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: Grain CI Workflow
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
+  merge_group:
 
 # This will cancel previous runs when a branch or PR is updated
 concurrency:

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -7,7 +7,7 @@ on:
   workflow_call:
     inputs:
       ref:
-        description: "Git reference to checkout"
+        description: Git reference to checkout
         type: string
         required: false
     secrets:

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -1,0 +1,48 @@
+# This workflow assumes that a `grain-linux-x64` binary was uploaded earlier within the same Action run.
+# It downloads the binary, regenerates the documentation for the project, and pushes it to the ref that was checked out.
+# Note: the `ref` should always be a branch for successful pushes!
+name: Generate documentation
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git reference to checkout"
+        type: string
+        required: false
+    secrets:
+      PUSH_TOKEN:
+        description: Token used to push back to repository
+        required: true
+
+jobs:
+  generate-docs:
+    name: Generate documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup bot user
+        run: |
+          git config --global user.email "bot@grain-lang.org"
+          git config --global user.name "Grain Bot"
+
+      - name: Checkout project
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+          token: ${{ secrets.PUSH_TOKEN }}
+
+      - name: Fetch linux binary
+        uses: actions/download-artifact@v3
+        with:
+          name: grain-linux-x64
+
+      - name: Untar download
+        run: |
+          tar -xvf grain.tar
+
+      - name: Regenerate documentation
+        run: |
+          ./grain doc stdlib -o stdlib --current-version=$(./grain -v)
+          git add stdlib
+          git commit -m 'chore(stdlib): Regenerate markdown documentation'
+          git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       stdlib-tag-name: ${{ steps.release.outputs.stdlib--tag_name }}
       js-runner-tag-name: ${{ steps.release.outputs.js-runner--tag_name }}
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v3.2.5
+      - uses: GoogleCloudPlatform/release-please-action@v3.7.5
         id: release
         with:
           # Explicitly use GITHUB_TOKEN here so Release Please doesn't start a CI run that will fail
@@ -111,7 +111,7 @@ jobs:
 
       - name: Upload stdlib
         id: stdlib-upload
-        uses: grain-lang/upload-release-action@v3.0.1
+        uses: grain-lang/upload-release-action@v3.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           file: ./stdlib/${{ env.STDLIB_TAR }}
@@ -127,7 +127,7 @@ jobs:
 
       - name: Upload js-runner
         id: js-runner-upload
-        uses: grain-lang/upload-release-action@v3.0.1
+        uses: grain-lang/upload-release-action@v3.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           file: ./js-runner/${{ env.RUNNER_TAR }}
@@ -140,7 +140,7 @@ jobs:
     name: Dispatch website release
     runs-on: ubuntu-latest
     steps:
-      - uses: grain-lang/workflow-dispatch-action@v1.0.0
+      - uses: grain-lang/workflow-dispatch-action@v1.0.1
         with:
           workflow: Grain Release
           token: ${{ secrets.WORKFLOW_TOKEN }}
@@ -154,7 +154,7 @@ jobs:
     name: Dispatch homebrew release
     runs-on: ubuntu-latest
     steps:
-      - uses: grain-lang/workflow-dispatch-action@v1.0.0
+      - uses: grain-lang/workflow-dispatch-action@v1.0.1
         with:
           workflow: Grain Release
           token: ${{ secrets.WORKFLOW_TOKEN }}
@@ -168,7 +168,7 @@ jobs:
     name: Dispatch Docker builds
     runs-on: ubuntu-latest
     steps:
-      - uses: grain-lang/workflow-dispatch-action@v1.0.0
+      - uses: grain-lang/workflow-dispatch-action@v1.0.1
         with:
           workflow: Publish Docker images
           token: ${{ secrets.WORKFLOW_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,106 +3,106 @@ on:
   push:
     branches: [main]
 
+# This will cancel previous runs when a branch or PR is updated
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   release-please:
     name: Create Release
     runs-on: ubuntu-latest
     outputs:
-      releases_created: ${{ steps.release.outputs.releases_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
-      stdlib_tag_name: ${{ steps.release.outputs.stdlib--tag_name }}
-      js-runner_tag_name: ${{ steps.release.outputs.js-runner--tag_name }}
+      release-pr: ${{ steps.release.outputs.pr }}
+      releases-created: ${{ steps.release.outputs.releases_created }}
+      tag-name: ${{ steps.release.outputs.tag_name }}
+      stdlib-tag-name: ${{ steps.release.outputs.stdlib--tag_name }}
+      js-runner-tag-name: ${{ steps.release.outputs.js-runner--tag_name }}
     steps:
       - uses: GoogleCloudPlatform/release-please-action@v3.2.5
         id: release
         with:
+          # Explicitly use GITHUB_TOKEN here so Release Please doesn't start a CI run that will fail
+          # The correct CI run is triggered by the `generate-docs` job below when it pushes updated documentation
           token: ${{ secrets.GITHUB_TOKEN }}
           command: manifest
 
-  prepare-artifacts:
+  build-preview:
+    name: Build preview binaries
     needs: [release-please]
-    if: ${{ needs.release-please.outputs.releases_created }}
-    name: Prepare artifacts
+    if: ${{ needs.release-please.outputs.release-pr }}
+    uses: ./.github/workflows/build-js.yml
+    with:
+      os: ubuntu-latest
+      ref: ${{ fromJSON(needs.release-please.outputs.release-pr).headBranchName }}
+
+  generate-docs:
+    name: Generate documentation
+    needs: [release-please, build-preview]
+    if: ${{ needs.release-please.outputs.release-pr }}
+    uses: ./.github/workflows/generate-docs.yml
+    with:
+      ref: ${{ fromJSON(needs.release-please.outputs.release-pr).headBranchName }}
+    secrets:
+      # This uses WORKFLOW_TOKEN because we want the push to trigger our `ci.yml` runs on the release PR
+      # and the GITHUB_TOKEN is blocked from triggering other workflows.
+      # See https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+      PUSH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+
+  upload-preview:
+    name: Upload preview binaries
+    needs: [release-please, build-preview]
+    if: ${{ needs.release-please.outputs.release-pr }}
+    uses: ./.github/workflows/upload-binaries.yml
+    with:
+      tag: preview
+      ref: ${{ fromJSON(needs.release-please.outputs.release-pr).headBranchName }}
+    secrets:
+      UPLOAD_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-release:
+    name: Build release binaries
+    needs: [release-please]
+    if: ${{ needs.release-please.outputs.releases-created }}
+    uses: ./.github/workflows/build-js.yml
+    with:
+      os: ubuntu-latest
+      ref: ${{ needs.release-please.outputs.tag-name }}
+
+  upload-release:
+    name: Upload release binaries
+    needs: [release-please, build-release]
+    if: ${{ needs.release-please.outputs.releases-created }}
+    uses: ./.github/workflows/upload-binaries.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag-name }}
+      ref: ${{ needs.release-please.outputs.tag-name }}
+    secrets:
+      UPLOAD_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  upload-npm-artifacts:
+    needs: [release-please]
+    if: ${{ needs.release-please.outputs.releases-created }}
+    name: Upload release npm artifacts
     runs-on: ubuntu-latest
     outputs:
-      stdlib_download_url: ${{ steps.stdlib-upload.outputs.browser_download_url }}
-      js-runner_download_url: ${{ steps.js-runner-upload.outputs.browser_download_url }}
+      stdlib-download-url: ${{ steps.stdlib-upload.outputs.browser_download_url }}
+      js-runner-download-url: ${{ steps.js-runner-upload.outputs.browser_download_url }}
     steps:
       - name: Checkout project
         uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.release-please.outputs.tag-name }}
 
       # Many of these steps are the same as building the compiler for tests
       - name: Setup Node.js
-        uses: actions/setup-node@v3.1.1
+        uses: actions/setup-node@v3.6.0
         with:
           node-version: "16"
           check-latest: true
           cache: "npm"
 
-      - name: Setup environment
-        run: |
-          npm install -g shx
-
-      - name: Set up JS runner and CLI
-        run: |
-          npm ci
-
-      - name: Esy setup
-        run: |
-          npm run compiler prepare
-
-      - name: Esy cache
-        id: esy-cache
-        uses: actions/cache@v2
-        with:
-          path: compiler/_export
-          key: ${{ runner.os }}-esy-${{ hashFiles('compiler/esy.lock/index.json') }}
-
-      - name: Import esy cache
-        if: steps.esy-cache.outputs.cache-hit == 'true'
-        # Don't crash the run if esy cache import fails - mostly happens on Windows
-        continue-on-error: true
-        run: |
-          npm run compiler import-dependencies
-          shx rm -rf compiler/_export
-
-      # Don't build grainc.exe, only the JS builds
-      # TODO(#589): Actually build the exe's these once users can install them locally
-      - name: Build compiler
-        run: |
-          npm run compiler build:js
-
-      # This will log a warning because we removed the grainc.exe file
-      - name: Build Binaries
-        run: |
-          npm run cli build-pkg -- --target=win-x64,mac-x64,linux-x64
-
-      - name: Upload Binary (Windows)
-        uses: grain-lang/upload-release-action@v3.0.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          file: ./pkg/grain-win.exe
-          asset_name: grain-win-x64.exe
-          tag: ${{ needs.release-please.outputs.tag_name }}
-
-      - name: Upload Binary (Mac)
-        uses: grain-lang/upload-release-action@v3.0.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          file: ./pkg/grain-macos
-          asset_name: grain-mac-x64
-          tag: ${{ needs.release-please.outputs.tag_name }}
-
-      - name: Upload Binary (Linux)
-        uses: grain-lang/upload-release-action@v3.0.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          file: ./pkg/grain-linux
-          asset_name: grain-linux-x64
-          tag: ${{ needs.release-please.outputs.tag_name }}
-
       - name: Pack stdlib
-        if: ${{ needs.release-please.outputs.releases_created }}
         working-directory: ./stdlib
         # Runs `npm pack` and assigns the filename to an env var we can use later
         # `sed` is used to workaround https://github.com/npm/cli/issues/3405
@@ -111,16 +111,14 @@ jobs:
 
       - name: Upload stdlib
         id: stdlib-upload
-        if: ${{ needs.release-please.outputs.releases_created }}
         uses: grain-lang/upload-release-action@v3.0.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           file: ./stdlib/${{ env.STDLIB_TAR }}
           asset_name: stdlib.tgz
-          tag: ${{ needs.release-please.outputs.stdlib_tag_name }}
+          tag: ${{ needs.release-please.outputs.stdlib-tag-name }}
 
       - name: Pack js-runner
-        if: ${{ needs.release-please.outputs.releases_created }}
         working-directory: ./js-runner
         # Runs `npm pack` and assigns the filename to an env var we can use later
         # `sed` is used to workaround https://github.com/npm/cli/issues/3405
@@ -129,17 +127,16 @@ jobs:
 
       - name: Upload js-runner
         id: js-runner-upload
-        if: ${{ needs.release-please.outputs.releases_created }}
         uses: grain-lang/upload-release-action@v3.0.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           file: ./js-runner/${{ env.RUNNER_TAR }}
           asset_name: js-runner.tgz
-          tag: ${{ needs.release-please.outputs.js-runner_tag_name }}
+          tag: ${{ needs.release-please.outputs.js-runner-tag-name }}
 
   dispatch-website:
-    needs: [release-please, prepare-artifacts]
-    if: ${{ needs.release-please.outputs.releases_created }}
+    needs: [release-please, upload-release]
+    if: ${{ needs.release-please.outputs.releases-created }}
     name: Dispatch website release
     runs-on: ubuntu-latest
     steps:
@@ -149,11 +146,11 @@ jobs:
           token: ${{ secrets.WORKFLOW_TOKEN }}
           ref: master
           repo: grain-lang/grain-lang.org
-          tag_input: ${{ needs.release-please.outputs.tag_name }}
+          tag_input: ${{ needs.release-please.outputs.tag-name }}
 
   dispatch-homebrew:
-    needs: [release-please, prepare-artifacts]
-    if: ${{ needs.release-please.outputs.releases_created }}
+    needs: [release-please, upload-release]
+    if: ${{ needs.release-please.outputs.releases-created }}
     name: Dispatch homebrew release
     runs-on: ubuntu-latest
     steps:
@@ -163,11 +160,11 @@ jobs:
           token: ${{ secrets.WORKFLOW_TOKEN }}
           ref: main
           repo: grain-lang/homebrew-tap
-          tag_input: ${{ needs.release-please.outputs.tag_name }}
+          tag_input: ${{ needs.release-please.outputs.tag-name }}
 
   dispatch-docker:
-    needs: [release-please, prepare-artifacts]
-    if: ${{ needs.release-please.outputs.releases_created }}
+    needs: [release-please]
+    if: ${{ needs.release-please.outputs.releases-created }}
     name: Dispatch Docker builds
     runs-on: ubuntu-latest
     steps:
@@ -177,40 +174,40 @@ jobs:
           token: ${{ secrets.WORKFLOW_TOKEN }}
           ref: main
           repo: grain-lang/grain
-          tag_input: ${{ needs.release-please.outputs.tag_name }}
+          tag_input: ${{ needs.release-please.outputs.tag-name }}
 
   npm-release-stdlib:
-    needs: [release-please, prepare-artifacts]
-    if: ${{ needs.release-please.outputs.releases_created }}
+    needs: [release-please, upload-npm-artifacts]
+    if: ${{ needs.release-please.outputs.releases-created }}
     name: Publish stdlib to npm registry
     runs-on: ubuntu-latest
     steps:
       - name: Setup NodeJS
-        uses: actions/setup-node@v3.1.1
+        uses: actions/setup-node@v3.6.0
         with:
           node-version: "16"
           registry-url: "https://registry.npmjs.org"
 
       - name: Publish to npm
         run: |
-          npm publish ${{ needs.prepare-artifacts.outputs.stdlib_download_url }}
+          npm publish ${{ needs.upload-npm-artifacts.outputs.stdlib-download-url }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_RELEASE }}
 
   npm-release-js-runner:
-    needs: [release-please, prepare-artifacts]
-    if: ${{ needs.release-please.outputs.releases_created }}
+    needs: [release-please, upload-npm-artifacts]
+    if: ${{ needs.release-please.outputs.releases-created }}
     name: Publish js-runner to npm registry
     runs-on: ubuntu-latest
     steps:
       - name: Setup NodeJS
-        uses: actions/setup-node@v3.1.1
+        uses: actions/setup-node@v3.6.0
         with:
           node-version: "16"
           registry-url: "https://registry.npmjs.org"
 
       - name: Publish to npm
         run: |
-          npm publish ${{ needs.prepare-artifacts.outputs.js-runner_download_url }}
+          npm publish ${{ needs.upload-npm-artifacts.outputs.js-runner-download-url }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_RELEASE }}

--- a/.github/workflows/test-pkg.yml
+++ b/.github/workflows/test-pkg.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       ref:
-        description: "Git reference to checkout"
+        description: Git reference to checkout
         type: string
         required: false
 

--- a/.github/workflows/test-pkg.yml
+++ b/.github/workflows/test-pkg.yml
@@ -1,6 +1,12 @@
 name: Test pkg binaries
 
-on: [workflow_call]
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git reference to checkout"
+        type: string
+        required: false
 
 jobs:
   test-pkg:
@@ -20,6 +26,8 @@ jobs:
     steps:
       - name: Checkout project
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Fetch pkg binary
         uses: actions/download-artifact@v3

--- a/.github/workflows/upload-binaries.yml
+++ b/.github/workflows/upload-binaries.yml
@@ -1,0 +1,83 @@
+# This workflow assumes that pkg binaries were uploaded earlier within the same Action run.
+# It downloads each binary and uploads them to the specified tag.
+# Note: the tag is forcefully overwritten, so use with caution!
+name: Upload binaries
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git reference to checkout"
+        type: string
+        required: false
+      tag:
+        description: "Git tag to attach binaries"
+        type: string
+        required: true
+    secrets:
+      UPLOAD_TOKEN:
+        description: Token used to push back to repository
+        required: true
+
+jobs:
+  upload:
+    name: Upload binaries to ${{ inputs.tag }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup bot user
+        run: |
+          git config --global user.email "bot@grain-lang.org"
+          git config --global user.name "Grain Bot"
+
+      - name: Checkout project
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+          token: ${{ secrets.UPLOAD_TOKEN }}
+
+      - name: Tag commit as ${{ inputs.tag }}
+        run: |
+          git tag ${{ inputs.tag }} -f
+          git push origin ${{ inputs.tag }} -f
+
+      - name: Fetch linux binary
+        uses: actions/download-artifact@v3
+        with:
+          name: grain-linux-x64
+
+      - name: Upload linux binary
+        run: |
+          tar -xvf grain.tar
+          mv grain grain-linux-x64
+          gh release upload ${{ inputs.tag }} "./grain-linux-x64" --clobber
+          rm grain-linux-x64 grain.tar
+        env:
+          GITHUB_TOKEN: ${{ secrets.UPLOAD_TOKEN }}
+
+      - name: Fetch mac binary
+        uses: actions/download-artifact@v3
+        with:
+          name: grain-mac-x64
+
+      - name: Upload mac binary
+        run: |
+          tar -xvf grain.tar
+          mv grain grain-mac-x64
+          gh release upload ${{ inputs.tag }} "./grain-mac-x64" --clobber
+          rm grain-mac-x64 grain.tar
+        env:
+          GITHUB_TOKEN: ${{ secrets.UPLOAD_TOKEN }}
+
+      - name: Fetch win binary
+        uses: actions/download-artifact@v3
+        with:
+          name: grain-win-x64
+
+      - name: Upload win binary
+        run: |
+          tar -xvf grain.tar
+          mv grain.exe grain-win-x64.exe
+          gh release upload ${{ inputs.tag }} "./grain-win-x64.exe" --clobber
+          rm grain-win-x64.exe grain.tar
+        env:
+          GITHUB_TOKEN: ${{ secrets.UPLOAD_TOKEN }}

--- a/.github/workflows/upload-binaries.yml
+++ b/.github/workflows/upload-binaries.yml
@@ -7,11 +7,11 @@ on:
   workflow_call:
     inputs:
       ref:
-        description: "Git reference to checkout"
+        description: Git reference to checkout
         type: string
         required: false
       tag:
-        description: "Git tag to attach binaries"
+        description: Git tag to attach binaries
         type: string
         required: true
     secrets:


### PR DESCRIPTION
This updates the Release workflow to generate "preview" binaries whenever the Release Please updates the release PR. It also uses that binary to regenerate and push the docs on the release branch, which triggers a CI run necessary for us to merge the release in the queue.

I refactored the workflow a bit so we use the same logic to build and upload the binaries with the same workflow. This should allow us to be more confident the release flow will happen successfully since the previews are built often.

I didn't get around to adding workflow_dispatch so we could run these in isolation, which is mostly because we rely on the binary being an artifact of a run. We might need to combine some reusable workflows into a dispatch, but I'm not sure yet.