### PR TITLE
chore(compiler): Use `String.ends_with` to check last character

### DIFF
--- a/compiler/src/utils/fs_access.re
+++ b/compiler/src/utils/fs_access.re
@@ -11,7 +11,6 @@ let determine_eol = line => {
   switch (line) {
   | Some(line) when String.length(line) > 0 =>
     // check what the last char was
-    // TODO: Replace with `String.ends_with` in OCaml 4.13
     if (String.ends_with(~suffix="\r", line)) {
       CRLF;
     } else {

--- a/compiler/src/utils/fs_access.re
+++ b/compiler/src/utils/fs_access.re
@@ -12,12 +12,11 @@ let determine_eol = line => {
   | Some(line) when String.length(line) > 0 =>
     // check what the last char was
     // TODO: Replace with `String.ends_with` in OCaml 4.13
-    let last_char = line.[String.length(line) - 1];
-    if (last_char == '\r') {
+    if (String.ends_with(~suffix="\r", line)) {
       CRLF;
     } else {
       LF;
-    };
+    }
   | _ =>
     // must use OS default as this file has no newline we can use
     Sys.win32 ? CRLF : LF


### PR DESCRIPTION
This just handles a single `TODO` related to using `String.ends_with` 