### PR TITLE
feat: Add A Special Error for includes ending in `.gr`

### DIFF
--- a/compiler/src/typed/module_resolution.re
+++ b/compiler/src/typed/module_resolution.re
@@ -552,8 +552,15 @@ let report_error = ppf =>
         "was not found",
       );
     }
-  | No_module_file(_, m, None) =>
-    fprintf(ppf, "Missing file for module %s", m)
+  | No_module_file(_, m, None) => {
+      let m =
+        if (String.ends_with(~suffix=".gr", m)) {
+          m ++ " did you mean " ++ String.sub(m, 0, String.length(m) - 3);
+        } else {
+          m;
+        };
+      fprintf(ppf, "Missing file for module %s", m);
+    }
   | No_module_file(_, m, Some(msg)) =>
     fprintf(ppf, "Missing file for module %s: %s", m, msg);
 

--- a/compiler/test/suites/includes.re
+++ b/compiler/test/suites/includes.re
@@ -137,6 +137,11 @@ describe("includes", ({test, testSkip}) => {
     "include \"foo\" as Foo; 2",
     "Missing file for module foo",
   );
+  assertCompileError(
+    "include_missing_file_gr",
+    "include \"foo.gr\" as Foo; 2",
+    "Missing file for module foo.gr did you mean foo",
+  );
   /* Unbound module tests */
   assertCompileError(
     "test_unbound_module",


### PR DESCRIPTION
This changes the error when an include is not found and ends with `.gr` to say `Missing file for module foo.gr did you mean foo` otherwise it is left the same in the case of you trying to include a file named `foo.gr.gr` it would not error, This is really just a slight dx improvement.
I think this may be breaking but I am not sure, might be breaking because it changes the behiavour of an error let me know.