### PR TITLE
feat(compiler)!: Make types nonrecursive by default, change mutually recursive group delimiter to `and` from comma

### DIFF
--- a/compiler/src/formatting/format.re
+++ b/compiler/src/formatting/format.re
@@ -4353,6 +4353,11 @@ let rec print_data =
       Doc.concat([
         Doc.text("type"),
         Doc.space,
+        if (data.pdata_rec == Recursive) {
+          Doc.text("rec ");
+        } else {
+          Doc.nil;
+        },
         Doc.text(data.pdata_name.txt),
         Doc.group(
           Doc.concat([
@@ -4597,6 +4602,11 @@ let rec print_data =
       Doc.concat([
         Doc.text("enum"),
         Doc.space,
+        if (data.pdata_rec == Recursive) {
+          Doc.text("rec ");
+        } else {
+          Doc.nil;
+        },
         Doc.text(nameloc.txt),
         switch (data.pdata_params) {
         | [] => Doc.space
@@ -4712,6 +4722,11 @@ let rec print_data =
       Doc.concat([
         Doc.text("record"),
         Doc.space,
+        if (data.pdata_rec == Recursive) {
+          Doc.text("rec ");
+        } else {
+          Doc.nil;
+        },
         Doc.text(nameloc.txt),
         switch (data.pdata_params) {
         | [] => Doc.space
@@ -4768,9 +4783,9 @@ let data_print =
     ) => {
   let previous_data: ref(option(Parsetree.data_declaration)) = ref(None);
   Doc.join(
-    ~sep=Doc.concat([Doc.comma, Doc.hardLine]),
-    List.map(
-      data => {
+    ~sep=Doc.concat([Doc.hardLine]),
+    List.mapi(
+      (i, data) => {
         let (expt, decl: Parsetree.data_declaration) = data;
 
         let leading_comments =
@@ -4797,6 +4812,11 @@ let data_print =
 
         Doc.concat([
           leading_comment_docs,
+          if (i != 0) {
+            Doc.text("and ");
+          } else {
+            Doc.nil;
+          },
           switch ((expt: Asttypes.provide_flag)) {
           | NotProvided => Doc.nil
           | Provided => Doc.text("provide ")

--- a/compiler/src/formatting/format.re
+++ b/compiler/src/formatting/format.re
@@ -4198,110 +4198,136 @@ and print_value_bind =
     | Mutable => Doc.text("mut ")
     };
 
-  let formatted_items =
-    switch (vbs) {
-    | [] => []
-    | [first, ...rem] =>
-      let get_loc = (vb: Parsetree.value_binding) => vb.pvb_loc;
-      let print_item = (~comments, vb: Parsetree.value_binding) => {
-        let after_let_comments =
-          Comment_utils.get_comments_enclosed_and_before_location(
-            ~loc1=get_loc(vb),
-            ~loc2=vb.pvb_pat.ppat_loc,
-            comments,
-          );
-
-        let after_let_comments_docs =
-          switch (after_let_comments) {
-          | [] => Doc.nil
-          | _ =>
-            Comment_utils.inbetween_comments_to_docs(
-              ~offset=false,
-              after_let_comments,
-            )
-          };
-
-        let expr_comments =
-          Comment_utils.get_comments_inside_location(
-            ~location=vb.pvb_expr.pexp_loc,
-            comments,
-          );
-        let printed =
-          print_expression(
-            ~expression_parent=GenericExpression,
-            ~original_source,
-            ~comments=expr_comments,
-            vb.pvb_expr,
-          );
-
-        let expression =
-          switch (vb.pvb_expr.pexp_desc) {
-          | PExpIf(_) =>
-            if (Doc.willBreak(printed)) {
-              Doc.concat([Doc.space, printed]);
-            } else {
-              Doc.indent(Doc.concat([Doc.line, printed]));
-            }
-          | _ => Doc.concat([Doc.space, printed])
-          };
-
-        let pattern_comments =
-          Comment_utils.get_comments_enclosed_and_before_location(
-            ~loc1=vb.pvb_loc,
-            ~loc2=vb.pvb_expr.pexp_loc,
-            comments,
-          );
-
-        Doc.concat([
-          Doc.group(
-            print_pattern(
-              ~original_source,
-              ~comments=pattern_comments,
-              ~next_loc=vb.pvb_loc,
-              vb.pvb_pat,
-            ),
-          ),
-          after_let_comments_docs,
-          switch (after_let_comments) {
-          | [] => Doc.space
-          | _ => Doc.nil
-          },
-          Doc.equal,
-          expression,
-        ]);
-      };
-
-      item_iterator(
-        ~get_loc,
-        ~print_item,
-        ~comments,
-        ~iterated_item=IteratedValueBindings,
-        vbs,
-      );
-    };
-
   let value_bindings =
-    List.mapi(
-      (index, doc) => {
-        let item =
-          if (index > 0) {
-            Doc.concat([Doc.line, doc]);
-          } else {
-            doc;
-          };
-        let vb = List.nth(vbs, index);
-        switch (vb.pvb_expr.pexp_desc) {
-        | PExpLambda(fn, _) => item
+    switch (vbs) {
+    | [] => Doc.nil
+    | [first, ...rem] =>
+      let leading_comments =
+        Comment_utils.get_comments_before_location(
+          ~location=first.pvb_loc,
+          comments,
+        );
+      let leading_comments_docs =
+        switch (leading_comments) {
+        | [] => Doc.nil
         | _ =>
-          if (index > 0) {
-            Doc.indent(item);
-          } else {
-            item;
-          }
+          Doc.group(
+            Doc.concat([
+              Comment_utils.new_comments_to_docs(leading_comments),
+              Doc.ifBreaks(Doc.nil, Doc.space),
+            ]),
+          )
         };
-      },
-      formatted_items,
-    );
+
+      let previous_bind: ref(option(Parsetree.value_binding)) = ref(None);
+      let docs =
+        Doc.join(
+          ~sep=Doc.concat([Doc.hardLine]),
+          List.mapi(
+            (i, vb: Parsetree.value_binding) => {
+              let leading_comments =
+                switch (previous_bind^) {
+                | None => []
+                | Some(prev) =>
+                  Comment_utils.get_comments_between_locations(
+                    ~loc1=prev.pvb_loc,
+                    ~loc2=vb.pvb_loc,
+                    comments,
+                  )
+                };
+
+              let leading_comment_docs =
+                switch (leading_comments) {
+                | [] => Doc.nil
+                | _ =>
+                  Doc.group(
+                    Doc.concat([
+                      Comment_utils.new_comments_to_docs(leading_comments),
+                      Doc.ifBreaks(Doc.nil, Doc.space),
+                    ]),
+                  )
+                };
+
+              let after_let_comments =
+                Comment_utils.get_comments_enclosed_and_before_location(
+                  ~loc1=vb.pvb_loc,
+                  ~loc2=vb.pvb_pat.ppat_loc,
+                  comments,
+                );
+
+              let after_let_comments_docs =
+                switch (after_let_comments) {
+                | [] => Doc.nil
+                | _ =>
+                  Comment_utils.inbetween_comments_to_docs(
+                    ~offset=false,
+                    after_let_comments,
+                  )
+                };
+
+              let expr_comments =
+                Comment_utils.get_comments_inside_location(
+                  ~location=vb.pvb_expr.pexp_loc,
+                  comments,
+                );
+              let printed =
+                print_expression(
+                  ~expression_parent=GenericExpression,
+                  ~original_source,
+                  ~comments=expr_comments,
+                  vb.pvb_expr,
+                );
+
+              let expression =
+                switch (vb.pvb_expr.pexp_desc) {
+                | PExpIf(_) =>
+                  if (Doc.willBreak(printed)) {
+                    Doc.concat([Doc.space, printed]);
+                  } else {
+                    Doc.indent(Doc.concat([Doc.line, printed]));
+                  }
+                | _ => Doc.concat([Doc.space, printed])
+                };
+
+              let pattern_comments =
+                Comment_utils.get_comments_enclosed_and_before_location(
+                  ~loc1=vb.pvb_loc,
+                  ~loc2=vb.pvb_expr.pexp_loc,
+                  comments,
+                );
+
+              previous_bind := Some(vb);
+
+              Doc.concat([
+                leading_comment_docs,
+                if (i != 0) {
+                  Doc.text("and ");
+                } else {
+                  Doc.nil;
+                },
+                Doc.group(
+                  print_pattern(
+                    ~original_source,
+                    ~comments=pattern_comments,
+                    ~next_loc=vb.pvb_loc,
+                    vb.pvb_pat,
+                  ),
+                ),
+                after_let_comments_docs,
+                switch (after_let_comments) {
+                | [] => Doc.space
+                | _ => Doc.nil
+                },
+                Doc.equal,
+                expression,
+              ]);
+            },
+            vbs,
+          ),
+        );
+
+      Doc.concat([leading_comments_docs, docs]);
+    };
 
   Doc.group(
     Doc.concat([
@@ -4310,7 +4336,7 @@ and print_value_bind =
       Doc.space,
       recursive,
       mutble,
-      Doc.concat(value_bindings),
+      value_bindings,
     ]),
   );
 };
@@ -4427,6 +4453,11 @@ let rec print_data =
       Doc.concat([
         Doc.text("type"),
         Doc.space,
+        if (data.pdata_rec == Recursive) {
+          Doc.text("rec ");
+        } else {
+          Doc.nil;
+        },
         Doc.group(Doc.concat([Doc.text(data.pdata_name.txt), ...params])),
         switch (data.pdata_manifest) {
         | Some(manifest) =>

--- a/compiler/src/parsing/ast_helper.re
+++ b/compiler/src/parsing/ast_helper.re
@@ -141,10 +141,10 @@ module LabelDeclaration = {
 };
 
 module DataDeclaration = {
-  let mk = (~loc=?, r, n, t, k, m) => {
+  let mk = (~loc=?, ~rec_flag=Nonrecursive, n, t, k, m) => {
     let loc = Option.value(~default=Location.dummy_loc, loc);
     {
-      pdata_rec: r,
+      pdata_rec: rec_flag,
       pdata_name: n,
       pdata_params: t,
       pdata_kind: k,
@@ -152,12 +152,12 @@ module DataDeclaration = {
       pdata_loc: loc,
     };
   };
-  let abstract = (~loc=?, r, n, t, m) =>
-    mk(~loc?, r, n, t, PDataAbstract, m);
-  let variant = (~loc=?, r, n, t, cdl) =>
-    mk(~loc?, r, n, t, PDataVariant(cdl), None);
-  let record = (~loc=?, r, n, t, ldl) =>
-    mk(~loc?, r, n, t, PDataRecord(ldl), None);
+  let abstract = (~loc=?, ~rec_flag=?, n, t, m) =>
+    mk(~loc?, ~rec_flag?, n, t, PDataAbstract, m);
+  let variant = (~loc=?, ~rec_flag=?, n, t, cdl) =>
+    mk(~loc?, ~rec_flag?, n, t, PDataVariant(cdl), None);
+  let record = (~loc=?, ~rec_flag=?, n, t, ldl) =>
+    mk(~loc?, ~rec_flag?, n, t, PDataRecord(ldl), None);
 };
 
 module Exception = {

--- a/compiler/src/parsing/ast_helper.re
+++ b/compiler/src/parsing/ast_helper.re
@@ -141,9 +141,10 @@ module LabelDeclaration = {
 };
 
 module DataDeclaration = {
-  let mk = (~loc=?, n, t, k, m) => {
+  let mk = (~loc=?, r, n, t, k, m) => {
     let loc = Option.value(~default=Location.dummy_loc, loc);
     {
+      pdata_rec: r,
       pdata_name: n,
       pdata_params: t,
       pdata_kind: k,
@@ -151,11 +152,12 @@ module DataDeclaration = {
       pdata_loc: loc,
     };
   };
-  let abstract = (~loc=?, n, t, m) => mk(~loc?, n, t, PDataAbstract, m);
-  let variant = (~loc=?, n, t, cdl) =>
-    mk(~loc?, n, t, PDataVariant(cdl), None);
-  let record = (~loc=?, n, t, ldl) =>
-    mk(~loc?, n, t, PDataRecord(ldl), None);
+  let abstract = (~loc=?, r, n, t, m) =>
+    mk(~loc?, r, n, t, PDataAbstract, m);
+  let variant = (~loc=?, r, n, t, cdl) =>
+    mk(~loc?, r, n, t, PDataVariant(cdl), None);
+  let record = (~loc=?, r, n, t, ldl) =>
+    mk(~loc?, r, n, t, PDataRecord(ldl), None);
 };
 
 module Exception = {

--- a/compiler/src/parsing/ast_helper.rei
+++ b/compiler/src/parsing/ast_helper.rei
@@ -90,7 +90,7 @@ module DataDeclaration: {
   let mk:
     (
       ~loc: loc=?,
-      rec_flag,
+      ~rec_flag: rec_flag=?,
       str,
       list(parsed_type),
       data_kind,
@@ -98,12 +98,18 @@ module DataDeclaration: {
     ) =>
     data_declaration;
   let abstract:
-    (~loc: loc=?, rec_flag, str, list(parsed_type), option(parsed_type)) =>
+    (
+      ~loc: loc=?,
+      ~rec_flag: rec_flag=?,
+      str,
+      list(parsed_type),
+      option(parsed_type)
+    ) =>
     data_declaration;
   let variant:
     (
       ~loc: loc=?,
-      rec_flag,
+      ~rec_flag: rec_flag=?,
       str,
       list(parsed_type),
       list(constructor_declaration)
@@ -112,7 +118,7 @@ module DataDeclaration: {
   let record:
     (
       ~loc: loc=?,
-      rec_flag,
+      ~rec_flag: rec_flag=?,
       str,
       list(parsed_type),
       list(label_declaration)

--- a/compiler/src/parsing/ast_helper.rei
+++ b/compiler/src/parsing/ast_helper.rei
@@ -88,16 +88,35 @@ module LabelDeclaration: {
 
 module DataDeclaration: {
   let mk:
-    (~loc: loc=?, str, list(parsed_type), data_kind, option(parsed_type)) =>
+    (
+      ~loc: loc=?,
+      rec_flag,
+      str,
+      list(parsed_type),
+      data_kind,
+      option(parsed_type)
+    ) =>
     data_declaration;
   let abstract:
-    (~loc: loc=?, str, list(parsed_type), option(parsed_type)) =>
+    (~loc: loc=?, rec_flag, str, list(parsed_type), option(parsed_type)) =>
     data_declaration;
   let variant:
-    (~loc: loc=?, str, list(parsed_type), list(constructor_declaration)) =>
+    (
+      ~loc: loc=?,
+      rec_flag,
+      str,
+      list(parsed_type),
+      list(constructor_declaration)
+    ) =>
     data_declaration;
   let record:
-    (~loc: loc=?, str, list(parsed_type), list(label_declaration)) =>
+    (
+      ~loc: loc=?,
+      rec_flag,
+      str,
+      list(parsed_type),
+      list(label_declaration)
+    ) =>
     data_declaration;
 };
 

--- a/compiler/src/parsing/ast_mapper.re
+++ b/compiler/src/parsing/ast_mapper.re
@@ -316,17 +316,17 @@ module D = {
     let sargs = List.map(sub.typ(sub), args);
     let sman = Option.map(sub.typ(sub), man);
     switch (kind) {
-    | PDataAbstract => abstract(~loc, rec_flag, sname, sargs, sman)
+    | PDataAbstract => abstract(~loc, ~rec_flag, sname, sargs, sman)
     | PDataVariant(cdl) =>
       variant(
         ~loc,
-        rec_flag,
+        ~rec_flag,
         sname,
         sargs,
         List.map(sub.constructor(sub), cdl),
       )
     | PDataRecord(ldl) =>
-      record(~loc, rec_flag, sname, sargs, List.map(sub.label(sub), ldl))
+      record(~loc, ~rec_flag, sname, sargs, List.map(sub.label(sub), ldl))
     };
   };
 };

--- a/compiler/src/parsing/ast_mapper.re
+++ b/compiler/src/parsing/ast_mapper.re
@@ -302,6 +302,7 @@ module D = {
       (
         sub,
         {
+          pdata_rec: rec_flag,
           pdata_name: name,
           pdata_params: args,
           pdata_kind: kind,
@@ -315,11 +316,17 @@ module D = {
     let sargs = List.map(sub.typ(sub), args);
     let sman = Option.map(sub.typ(sub), man);
     switch (kind) {
-    | PDataAbstract => abstract(~loc, sname, sargs, sman)
+    | PDataAbstract => abstract(~loc, rec_flag, sname, sargs, sman)
     | PDataVariant(cdl) =>
-      variant(~loc, sname, sargs, List.map(sub.constructor(sub), cdl))
+      variant(
+        ~loc,
+        rec_flag,
+        sname,
+        sargs,
+        List.map(sub.constructor(sub), cdl),
+      )
     | PDataRecord(ldl) =>
-      record(~loc, sname, sargs, List.map(sub.label(sub), ldl))
+      record(~loc, rec_flag, sname, sargs, List.map(sub.label(sub), ldl))
     };
   };
 };

--- a/compiler/src/parsing/lexer.re
+++ b/compiler/src/parsing/lexer.re
@@ -337,6 +337,7 @@ let rec token = lexbuf => {
   | "," => positioned(COMMA)
   | ";" => positioned(SEMI)
   | "as" => positioned(AS)
+  | "and" => positioned(AND)
   | "(" => positioned(LPAREN)
   | ")" => positioned(RPAREN)
   | "{" => positioned(LBRACE)

--- a/compiler/src/parsing/parser.messages
+++ b/compiler/src/parsing/parser.messages
@@ -4465,22 +4465,14 @@ program: MODULE UIDENT EOL LET UIDENT LPAREN WHILE
 
 Expected a comma-separated list of patterns.
 
-program: MODULE UIDENT EOL LET WASMI64 EQUAL WASMI64 COMMA EOL WHILE
+program: MODULE UIDENT EOL LET NUMBER_INT EQUAL UIDENT AND YIELD
 ##
-## Ends in an error in state: 433.
+## Ends in an error in state: 423.
 ##
-## lseparated_nonempty_list_inner(comma,value_bind) -> lseparated_nonempty_list_inner(comma,value_bind) comma . value_bind [ SEMI RBRACE EOL EOF COMMA ]
+## lseparated_nonempty_list_inner(AND,value_bind) -> lseparated_nonempty_list_inner(AND,value_bind) AND . value_bind [ SEMI RBRACE EOL EOF AND ]
 ##
 ## The known suffix of the stack is as follows:
-## lseparated_nonempty_list_inner(comma,value_bind) comma
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
-## In state 5, spurious reduction of production eols -> nonempty_list(eol)
-## In state 96, spurious reduction of production comma -> COMMA eols
+## lseparated_nonempty_list_inner(AND,value_bind) AND
 ##
 
 Expected a binding, e.g. `foo = 5`.

--- a/compiler/src/parsing/parser.messages
+++ b/compiler/src/parsing/parser.messages
@@ -790,34 +790,38 @@ program: MODULE UIDENT EOL ENUM UIDENT LBRACE UIDENT LPAREN WHILE
 
 Expected one or more types to complete the variant definition.
 
-program: MODULE UIDENT EOL ENUM UIDENT LBRACE UIDENT RBRACE COMMA EOL WHILE
+program: MODULE UIDENT EOL TYPE UIDENT EQUAL UIDENT AND YIELD
 ##
-## Ends in an error in state: 986.
+## Ends in an error in state: 860.
 ##
-## separated_nonempty_list(comma,data_declaration_stmt) -> data_declaration_stmt comma . separated_nonempty_list(comma,data_declaration_stmt) [ SEMI EOL EOF ]
+## separated_nonempty_list(AND,data_declaration_stmt) -> data_declaration_stmt AND . separated_nonempty_list(AND,data_declaration_stmt) [ SEMI RBRACE EOL EOF ]
 ##
 ## The known suffix of the stack is as follows:
-## data_declaration_stmt comma
+## data_declaration_stmt AND
 ##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
-## In state 5, spurious reduction of production eols -> nonempty_list(eol)
-## In state 96, spurious reduction of production comma -> COMMA eols
+program: MODULE UIDENT EOL TYPE UIDENT EQUAL UIDENT AND PROVIDE YIELD
 ##
-program: MODULE UIDENT EOL ENUM UIDENT LBRACE UIDENT RBRACE COMMA PROVIDE WHILE
+## Ends in an error in state: 861.
 ##
-## Ends in an error in state: 987.
-##
-## data_declaration_stmt -> PROVIDE . data_declaration [ SEMI EOL EOF COMMA ]
+## data_declaration_stmt -> PROVIDE . data_declaration [ SEMI RBRACE EOL EOF AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## PROVIDE
 ##
 
-Mutually recursive type declarations are separated by commas, but cannot be mixed with other kinds of expressions.
+Mutually recursive type declarations are separated by `and`, but cannot be mixed with other kinds of expressions.
+
+program: MODULE UIDENT EOL TYPE REC YIELD
+##
+## Ends in an error in state: 743.
+##
+## data_declaration -> TYPE option(REC) . UIDENT option(id_vec) equal typ [ SEMI RBRACE EOL EOF AND ]
+##
+## The known suffix of the stack is as follows:
+## TYPE option(REC)
+##
+
+Expected a capitalized type name.
 
 program: MODULE UIDENT EOL ENUM UIDENT LBRACE UIDENT WHILE
 ##
@@ -861,7 +865,7 @@ program: MODULE UIDENT EOL ENUM UIDENT LBRACE UIDENT RBRACE WHILE
 ## data_declaration_stmt
 ##
 
-Expected a comma followed by more mutually-recursive type declarations or a newline character to complete the current one.
+Expected `and` followed by more mutually-recursive type declarations or a newline character to complete the current one.
 
 program: MODULE UIDENT EOL ENUM UIDENT LCARET LIDENT RCARET INFIX_80
 ##
@@ -907,6 +911,18 @@ program: MODULE UIDENT EOL ENUM WHILE
 ##
 ## The known suffix of the stack is as follows:
 ## ENUM
+##
+
+Expected `rec` or a capitalized name for the enum declaration.
+
+program: MODULE UIDENT EOL ENUM REC YIELD
+##
+## Ends in an error in state: 804.
+##
+## data_declaration -> ENUM option(REC) . UIDENT option(id_vec) data_constructors [ SEMI RBRACE EOL EOF AND ]
+##
+## The known suffix of the stack is as follows:
+## ENUM option(REC)
 ##
 
 Expected a capitalized name for the enum declaration.
@@ -5139,6 +5155,18 @@ program: MODULE UIDENT EOL RECORD WHILE
 ##
 ## The known suffix of the stack is as follows:
 ## RECORD
+##
+
+Expected `rec` or a capitalized identifier for the record type.
+
+program: MODULE UIDENT EOL RECORD REC YIELD
+##
+## Ends in an error in state: 758.
+##
+## data_declaration -> RECORD option(REC) . UIDENT option(id_vec) data_labels [ SEMI RBRACE EOL EOF AND ]
+##
+## The known suffix of the stack is as follows:
+## RECORD option(REC)
 ##
 
 Expected a capitalized identifier for the record type.

--- a/compiler/src/parsing/parser.mly
+++ b/compiler/src/parsing/parser.mly
@@ -411,9 +411,9 @@ id_vec:
   | lcaret lseparated_nonempty_list(comma, id_typ) comma? rcaret {$2}
 
 data_declaration:
-  | TYPE UIDENT id_vec? equal typ { DataDeclaration.abstract ~loc:(to_loc $loc) (mkstr $loc($2) $2) (Option.value ~default:[] $3) (Some $5) }
-  | ENUM UIDENT id_vec? data_constructors { DataDeclaration.variant ~loc:(to_loc $loc) (mkstr $loc($2) $2) (Option.value ~default:[] $3) $4 }
-  | RECORD UIDENT id_vec? data_record_body { DataDeclaration.record ~loc:(to_loc $loc) (mkstr $loc($2) $2) (Option.value ~default:[] $3) $4 }
+  | TYPE REC? UIDENT id_vec? equal typ { DataDeclaration.abstract ~loc:(to_loc $loc) (if Option.is_some $2 then Recursive else Nonrecursive) (mkstr $loc($3) $3) (Option.value ~default:[] $4) (Some $6) }
+  | ENUM REC? UIDENT id_vec? data_constructors { DataDeclaration.variant ~loc:(to_loc $loc) (if Option.is_some $2 then Recursive else Nonrecursive) (mkstr $loc($3) $3) (Option.value ~default:[] $4) $5 }
+  | RECORD REC? UIDENT id_vec? data_record_body { DataDeclaration.record ~loc:(to_loc $loc) (if Option.is_some $2 then Recursive else Nonrecursive) (mkstr $loc($3) $3) (Option.value ~default:[] $4) $5 }
 
 unop_expr:
   | prefix_op non_assign_expr { Expression.apply ~loc:(to_loc $loc) (mkid_expr $loc($1) [mkstr $loc($1) $1]) [{paa_label=Unlabeled; paa_expr=$2; paa_loc=(to_loc $loc($2))}] }

--- a/compiler/src/parsing/parser.mly
+++ b/compiler/src/parsing/parser.mly
@@ -38,6 +38,7 @@ module Grain_parsing = struct end
 %token <string> INFIX_ASSIGNMENT_10
 
 %token ENUM RECORD TYPE MODULE INCLUDE USE PROVIDE ABSTRACT FOREIGN WASM PRIMITIVE
+%token AND
 %token EXCEPT FROM STAR
 %token SLASH DASH PIPE
 %token EOL EOF
@@ -362,7 +363,7 @@ data_declaration_stmt:
   | data_declaration { (NotProvided, $1) }
 
 data_declaration_stmts:
-  | separated_nonempty_list(comma, data_declaration_stmt) { $1 }
+  | separated_nonempty_list(AND, data_declaration_stmt) { $1 }
 
 provide_item:
   | TYPE aliasable(uid) { PProvideType { name=fst $2; alias = snd $2; loc=to_loc $loc} }

--- a/compiler/src/parsing/parser.mly
+++ b/compiler/src/parsing/parser.mly
@@ -411,10 +411,13 @@ id_typ:
 id_vec:
   | lcaret lseparated_nonempty_list(comma, id_typ) comma? rcaret {$2}
 
+rec_flag:
+  | REC { Recursive }
+
 data_declaration:
-  | TYPE REC? UIDENT id_vec? equal typ { DataDeclaration.abstract ~loc:(to_loc $loc) (if Option.is_some $2 then Recursive else Nonrecursive) (mkstr $loc($3) $3) (Option.value ~default:[] $4) (Some $6) }
-  | ENUM REC? UIDENT id_vec? data_constructors { DataDeclaration.variant ~loc:(to_loc $loc) (if Option.is_some $2 then Recursive else Nonrecursive) (mkstr $loc($3) $3) (Option.value ~default:[] $4) $5 }
-  | RECORD REC? UIDENT id_vec? data_record_body { DataDeclaration.record ~loc:(to_loc $loc) (if Option.is_some $2 then Recursive else Nonrecursive) (mkstr $loc($3) $3) (Option.value ~default:[] $4) $5 }
+  | TYPE rec_flag? UIDENT id_vec? equal typ { DataDeclaration.abstract ~loc:(to_loc $loc) ?rec_flag:$2 (mkstr $loc($3) $3) (Option.value ~default:[] $4) (Some $6) }
+  | ENUM rec_flag? UIDENT id_vec? data_constructors { DataDeclaration.variant ~loc:(to_loc $loc) ?rec_flag:$2 (mkstr $loc($3) $3) (Option.value ~default:[] $4) $5 }
+  | RECORD rec_flag? UIDENT id_vec? data_record_body { DataDeclaration.record ~loc:(to_loc $loc) ?rec_flag:$2 (mkstr $loc($3) $3) (Option.value ~default:[] $4) $5 }
 
 unop_expr:
   | prefix_op non_assign_expr { Expression.apply ~loc:(to_loc $loc) (mkid_expr $loc($1) [mkstr $loc($1) $1]) [{paa_label=Unlabeled; paa_expr=$2; paa_loc=(to_loc $loc($2))}] }

--- a/compiler/src/parsing/parser.mly
+++ b/compiler/src/parsing/parser.mly
@@ -328,7 +328,7 @@ value_bind:
   | pattern equal expr { ValueBinding.mk ~loc:(to_loc $loc) $1 $3 }
 
 value_binds:
-  | lseparated_nonempty_list(comma, value_bind) { $1 }
+  | lseparated_nonempty_list(AND, value_bind) { $1 }
 
 as_prefix(X):
   | AS opt_eols X {$3}

--- a/compiler/src/parsing/parsetree.re
+++ b/compiler/src/parsing/parsetree.re
@@ -116,6 +116,7 @@ type data_declaration = {
   pdata_params: list(parsed_type),
   pdata_kind: data_kind,
   pdata_manifest: option(parsed_type),
+  pdata_rec: rec_flag,
   [@sexp_drop_if sexp_locs_disabled]
   pdata_loc: Location.t,
 };

--- a/compiler/src/parsing/well_formedness.re
+++ b/compiler/src/parsing/well_formedness.re
@@ -19,7 +19,9 @@ type wferr =
   | ReturnStatementOutsideFunction(Location.t)
   | MismatchedReturnStyles(Location.t)
   | LocalIncludeStatement(Location.t)
-  | ProvidedMultipleTimes(string, Location.t);
+  | ProvidedMultipleTimes(string, Location.t)
+  | MutualRecTypesMissingRec(Location.t)
+  | MutualRecExtraneousNonfirstRec(Location.t);
 
 exception Error(wferr);
 
@@ -91,6 +93,16 @@ let prepare_error =
           ~loc,
           "%s was provided multiple times, but can only be provided once.",
           name,
+        )
+      | MutualRecTypesMissingRec(loc) =>
+        errorf(
+          ~loc,
+          "Mutually recursive type groups must include `rec` on the first type in the group.",
+        )
+      | MutualRecExtraneousNonfirstRec(loc) =>
+        errorf(
+          ~loc,
+          "The `rec` keyword should only appear on the first type in the mutually recursive type group.",
         )
     )
   );
@@ -773,6 +785,37 @@ let provided_multiple_times = (errs, super) => {
   };
 };
 
+let mutual_rec_type_improper_rec_keyword = (errs, super) => {
+  let enter_toplevel_stmt = ({ptop_desc: desc, ptop_loc: loc} as e) => {
+    switch (desc) {
+    | PTopData([(_, first_decl), ...[_, ..._] as rest_decls]) =>
+      if (first_decl.pdata_rec != Recursive) {
+        errs := [MutualRecTypesMissingRec(loc), ...errs^];
+      } else {
+        List.iter(
+          ((_, decl)) =>
+            switch (decl) {
+            | {pdata_rec: Recursive} =>
+              errs := [MutualRecExtraneousNonfirstRec(loc), ...errs^]
+            | _ => ()
+            },
+          rest_decls,
+        );
+      }
+    | _ => ()
+    };
+    super.enter_toplevel_stmt(e);
+  };
+
+  {
+    errs,
+    iter_hooks: {
+      ...super,
+      enter_toplevel_stmt,
+    },
+  };
+};
+
 let compose_well_formedness = ({errs, iter_hooks}, cur) =>
   cur(errs, iter_hooks);
 
@@ -789,6 +832,7 @@ let well_formedness_checks = [
   malformed_return_statements,
   no_local_include,
   provided_multiple_times,
+  mutual_rec_type_improper_rec_keyword,
 ];
 
 let well_formedness_checker = () =>

--- a/compiler/src/parsing/well_formedness.re
+++ b/compiler/src/parsing/well_formedness.re
@@ -20,7 +20,8 @@ type wferr =
   | MismatchedReturnStyles(Location.t)
   | LocalIncludeStatement(Location.t)
   | ProvidedMultipleTimes(string, Location.t)
-  | MutualRecTypesWithRec(Location.t);
+  | MutualRecTypesMissingRec(Location.t)
+  | MutualRecExtraneousNonfirstRec(Location.t);
 
 exception Error(wferr);
 
@@ -93,10 +94,15 @@ let prepare_error =
           "%s was provided multiple times, but can only be provided once.",
           name,
         )
-      | MutualRecTypesWithRec(loc) =>
+      | MutualRecTypesMissingRec(loc) =>
         errorf(
           ~loc,
-          "Types in a mutually recursive type group are already self-recursive so `rec` should be removed.",
+          "Mutually recursive type groups must include `rec` on the first type in the group.",
+        )
+      | MutualRecExtraneousNonfirstRec(loc) =>
+        errorf(
+          ~loc,
+          "The `rec` keyword should only appear on the first type in the mutually recursive type group.",
         )
     )
   );
@@ -782,16 +788,20 @@ let provided_multiple_times = (errs, super) => {
 let mutual_rec_type_improper_rec_keyword = (errs, super) => {
   let enter_toplevel_stmt = ({ptop_desc: desc, ptop_loc: loc} as e) => {
     switch (desc) {
-    | PTopData(decls) when List.length(decls) >= 2 =>
-      List.iter(
-        ((_, decl)) =>
-          switch (decl) {
-          | {pdata_rec: Recursive} =>
-            errs := [MutualRecTypesWithRec(loc), ...errs^]
-          | _ => ()
-          },
-        decls,
-      )
+    | PTopData([(_, first_decl), ...[_, ..._] as rest_decls]) =>
+      if (first_decl.pdata_rec != Recursive) {
+        errs := [MutualRecTypesMissingRec(loc), ...errs^];
+      } else {
+        List.iter(
+          ((_, decl)) =>
+            switch (decl) {
+            | {pdata_rec: Recursive} =>
+              errs := [MutualRecExtraneousNonfirstRec(loc), ...errs^]
+            | _ => ()
+            },
+          rest_decls,
+        );
+      }
     | _ => ()
     };
     super.enter_toplevel_stmt(e);

--- a/compiler/src/parsing/wrapped_lexer.re
+++ b/compiler/src/parsing/wrapped_lexer.re
@@ -316,7 +316,7 @@ let token = state => {
 };
 
 let token = state => {
-  // if-else and or-patterns hack
+  // if-else, or-patterns, and `and` hack
   let (tok, _, _) as triple = token(state);
   if (tok == EOL) {
     let fst = ((a, _, _)) => a;
@@ -328,6 +328,7 @@ let token = state => {
     };
 
     switch (fst(next_triple^)) {
+    | AND
     | ELSE
     | PIPE => next_triple^
     | _ =>

--- a/compiler/src/typed/typemod.re
+++ b/compiler/src/typed/typemod.re
@@ -50,7 +50,8 @@ type error =
   | Scoping_pack(Identifier.t, type_expr)
   | Recursive_module_require_explicit_type
   | Apply_generative
-  | Cannot_scrape_alias(Path.t);
+  | Cannot_scrape_alias(Path.t)
+  | Nonrecursive_type_with_recursion(Identifier.t);
 
 exception Error(Location.t, Env.t, error);
 exception Error_forward(Location.error);
@@ -393,11 +394,35 @@ let rec type_module = (~toplevel=false, anchor, env, statements) => {
   };
 
   let process_datas = (env, data_decls, attributes, loc) => {
+    // A well-formedness check would have detected issues with improper use of
+    // `rec` on mutually-recursive types
+    let rec_flag =
+      switch (data_decls) {
+      | [(_, {pdata_rec: Recursive}), ..._] => Recursive
+      | _ => Nonrecursive
+      };
     let (decls, newenv) =
-      Typedecl.transl_data_decl(env, Recursive, data_decls);
+      try(Typedecl.transl_data_decl(env, rec_flag, data_decls)) {
+      | Typetexp.Error(_, _, Typetexp.Unbound_type_constructor(_)) =>
+        // Hack to detect if `rec` should be included on this type: if it does
+        // not raise an exception in `Recursive` mode but does otherwise,
+        // suggest that `rec` be used
+        switch (Typedecl.transl_data_decl(env, Recursive, data_decls)) {
+        | exception exn => raise(exn)
+        | _ =>
+          let (_, {pdata_name: type_name}) = List.hd(data_decls);
+          raise(
+            Error(
+              loc,
+              env,
+              Nonrecursive_type_with_recursion(IdentName(type_name)),
+            ),
+          );
+        }
+      };
     let ty_decls =
       map2_rec_type_with_row_types(
-        ~rec_flag=Recursive,
+        ~rec_flag,
         (rs, info, e) => {
           switch (e) {
           | NotProvided => None
@@ -1180,7 +1205,14 @@ let report_error = ppf =>
   | Apply_generative =>
     fprintf(ppf, "This is a generative functor. It can only be applied to ()")
   | Cannot_scrape_alias(p) =>
-    fprintf(ppf, "This is an alias for module %a, which is missing", path, p);
+    fprintf(ppf, "This is an alias for module %a, which is missing", path, p)
+  | Nonrecursive_type_with_recursion(lid) =>
+    fprintf(
+      ppf,
+      "Unbound type constructor %a. Hint: you are probably missing the `rec` keyword on this type",
+      identifier,
+      lid,
+    );
 
 let report_error = (env, ppf, err) =>
   Printtyp.wrap_printing_env(~error=true, env, () => report_error(ppf, err));

--- a/compiler/src/typed/typemod.re
+++ b/compiler/src/typed/typemod.re
@@ -394,10 +394,11 @@ let rec type_module = (~toplevel=false, anchor, env, statements) => {
   };
 
   let process_datas = (env, data_decls, attributes, loc) => {
+    // A well-formedness check would have detected issues with improper use of
+    // `rec` on mutually-recursive types
     let rec_flag =
       switch (data_decls) {
-      | [(_, {pdata_rec: Recursive})] => Recursive
-      | decls when List.length(decls) >= 2 => Recursive
+      | [(_, {pdata_rec: Recursive}), ..._] => Recursive
       | _ => Nonrecursive
       };
     let (decls, newenv) =

--- a/compiler/src/typed/typemod.re
+++ b/compiler/src/typed/typemod.re
@@ -394,11 +394,10 @@ let rec type_module = (~toplevel=false, anchor, env, statements) => {
   };
 
   let process_datas = (env, data_decls, attributes, loc) => {
-    // A well-formedness check would have detected issues with improper use of
-    // `rec` on mutually-recursive types
     let rec_flag =
       switch (data_decls) {
-      | [(_, {pdata_rec: Recursive}), ..._] => Recursive
+      | [(_, {pdata_rec: Recursive})] => Recursive
+      | decls when List.length(decls) >= 2 => Recursive
       | _ => Nonrecursive
       };
     let (decls, newenv) =

--- a/compiler/src/typed/typemod.re
+++ b/compiler/src/typed/typemod.re
@@ -1209,7 +1209,7 @@ let report_error = ppf =>
   | Nonrecursive_type_with_recursion(lid) =>
     fprintf(
       ppf,
-      "Unbound type constructor %a. Hint: you are probably missing the `rec` keyword on this type",
+      "Unbound type constructor %a. Are you missing the `rec` keyword on this type?",
       identifier,
       lid,
     );

--- a/compiler/src/typed/typemod.rei
+++ b/compiler/src/typed/typemod.rei
@@ -28,7 +28,8 @@ type error =
   | Scoping_pack(Identifier.t, type_expr)
   | Recursive_module_require_explicit_type
   | Apply_generative
-  | Cannot_scrape_alias(Path.t);
+  | Cannot_scrape_alias(Path.t)
+  | Nonrecursive_type_with_recursion(Identifier.t);
 
 exception Error(Location.t, Env.t, error);
 exception Error_forward(Location.error);

--- a/compiler/test/__snapshots__/records.02af5946.0.snapshot
+++ b/compiler/test/__snapshots__/records.02af5946.0.snapshot
@@ -59,5 +59,5 @@ records › record_definition_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1220
+ ;; custom section \"cmi\", size 1218
 )

--- a/compiler/test/__snapshots__/records.2dc39420.0.snapshot
+++ b/compiler/test/__snapshots__/records.2dc39420.0.snapshot
@@ -59,5 +59,5 @@ records › record_pun
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1156
+ ;; custom section \"cmi\", size 1154
 )

--- a/compiler/test/__snapshots__/records.5f340064.0.snapshot
+++ b/compiler/test/__snapshots__/records.5f340064.0.snapshot
@@ -59,5 +59,5 @@ records › record_value_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1200
+ ;; custom section \"cmi\", size 1198
 )

--- a/compiler/test/__snapshots__/records.60c7acc4.0.snapshot
+++ b/compiler/test/__snapshots__/records.60c7acc4.0.snapshot
@@ -63,5 +63,5 @@ records › record_pun_mixed_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1647
+ ;; custom section \"cmi\", size 1645
 )

--- a/compiler/test/__snapshots__/records.89d08e01.0.snapshot
+++ b/compiler/test/__snapshots__/records.89d08e01.0.snapshot
@@ -59,5 +59,5 @@ records › record_pun_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1192
+ ;; custom section \"cmi\", size 1190
 )

--- a/compiler/test/__snapshots__/records.a9c472b1.0.snapshot
+++ b/compiler/test/__snapshots__/records.a9c472b1.0.snapshot
@@ -94,5 +94,5 @@ records › record_multiple_fields_definition_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 2221
+ ;; custom section \"cmi\", size 2219
 )

--- a/compiler/test/__snapshots__/records.d34c4740.0.snapshot
+++ b/compiler/test/__snapshots__/records.d34c4740.0.snapshot
@@ -63,5 +63,5 @@ records › record_pun_mixed
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1593
+ ;; custom section \"cmi\", size 1591
 )

--- a/compiler/test/__snapshots__/records.d44e8007.0.snapshot
+++ b/compiler/test/__snapshots__/records.d44e8007.0.snapshot
@@ -63,5 +63,5 @@ records › record_pun_mixed_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1605
+ ;; custom section \"cmi\", size 1603
 )

--- a/compiler/test/__snapshots__/records.e4326567.0.snapshot
+++ b/compiler/test/__snapshots__/records.e4326567.0.snapshot
@@ -94,5 +94,5 @@ records › record_multiple_fields_both_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 2173
+ ;; custom section \"cmi\", size 2171
 )

--- a/compiler/test/__snapshots__/records.e5b56da8.0.snapshot
+++ b/compiler/test/__snapshots__/records.e5b56da8.0.snapshot
@@ -59,5 +59,5 @@ records › record_both_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1196
+ ;; custom section \"cmi\", size 1194
 )

--- a/compiler/test/__snapshots__/records.e705a980.0.snapshot
+++ b/compiler/test/__snapshots__/records.e705a980.0.snapshot
@@ -63,5 +63,5 @@ records › record_pun_multiple
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1611
+ ;; custom section \"cmi\", size 1609
 )

--- a/compiler/test/__snapshots__/records.f6e43cdb.0.snapshot
+++ b/compiler/test/__snapshots__/records.f6e43cdb.0.snapshot
@@ -63,5 +63,5 @@ records › record_pun_multiple_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1665
+ ;; custom section \"cmi\", size 1663
 )

--- a/compiler/test/__snapshots__/records.f6feee77.0.snapshot
+++ b/compiler/test/__snapshots__/records.f6feee77.0.snapshot
@@ -94,5 +94,5 @@ records › record_multiple_fields_value_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 2181
+ ;; custom section \"cmi\", size 2179
 )

--- a/compiler/test/__snapshots__/records.fae50a8e.0.snapshot
+++ b/compiler/test/__snapshots__/records.fae50a8e.0.snapshot
@@ -63,5 +63,5 @@ records › record_pun_mixed_2_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1659
+ ;; custom section \"cmi\", size 1657
 )

--- a/compiler/test/grainfmt/chained.expected.gr
+++ b/compiler/test/grainfmt/chained.expected.gr
@@ -1,25 +1,25 @@
 module Chained
 
-let g = 7, // g represents the precision desired, p is the values of p[i] to plug into Lanczos' formula
-  p = 8, // another comment
-  q = 32
+let g = 7 // g represents the precision desired, p is the values of p[i] to plug into Lanczos' formula
+and p = 8 // another comment
+and q = 32
 
 let myFunction2 = x => {
   let inter = x + 1
   "some string"
-},
-myFunction3 = y => {
+}
+and myFunction3 = y => {
   let myVal = 5
   "some string"
 }
 
-let g = 7, p = 8, q = 32
+let g = 7 and p = 8 and q = 32
 
 let myFunction2 = x => {
   let inter = x + 1
   "some string"
-}, // a comment
-myFunction3 = y => {
+} // a comment
+and myFunction3 = y => {
   let myVal = 5
   "some string"
 }

--- a/compiler/test/grainfmt/chained.expected.gr
+++ b/compiler/test/grainfmt/chained.expected.gr
@@ -1,7 +1,9 @@
 module Chained
 
-let g = 7 // g represents the precision desired, p is the values of p[i] to plug into Lanczos' formula
-and p = 8 // another comment
+let g = 7
+// g represents the precision desired, p is the values of p[i] to plug into Lanczos' formula
+and p = 8
+// another comment
 and q = 32
 
 let myFunction2 = x => {
@@ -13,12 +15,15 @@ and myFunction3 = y => {
   "some string"
 }
 
-let g = 7 and p = 8 and q = 32
+let g = 7
+and p = 8
+and q = 32
 
 let myFunction2 = x => {
   let inter = x + 1
   "some string"
-} // a comment
+}
+// a comment
 and myFunction3 = y => {
   let myVal = 5
   "some string"

--- a/compiler/test/grainfmt/chained.input.gr
+++ b/compiler/test/grainfmt/chained.input.gr
@@ -1,28 +1,28 @@
 module Chained
 
 
-  let g = 7, // g represents the precision desired, p is the values of p[i] to plug into Lanczos' formula
-      p = 8, // another comment
-      q = 32
+  let g = 7 // g represents the precision desired, p is the values of p[i] to plug into Lanczos' formula
+  and p = 8 // another comment
+  and q = 32
 
 
 let myFunction2 = x => {
   let inter = x + 1
   "some string"
-}, myFunction3 = y => {
+} and myFunction3 = y => {
   let myVal = 5
   "some string"
 }
 
-  let g = 7, 
-      p = 8, 
-      q = 32
+  let g = 7 
+  and p = 8 
+  and q = 32
 
   let myFunction2 = x => {
   let inter = x + 1
   "some string"
-},  // a comment
-myFunction3 = y => {
+}  // a comment
+and myFunction3 = y => {
   let myVal = 5
   "some string"
 }

--- a/compiler/test/grainfmt/data_docs.expected.gr
+++ b/compiler/test/grainfmt/data_docs.expected.gr
@@ -3,21 +3,21 @@ module DataDocs
 enum EventType {
   Enter,
   Exit,
-},
+}
 /**
  *   An event is the start or end of a token amongst other events.
  *   Tokens can “contain” other tokens, even though they are stored in a flat
  *   list, through `enter`ing before them, and `exit`ing after them.
  */
-type Event = (EventType, Token, TokenizeContext),
+and type Event = (EventType, Token, TokenizeContext)
 /**
  *   Another event is the start or end of a token amongst other events.
  *   Tokens can “contain” other tokens, even though they are stored in a flat
  *   list, through `enter`ing before them, and `exit`ing after them.
  */
-enum EventType2 {
+and enum EventType2 {
   Enter2,
   Exit2,
-},
+}
 // line comment
-type Event2 = (EventType2, Token, TokenizeContext)
+and type Event2 = (EventType2, Token, TokenizeContext)

--- a/compiler/test/grainfmt/data_docs.expected.gr
+++ b/compiler/test/grainfmt/data_docs.expected.gr
@@ -1,6 +1,6 @@
 module DataDocs
 
-enum EventType {
+enum rec EventType {
   Enter,
   Exit,
 }

--- a/compiler/test/grainfmt/data_docs.input.gr
+++ b/compiler/test/grainfmt/data_docs.input.gr
@@ -3,13 +3,13 @@ module DataDocs
 enum EventType {
   Enter,
   Exit,
-},
+}
 /**
  *   An event is the start or end of a token amongst other events.
  *   Tokens can “contain” other tokens, even though they are stored in a flat
  *   list, through `enter`ing before them, and `exit`ing after them.
  */
-type Event = (EventType, Token, TokenizeContext),
+and type Event = (EventType, Token, TokenizeContext)
 /**
  *   Another event is the start or end of a token amongst other events.
  *   Tokens can “contain” other tokens, even though they are stored in a flat
@@ -17,9 +17,9 @@ type Event = (EventType, Token, TokenizeContext),
  */
 
 
-enum EventType2 {
+and enum EventType2 {
   Enter2,
   Exit2,
-},
+}
 // line comment
-type Event2 = (EventType2, Token, TokenizeContext)
+and type Event2 = (EventType2, Token, TokenizeContext)

--- a/compiler/test/grainfmt/data_docs.input.gr
+++ b/compiler/test/grainfmt/data_docs.input.gr
@@ -1,6 +1,6 @@
 module DataDocs
 
-enum EventType {
+enum rec EventType {
   Enter,
   Exit,
 }

--- a/compiler/test/grainfmt/enum_long.expected.gr
+++ b/compiler/test/grainfmt/enum_long.expected.gr
@@ -102,8 +102,8 @@ enum EvenNumber {
   OddPlusOne(OddNumber), // comment 1
   // comment 2
   // comment 3
-},
-enum OddNumber {
+}
+and enum OddNumber {
   // comment 4
   // comment 5
   EvenPlusOne(EvenNumber),

--- a/compiler/test/grainfmt/enum_long.expected.gr
+++ b/compiler/test/grainfmt/enum_long.expected.gr
@@ -97,7 +97,7 @@ provide enum Test {
   ),
 }
 
-enum EvenNumber {
+enum rec EvenNumber {
   Zero, // comment 0
   OddPlusOne(OddNumber), // comment 1
   // comment 2

--- a/compiler/test/grainfmt/enum_long.input.gr
+++ b/compiler/test/grainfmt/enum_long.input.gr
@@ -14,8 +14,8 @@ enum EvenNumber {
   OddPlusOne(OddNumber), // comment 1
   // comment 2
   // comment 3
-},
-enum OddNumber {
+}
+and enum OddNumber {
   // comment 4
   // comment 5
   EvenPlusOne(EvenNumber),

--- a/compiler/test/grainfmt/enum_long.input.gr
+++ b/compiler/test/grainfmt/enum_long.input.gr
@@ -9,7 +9,7 @@ provide enum Test {
   String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String > ),
 }
 
-enum EvenNumber {
+enum rec EvenNumber {
   Zero, // comment 0
   OddPlusOne(OddNumber), // comment 1
   // comment 2

--- a/compiler/test/grainfmt/enums.expected.gr
+++ b/compiler/test/grainfmt/enums.expected.gr
@@ -77,7 +77,7 @@ enum rec ParsedRegularExpression {
   REUnicodeCategories(Bool), // symlist, true=match/false=does-not-match
 }
 
-record Node {
+record rec Node {
   node: AstValue,
 }
 and enum AstValue {

--- a/compiler/test/grainfmt/enums.expected.gr
+++ b/compiler/test/grainfmt/enums.expected.gr
@@ -20,7 +20,7 @@ provide enum Ship {
   Ship(Number, Number, Number),
 }
 
-enum ParsedRegularExpression {
+enum rec ParsedRegularExpression {
   RENever,
   REEmpty,
   REAny,
@@ -79,8 +79,8 @@ enum ParsedRegularExpression {
 
 record Node {
   node: AstValue,
-},
-enum AstValue {
+}
+and enum AstValue {
   NodeValue(Node),
   StringValue(String),
 }

--- a/compiler/test/grainfmt/enums.input.gr
+++ b/compiler/test/grainfmt/enums.input.gr
@@ -21,7 +21,7 @@ provide enum Ship {
   Ship(Number, Number, Number)
 }
 
-enum ParsedRegularExpression {
+enum rec ParsedRegularExpression {
   RENever,
   REEmpty,
   REAny,
@@ -48,6 +48,6 @@ enum ParsedRegularExpression {
 }
 
 
-record Node { node: AstValue },
+record Node { node: AstValue }
 
-enum AstValue { NodeValue(Node), StringValue(String) }
+and enum AstValue { NodeValue(Node), StringValue(String) }

--- a/compiler/test/grainfmt/enums.input.gr
+++ b/compiler/test/grainfmt/enums.input.gr
@@ -48,6 +48,6 @@ enum rec ParsedRegularExpression {
 }
 
 
-record Node { node: AstValue }
+record rec Node { node: AstValue }
 
 and enum AstValue { NodeValue(Node), StringValue(String) }

--- a/compiler/test/grainfmt/includes.expected.gr
+++ b/compiler/test/grainfmt/includes.expected.gr
@@ -30,7 +30,7 @@ include "runtime/unsafe/wasmi32"
 from WasmI32 use {
   eq, // comment1
   // comment 3
-  and as (&), // comment 2
+  and_ as (&), // comment 2
   or as (|),
   // no signed imports, as care should be taken to use signed or unsigned operators
 }

--- a/compiler/test/grainfmt/includes.input.gr
+++ b/compiler/test/grainfmt/includes.input.gr
@@ -28,7 +28,7 @@ include "runtime/unsafe/wasmi32"
 from WasmI32 use {
   eq, // comment1
   // comment 3
-  and as (&), // comment 2
+  and_ as (&), // comment 2
   or as (|)
   // no signed imports, as care should be taken to use signed or unsigned operators
 }

--- a/compiler/test/grainfmt/infix.expected.gr
+++ b/compiler/test/grainfmt/infix.expected.gr
@@ -1,8 +1,8 @@
 module Infix
 
 let trimString = (str: String, end: Bool) => {
-  let chars = [>], charsLength = 0
-  let mut i = 0, offset = 1
+  let chars = [>] and charsLength = 0
+  let mut i = 0 and offset = 1
 
   for (; i < charsLength && i > -1; i += offset) {
     let currentChar = chars[i]

--- a/compiler/test/grainfmt/infix.expected.gr
+++ b/compiler/test/grainfmt/infix.expected.gr
@@ -1,8 +1,10 @@
 module Infix
 
 let trimString = (str: String, end: Bool) => {
-  let chars = [>] and charsLength = 0
-  let mut i = 0 and offset = 1
+  let chars = [>]
+  and charsLength = 0
+  let mut i = 0
+  and offset = 1
 
   for (; i < charsLength && i > -1; i += offset) {
     let currentChar = chars[i]

--- a/compiler/test/grainfmt/infix.input.gr
+++ b/compiler/test/grainfmt/infix.input.gr
@@ -1,8 +1,8 @@
 module Infix
 
 let trimString = (str: String, end: Bool) => {
-  let chars = [>], charsLength = 0
-  let mut i = 0, offset = 1
+  let chars = [>] and charsLength = 0
+  let mut i = 0 and offset = 1
  
   for (; i < charsLength && i > -1; i += offset) {
     let currentChar = chars[i];

--- a/compiler/test/grainfmt/lets.expected.gr
+++ b/compiler/test/grainfmt/lets.expected.gr
@@ -1,6 +1,11 @@
 module Lets
 
-let rec myFun1 = x => x + 1 and myFun2 = x => x + 1
+let rec myFun1 = x =>
+  x +
+    1
+and myFun2 = x =>
+  x +
+    1
 
 let myBlock = {
   "some string"

--- a/compiler/test/grainfmt/lets.expected.gr
+++ b/compiler/test/grainfmt/lets.expected.gr
@@ -31,7 +31,7 @@ let rotate = (count, list) => {
   append(end, beginning)
 }
 
-let qsize = (if (WasmI32.eqz(WasmI32.and(m + 1n, 1n))) {
+let qsize = (if (WasmI32.eqz(WasmI32.and_(m + 1n, 1n))) {
     m + 1n
   } else {
     m + 2n

--- a/compiler/test/grainfmt/lets.expected.gr
+++ b/compiler/test/grainfmt/lets.expected.gr
@@ -1,6 +1,6 @@
 module Lets
 
-let rec myFun1 = x => x + 1, myFun2 = x => x + 1
+let rec myFun1 = x => x + 1 and myFun2 = x => x + 1
 
 let myBlock = {
   "some string"
@@ -9,8 +9,8 @@ let myBlock = {
 let myFunction2 = x => {
   let inter = x + 1
   "some string"
-},
-myFunction3 = y => {
+}
+and myFunction3 = y => {
   let myVal = 5
   "some string"
 }

--- a/compiler/test/grainfmt/lets.input.gr
+++ b/compiler/test/grainfmt/lets.input.gr
@@ -34,7 +34,7 @@ let rotate = (count, list) => {
   append(end, beginning)
 }
 
-let qsize = (if (WasmI32.eqz(WasmI32.and(m + 1n, 1n))) {
+let qsize = (if (WasmI32.eqz(WasmI32.and_(m + 1n, 1n))) {
     m + 1n
   } else {
     m + 2n

--- a/compiler/test/grainfmt/lets.input.gr
+++ b/compiler/test/grainfmt/lets.input.gr
@@ -1,6 +1,6 @@
 module Lets
 
-let rec myFun1 = x => x + 1, myFun2 = x => x + 1
+let rec myFun1 = x => x + 1 and myFun2 = x => x + 1
 
 let myBlock = {
   "some string"
@@ -10,9 +10,9 @@ let myBlock = {
 let myFunction2 = (x) => {
   let inter = x + 1
   "some string"
-},
+}
 
-myFunction3 = (y) =>  {
+and myFunction3 = (y) =>  {
   let myVal = 5
   "some string"
 }

--- a/compiler/test/input/basicenum.gr
+++ b/compiler/test/input/basicenum.gr
@@ -1,6 +1,6 @@
 module BasicNum
 
-enum List<a> {
+enum rec List<a> {
   Empty,
   Cons(a, List<a>),
 }

--- a/compiler/test/input/fib-bigint.gr
+++ b/compiler/test/input/fib-bigint.gr
@@ -6,8 +6,8 @@ let rec fib_help = (n, cur, next) => {
   } else {
     fib_help(n - 1, next, cur + next)
   }
-},
-fib = n => {
+}
+and fib = n => {
   fib_help(n, 0, 1)
 }
 

--- a/compiler/test/input/forward-decl.gr
+++ b/compiler/test/input/forward-decl.gr
@@ -8,8 +8,8 @@ let rec isEvenHelp = (n, b) => {
   } else {
     isOddHelp(n - 1, !b)
   }
-},
-isOddHelp = (n, b) => {
+}
+and isOddHelp = (n, b) => {
   if (n == 1) {
     b
   } else {
@@ -19,8 +19,8 @@ isOddHelp = (n, b) => {
 
 let isEven = n => {
   isEvenHelp(n, true)
-},
-isOdd = n => {
+}
+and isOdd = n => {
   isOddHelp(n, true)
 }
 

--- a/compiler/test/input/long_lists.gr
+++ b/compiler/test/input/long_lists.gr
@@ -12,8 +12,8 @@ let rec make_list = (x, n) => {
     }
   }
   helper(n, x, [])
-},
-loop = n => {
+}
+and loop = n => {
   if (n == 0) {
     true
   } else {

--- a/compiler/test/input/mixedPatternMatching.gr
+++ b/compiler/test/input/mixedPatternMatching.gr
@@ -8,7 +8,7 @@ provide record Rec {
   bar: String,
 }
 
-provide enum Poly {
+provide enum rec Poly {
   PList(List<Number>),
   PArray(Array<Poly>),
   PAssoc(Rec),

--- a/compiler/test/input/recursive-equal-box.gr
+++ b/compiler/test/input/recursive-equal-box.gr
@@ -1,6 +1,6 @@
 module RecursiveEqualBox
 
-provide enum R {
+provide enum rec R {
   Atom,
   Recursive(Box<Option<R>>),
 }
@@ -18,7 +18,7 @@ u := Some(w)
 
 assert x == w
 
-provide record Rec {
+provide record rec Rec {
   int: Number,
   r: Box<Option<Rec>>,
 }

--- a/compiler/test/input/recursive-equal-mut.gr
+++ b/compiler/test/input/recursive-equal-mut.gr
@@ -3,7 +3,7 @@ module RecursiveEqualMut
 // Note: This file doesn't include the Recursive type test
 // because it isn't achievable with `let mut`
 
-provide record Rec {
+provide record rec Rec {
   int: Number,
   mut r: Option<Rec>,
 }

--- a/compiler/test/input/sinister-tail-call.gr
+++ b/compiler/test/input/sinister-tail-call.gr
@@ -9,19 +9,19 @@ let rec isEvenHelp = (n, b) => {
     // Note the different argument size
     isOdd(n - 1)
   }
-},
-isOddHelp = (n, b) => {
+}
+and isOddHelp = (n, b) => {
   if (n == 1) {
     b
   } else {
     // See above
     isEven(n - 1)
   }
-},
-isEven = n => {
+}
+and isEven = n => {
   isEvenHelp(n, true)
-},
-isOdd = n => {
+}
+and isOdd = n => {
   isOddHelp(n, true)
 }
 

--- a/compiler/test/stdlib/hash.test.gr
+++ b/compiler/test/stdlib/hash.test.gr
@@ -109,7 +109,7 @@ let charList = Array.toList(chars)
 assert uniq(List.map(Hash.hash, charList))
 Array.forEach(c => assert Hash.hash(c) == Hash.hash(c), chars)
 
-enum Variants {
+enum rec Variants {
   A,
   B,
   C,

--- a/compiler/test/stdlib/marshal.test.gr
+++ b/compiler/test/stdlib/marshal.test.gr
@@ -31,7 +31,7 @@ assert roundtripOk([> 1l, 2l, 3l])
 assert roundtripOk([1, 2, 3])
 assert roundtripOk([1l, 2l, 3l])
 
-enum Foo<a> {
+enum rec Foo<a> {
   Bar,
   Baz(a),
   Qux(String, a),
@@ -67,7 +67,7 @@ let closureTest = () => {
 
 closureTest()
 
-record Cyclic {
+record rec Cyclic {
   mut self: List<Cyclic>,
 }
 

--- a/compiler/test/suites/basic_functionality.re
+++ b/compiler/test/suites/basic_functionality.re
@@ -257,7 +257,6 @@ describe("basic functionality", ({test, testSkip}) => {
               (
                 Asttypes.NotProvided,
                 DataDeclaration.variant(
-                  Parsetree.Nonrecursive,
                   Location.mknoloc("Caipirinha"),
                   [],
                   [
@@ -289,7 +288,6 @@ describe("basic functionality", ({test, testSkip}) => {
               (
                 Asttypes.NotProvided,
                 DataDeclaration.abstract(
-                  Parsetree.Nonrecursive,
                   Location.mknoloc("Über"),
                   [],
                   Some(

--- a/compiler/test/suites/basic_functionality.re
+++ b/compiler/test/suites/basic_functionality.re
@@ -257,6 +257,7 @@ describe("basic functionality", ({test, testSkip}) => {
               (
                 Asttypes.NotProvided,
                 DataDeclaration.variant(
+                  Parsetree.Nonrecursive,
                   Location.mknoloc("Caipirinha"),
                   [],
                   [
@@ -288,6 +289,7 @@ describe("basic functionality", ({test, testSkip}) => {
               (
                 Asttypes.NotProvided,
                 DataDeclaration.abstract(
+                  Parsetree.Nonrecursive,
                   Location.mknoloc("Über"),
                   [],
                   Some(

--- a/compiler/test/suites/basic_functionality.re
+++ b/compiler/test/suites/basic_functionality.re
@@ -52,7 +52,7 @@ describe("basic functionality", ({test, testSkip}) => {
 
   assertSnapshot(
     "complex1",
-    "\n    let x = 2, y = 3, z = if (true) { 4 } else { 5 };\n    if (true) {\n      print(y)\n      y - (z + x)\n    } else {\n      print(8)\n      8\n    }\n    ",
+    "\n    let x = 2 and y = 3 and z = if (true) { 4 } else { 5 };\n    if (true) {\n      print(y)\n      y - (z + x)\n    } else {\n      print(8)\n      8\n    }\n    ",
   );
   assertSnapshot("complex2", "print(2 + 3)");
   assertSnapshot("binop1", "2 + 2");
@@ -123,7 +123,7 @@ describe("basic functionality", ({test, testSkip}) => {
   assertSnapshot("comp7", "if (2 == 2) {8} else {9}");
   assertSnapshot("comp8", "if (2 <= 2) {10} else {11}");
   assertSnapshot("comp9", "if (2 >= 2) {10} else {11}");
-  assertSnapshot("comp10", "let x = 2, y = 4; (y - 2) == x");
+  assertSnapshot("comp10", "let x = 2 and y = 4; (y - 2) == x");
   assertCompileError("comp11", "true == 2", "has type Number but");
   assertCompileError("comp12", "2 == false", "has type Bool but");
   assertSnapshot("comp13", "true == true");

--- a/compiler/test/suites/enums.re
+++ b/compiler/test/suites/enums.re
@@ -23,7 +23,7 @@ describe("enums", ({test, testSkip}) => {
   );
   // Taken from https://en.wikipedia.org/wiki/Recursive_data_type#Mutually_recursive_data_types
   let recursive_contents = {|
-    enum Tree<a> {
+    enum rec Tree<a> {
       Empty,
       Node(a, Forest<a>)
     },

--- a/compiler/test/suites/enums.re
+++ b/compiler/test/suites/enums.re
@@ -23,11 +23,11 @@ describe("enums", ({test, testSkip}) => {
   );
   // Taken from https://en.wikipedia.org/wiki/Recursive_data_type#Mutually_recursive_data_types
   let recursive_contents = {|
-    enum rec Tree<a> {
+    enum Tree<a> {
       Empty,
       Node(a, Forest<a>)
-    },
-    enum Forest<a> {
+    }
+    and enum Forest<a> {
       Nil,
       Cons(Tree<a>, Forest<a>)
     }

--- a/compiler/test/suites/enums.re
+++ b/compiler/test/suites/enums.re
@@ -23,7 +23,7 @@ describe("enums", ({test, testSkip}) => {
   );
   // Taken from https://en.wikipedia.org/wiki/Recursive_data_type#Mutually_recursive_data_types
   let recursive_contents = {|
-    enum Tree<a> {
+    enum rec Tree<a> {
       Empty,
       Node(a, Forest<a>)
     }

--- a/compiler/test/suites/functions.re
+++ b/compiler/test/suites/functions.re
@@ -195,8 +195,8 @@ truc()|},
           } else {
             isOdd(n - 1)
           }
-        },
-        isOdd = n => {
+        }
+        and isOdd = n => {
           if (n <= 1) {
             n == 1
           } else {

--- a/compiler/test/suites/functions.re
+++ b/compiler/test/suites/functions.re
@@ -25,17 +25,17 @@ describe("functions", ({test, testSkip}) => {
   assertRun("func_no_args", "let foo = (() => {print(5)});\nfoo()", "5\n");
   assertCompileError(
     "multi_bind",
-    "let x = 2, y = x + 1; y",
+    "let x = 2 and y = x + 1; y",
     "Unbound value x",
   );
-  assertSnapshot("multi_bind2", "let x = 2, y = 3; y");
+  assertSnapshot("multi_bind2", "let x = 2 and y = 3; y");
   assertSnapshot("curried_func", "let add = a => b => a + b; add(2)(3)");
   assertCompileError("unbound_fun", "2 + foo()", "unbound");
   assertCompileError("unbound_id_simple", "5 - x", "unbound");
   assertCompileError("unbound_id_let", "let x = x; 2 + 2", "unbound");
   assertCompileError(
     "shadow_multi",
-    "let x = 12, x = 14; x",
+    "let x = 12 and x = 14; x",
     "Variable x is bound several times",
   );
   assertSnapshot(
@@ -102,23 +102,23 @@ describe("functions", ({test, testSkip}) => {
   assertSnapshot("app_1", "((x) => {x})(1)");
   assertRun(
     "letrec_1",
-    "let rec x = ((n) => {if (n > 3) {n} else {x(n + 2)}}),\n                        y = ((n) => {x(n + 1)});\n                 print(y(2))",
+    "let rec x = ((n) => {if (n > 3) {n} else {x(n + 2)}})\n                        and y = ((n) => {x(n + 1)});\n                 print(y(2))",
     "5\n",
   );
   /* Check that recursion is order-independent */
   assertRun(
     "letrec_2",
-    "let rec y = ((n) => {x(n + 1)}),\n                        x = ((n) => {if (n > 3) {n} else {x(n + 2)}});\n                 print(y(2))",
+    "let rec y = ((n) => {x(n + 1)})\n                        and x = ((n) => {if (n > 3) {n} else {x(n + 2)}});\n                 print(y(2))",
     "5\n",
   );
   assertRun(
     "let_1",
-    "let rec x = ((n) => {n + 1}),\n                     y = (() => x(3)),\n                     z = ((n) => {x(n) + y()});\n               print(z(5))",
+    "let rec x = ((n) => {n + 1})\n                     and y = (() => x(3))\n                     and z = ((n) => {x(n) + y()});\n               print(z(5))",
     "10\n",
   );
   assertCompileError(
     "let_norec_1",
-    "let x = ((n) => {if (n > 3) {n} else {x(n + 2)}}),\n                        y = ((n) => {x(n + 1)});\n                 print(y(2))",
+    "let x = ((n) => {if (n > 3) {n} else {x(n + 2)}})\n                        and y = ((n) => {x(n + 1)});\n                 print(y(2))",
     "Unbound value x.",
   );
   assertCompileError(
@@ -144,7 +144,7 @@ describe("functions", ({test, testSkip}) => {
   );
   assertCompileError(
     "letrec_nonstatic_other",
-    "let rec x = ((z) => {z + 1}), y = x; y(2)",
+    "let rec x = ((z) => {z + 1}) and y = x; y(2)",
     "let rec may only be used with recursive function definitions",
   );
   assertCompileError("nonfunction_1", "let x = 5; x(3)", "type");

--- a/compiler/test/suites/gc.re
+++ b/compiler/test/suites/gc.re
@@ -148,8 +148,8 @@ describe("garbage collection", ({test, testSkip}) => {
         }
       }
       helper(n, x, [])
-    },
-    loop = n => {
+    }
+    and loop = n => {
       if (n == 0) {
         true
       } else {

--- a/compiler/test/suites/optimizations.re
+++ b/compiler/test/suites/optimizations.re
@@ -64,7 +64,7 @@ describe("optimizations", ({test, testSkip}) => {
 
   assertSnapshot(
     "trs1",
-    "let f1 = ((x, y) => {x}),\n         f2 = ((x, y) => {y});\n       f1(1, 2)",
+    "let f1 = ((x, y) => {x})\n         and f2 = ((x, y) => {y});\n       f1(1, 2)",
   );
   assertRun(
     "regression_no_elim_impure_call",

--- a/compiler/test/suites/records.re
+++ b/compiler/test/suites/records.re
@@ -165,10 +165,10 @@ describe("records", ({test, testSkip}) => {
   assertSnapshot(
     "record_recursive_data_definition",
     {|
-      record rec Bar {
+      record Bar {
         mut foo: Option<Foo>
-      },
-      record Foo {
+      }
+      and record Foo {
         mut bar: Option<Bar>
       }
 

--- a/compiler/test/suites/records.re
+++ b/compiler/test/suites/records.re
@@ -165,7 +165,7 @@ describe("records", ({test, testSkip}) => {
   assertSnapshot(
     "record_recursive_data_definition",
     {|
-      record Bar {
+      record rec Bar {
         mut foo: Option<Foo>
       }
       and record Foo {

--- a/compiler/test/suites/records.re
+++ b/compiler/test/suites/records.re
@@ -165,7 +165,7 @@ describe("records", ({test, testSkip}) => {
   assertSnapshot(
     "record_recursive_data_definition",
     {|
-      record Bar {
+      record rec Bar {
         mut foo: Option<Foo>
       },
       record Foo {

--- a/compiler/test/suites/types.re
+++ b/compiler/test/suites/types.re
@@ -386,31 +386,31 @@ describe("recursive types", ({test, testSkip}) => {
   assertCompileError(
     "type_rec_incorrect_2",
     {|
-      record rec T {
+      record T {
         x: Number
       }
       and enum T2 {
         T2(Number)
       }
     |},
-    "Types in a mutually recursive type group are already self-recursive so `rec` should be removed.",
+    "Mutually recursive type groups must include `rec` on the first type in the group.",
   );
   assertCompileError(
     "type_rec_incorrect_3",
     {|
-      record T {
+      record rec T {
         x: Number
       }
       and enum rec T2 {
         T2(Number)
       }
     |},
-    "Types in a mutually recursive type group are already self-recursive so `rec` should be removed.",
+    "The `rec` keyword should only appear on the first type in the mutually recursive type group.",
   );
   assertRun(
     "type_rec_correct_1",
     {|
-      record T {
+      record rec T {
         x: T
       }
       and enum T2 {

--- a/compiler/test/suites/types.re
+++ b/compiler/test/suites/types.re
@@ -366,3 +366,59 @@ describe("abstract types", ({test, testSkip}) => {
     "abc\n",
   );
 });
+
+describe("recursive types", ({test, testSkip}) => {
+  let test_or_skip =
+    Sys.backend_type == Other("js_of_ocaml") ? testSkip : test;
+
+  let assertCompileError = makeCompileErrorRunner(test);
+  let assertRun = makeRunner(test_or_skip);
+
+  assertCompileError(
+    "type_rec_incorrect_1",
+    {|
+      record Oops {
+        x: Oops
+      }
+    |},
+    "Unbound type constructor Oops. Hint: you are probably missing the `rec` keyword on this type",
+  );
+  assertCompileError(
+    "type_rec_incorrect_2",
+    {|
+      record T {
+        x: Number
+      },
+      enum T2 {
+        T2(Number)
+      }
+    |},
+    "Mutually recursive type groups must include `rec` on the first type in the group.",
+  );
+  assertCompileError(
+    "type_rec_incorrect_3",
+    {|
+      record rec T {
+        x: Number
+      },
+      enum rec T2 {
+        T2(Number)
+      }
+    |},
+    "The `rec` keyword should only appear on the first type in the mutually recursive type group.",
+  );
+  assertRun(
+    "type_rec_correct",
+    {|
+      record rec T {
+        x: T
+      },
+      enum T2 {
+        T2(T2),
+        Val(Number)
+      }
+      print(T2(T2(Val(1))))
+    |},
+    "T2(T2(Val(1)))\n",
+  );
+});

--- a/compiler/test/suites/types.re
+++ b/compiler/test/suites/types.re
@@ -408,7 +408,7 @@ describe("recursive types", ({test, testSkip}) => {
     "The `rec` keyword should only appear on the first type in the mutually recursive type group.",
   );
   assertRun(
-    "type_rec_correct",
+    "type_rec_correct_1",
     {|
       record rec T {
         x: T
@@ -420,5 +420,16 @@ describe("recursive types", ({test, testSkip}) => {
       print(T2(T2(Val(1))))
     |},
     "T2(T2(Val(1)))\n",
+  );
+  assertRun(
+    "type_rec_correct_2",
+    {|
+      record T {
+        x: Number
+      }
+      type T = T
+      print({ x: 1 }: T)
+    |},
+    "{\n  x: 1\n}\n",
   );
 });

--- a/compiler/test/suites/types.re
+++ b/compiler/test/suites/types.re
@@ -381,7 +381,7 @@ describe("recursive types", ({test, testSkip}) => {
         x: Oops
       }
     |},
-    "Unbound type constructor Oops. Hint: you are probably missing the `rec` keyword on this type",
+    "Unbound type constructor Oops. Are you missing the `rec` keyword on this type?",
   );
   assertCompileError(
     "type_rec_incorrect_2",

--- a/compiler/test/suites/types.re
+++ b/compiler/test/suites/types.re
@@ -386,34 +386,34 @@ describe("recursive types", ({test, testSkip}) => {
   assertCompileError(
     "type_rec_incorrect_2",
     {|
-      record T {
+      record rec T {
         x: Number
-      },
-      enum T2 {
+      }
+      and enum T2 {
         T2(Number)
       }
     |},
-    "Mutually recursive type groups must include `rec` on the first type in the group.",
+    "Types in a mutually recursive type group are already self-recursive so `rec` should be removed.",
   );
   assertCompileError(
     "type_rec_incorrect_3",
     {|
-      record rec T {
+      record T {
         x: Number
-      },
-      enum rec T2 {
+      }
+      and enum rec T2 {
         T2(Number)
       }
     |},
-    "The `rec` keyword should only appear on the first type in the mutually recursive type group.",
+    "Types in a mutually recursive type group are already self-recursive so `rec` should be removed.",
   );
   assertRun(
     "type_rec_correct_1",
     {|
-      record rec T {
+      record T {
         x: T
-      },
-      enum T2 {
+      }
+      and enum T2 {
         T2(T2),
         Val(Number)
       }

--- a/compiler/test/test-libs/tlists.gr
+++ b/compiler/test/test-libs/tlists.gr
@@ -1,6 +1,6 @@
 module TLists
 
-provide enum TList<a> {
+provide enum rec TList<a> {
   Empty,
   Cons(a, TList<a>),
 }

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -1121,7 +1121,7 @@ provide module Immutable {
   // To be applied to numbers to bring them within the range [0, 32)
   let bitmask = branchingFactor - 1
 
-  type Tree<a> = Array<Node<a>>
+  type rec Tree<a> = Array<Node<a>>
   and enum Node<a> {
     Tree(Tree<a>),
     Leaf(Array<a>),

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -1121,7 +1121,7 @@ provide module Immutable {
   // To be applied to numbers to bring them within the range [0, 32)
   let bitmask = branchingFactor - 1
 
-  type Tree<a> = Array<Node<a>>,
+  type rec Tree<a> = Array<Node<a>>,
   enum Node<a> {
     Tree(Tree<a>),
     Leaf(Array<a>),

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -1121,8 +1121,8 @@ provide module Immutable {
   // To be applied to numbers to bring them within the range [0, 32)
   let bitmask = branchingFactor - 1
 
-  type rec Tree<a> = Array<Node<a>>,
-  enum Node<a> {
+  type Tree<a> = Array<Node<a>>
+  and enum Node<a> {
     Tree(Tree<a>),
     Leaf(Array<a>),
   }

--- a/stdlib/map.gr
+++ b/stdlib/map.gr
@@ -20,7 +20,7 @@ include "runtime/unsafe/memory"
 include "runtime/unsafe/wasmi32"
 
 // TODO: Consider implementing this as List<(Box<k>, Box<v>)>
-record Bucket<k, v> {
+record rec Bucket<k, v> {
   mut key: k,
   mut value: v,
   mut next: Option<Bucket<k, v>>,
@@ -519,7 +519,7 @@ provide let getInternalStats = map => {
 provide module Immutable {
   // implementation based on the paper "Implementing Sets Efficiently in a
   // Functional Language" by Stephen Adams
-  record Node<k, v> {
+  record rec Node<k, v> {
     key: k,
     val: v,
     size: Number,

--- a/stdlib/map.gr
+++ b/stdlib/map.gr
@@ -519,7 +519,7 @@ provide let getInternalStats = map => {
 provide module Immutable {
   // implementation based on the paper "Implementing Sets Efficiently in a
   // Functional Language" by Stephen Adams
-  record Node<k, v> {
+  record rec Node<k, v> {
     key: k,
     val: v,
     size: Number,

--- a/stdlib/map.gr
+++ b/stdlib/map.gr
@@ -519,14 +519,14 @@ provide let getInternalStats = map => {
 provide module Immutable {
   // implementation based on the paper "Implementing Sets Efficiently in a
   // Functional Language" by Stephen Adams
-  record rec Node<k, v> {
+  record Node<k, v> {
     key: k,
     val: v,
     size: Number,
     left: Map<k, v>,
     right: Map<k, v>,
-  },
-  abstract enum Map<k, v> {
+  }
+  and abstract enum Map<k, v> {
     Empty,
     Tree(Node<k, v>),
   }

--- a/stdlib/path.gr
+++ b/stdlib/path.gr
@@ -79,7 +79,7 @@ record TFileType<a> {
 }
 
 // Rel(Number) represents the number of directories up from the base point
-enum Base {
+enum rec Base {
   Rel(Number),
   Abs(AbsoluteRoot),
 },
@@ -129,7 +129,7 @@ abstract record Directory {
  * Represents a path typed on (`Absolute` or `Relative`) and (`File` or
  * `Directory`)
  */
-abstract type TypedPath<a, b> = (TBase<a>, TFileType<b>, List<String>),
+abstract type rec TypedPath<a, b> = (TBase<a>, TFileType<b>, List<String>),
 /**
  * Represents a system path.
  */

--- a/stdlib/path.gr
+++ b/stdlib/path.gr
@@ -79,18 +79,18 @@ record TFileType<a> {
 }
 
 // Rel(Number) represents the number of directories up from the base point
-enum rec Base {
+enum Base {
   Rel(Number),
   Abs(AbsoluteRoot),
-},
-type PathInfo = (Base, FileType, List<String>),
-record TBase<a> {
+}
+and type PathInfo = (Base, FileType, List<String>)
+and record TBase<a> {
   base: Base,
-},
+}
 /**
  * Represents an absolute path's anchor point.
  */
-provide enum AbsoluteRoot {
+and provide enum AbsoluteRoot {
   Root,
   Drive(Char),
 }
@@ -129,11 +129,11 @@ abstract record Directory {
  * Represents a path typed on (`Absolute` or `Relative`) and (`File` or
  * `Directory`)
  */
-abstract type rec TypedPath<a, b> = (TBase<a>, TFileType<b>, List<String>),
+abstract type TypedPath<a, b> = (TBase<a>, TFileType<b>, List<String>)
 /**
  * Represents a system path.
  */
-provide enum Path {
+and provide enum Path {
   AbsoluteFile(TypedPath<Absolute, File>),
   AbsoluteDir(TypedPath<Absolute, Directory>),
   RelativeFile(TypedPath<Relative, File>),

--- a/stdlib/path.gr
+++ b/stdlib/path.gr
@@ -79,7 +79,7 @@ record TFileType<a> {
 }
 
 // Rel(Number) represents the number of directories up from the base point
-enum Base {
+enum rec Base {
   Rel(Number),
   Abs(AbsoluteRoot),
 }
@@ -129,7 +129,7 @@ abstract record Directory {
  * Represents a path typed on (`Absolute` or `Relative`) and (`File` or
  * `Directory`)
  */
-abstract type TypedPath<a, b> = (TBase<a>, TFileType<b>, List<String>)
+abstract type rec TypedPath<a, b> = (TBase<a>, TFileType<b>, List<String>)
 /**
  * Represents a system path.
  */

--- a/stdlib/priorityqueue.gr
+++ b/stdlib/priorityqueue.gr
@@ -264,7 +264,7 @@ provide module Immutable {
   // as described in the paper "Optimal Purely Functional Priority Queues" by Chris Okasaki.
 
   // rank is a stand-in for height of this skew binomial tree
-  record Node<a> {
+  record rec Node<a> {
     val: a,
     rank: Number,
     children: List<Node<a>>,

--- a/stdlib/regex.gr
+++ b/stdlib/regex.gr
@@ -407,7 +407,7 @@ enum UnicodeCategory {
   OtherPrivateUse,
 }
 
-enum ParsedRegularExpression {
+enum rec ParsedRegularExpression {
   RENever,
   REEmpty,
   REAny,

--- a/stdlib/regex.gr
+++ b/stdlib/regex.gr
@@ -245,8 +245,8 @@ let rec rangeAdd = (rng: CharRange, v: CharRangeElt) => {
     _ when rangeContains(rng, v) => rng,
     _ => rangeUnion(rng, [(v, v)]),
   }
-},
-rangeUnion = (rng1, rng2) => {
+}
+and rangeUnion = (rng1, rng2) => {
   match ((rng1, rng2)) {
     ([], _) => rng2,
     (_, []) => rng1,
@@ -643,8 +643,8 @@ let rec parseRangeNot = (buf: RegExBuf) => {
       Ok(_) => parseRange(buf),
     }
   }
-},
-parseRange = (buf: RegExBuf) => {
+}
+and parseRange = (buf: RegExBuf) => {
   if (!more(buf)) {
     Err(parseErr(buf, "Missing closing `]`", 0))
   } else {
@@ -667,8 +667,8 @@ parseRange = (buf: RegExBuf) => {
       Ok(_) => parseRangeRest(buf, [], None, None),
     }
   }
-},
-parseClass = (buf: RegExBuf) => {
+}
+and parseClass = (buf: RegExBuf) => {
   if (!more(buf)) {
     Err(
       "no chars"
@@ -703,8 +703,8 @@ parseClass = (buf: RegExBuf) => {
       Ok(c) => Err("unknown class: " ++ toString(c)),
     }
   }
-},
-parsePosixCharClass = (buf: RegExBuf) => {
+}
+and parsePosixCharClass = (buf: RegExBuf) => {
   if (!more(buf)) {
     Err(parseErr(buf, "Missing POSIX character class after `[`", 0))
   } else {
@@ -820,8 +820,8 @@ parsePosixCharClass = (buf: RegExBuf) => {
         ),
     }
   }
-},
-parseRangeRest =
+}
+and parseRangeRest =
   (
     buf: RegExBuf,
     rng: CharRange,
@@ -973,8 +973,8 @@ parseRangeRest =
       },
     }
   }
-},
-parseRangeRestSpan =
+}
+and parseRangeRestSpan =
   (
     buf: RegExBuf,
     c,
@@ -1223,8 +1223,8 @@ let rec parseAtom = (buf: RegExBuf) => {
         _ => parseLiteral(buf),
       },
   }
-},
-parseLook = (buf: RegExBuf) => {
+}
+and parseLook = (buf: RegExBuf) => {
   let preNumGroups = unbox(buf.config.groupNumber)
   let spanNumGroups = () => unbox(buf.config.groupNumber) - preNumGroups
   // (isMatch, isAhead)
@@ -1290,8 +1290,8 @@ parseLook = (buf: RegExBuf) => {
       }
     },
   }
-},
-parseTest = (buf: RegExBuf) => {
+}
+and parseTest = (buf: RegExBuf) => {
   if (!more(buf)) {
     Err(parseErr(buf, "Expected test", 0))
   } else {
@@ -1328,8 +1328,8 @@ parseTest = (buf: RegExBuf) => {
         ),
     }
   }
-},
-parseInteger = (buf: RegExBuf, n) => {
+}
+and parseInteger = (buf: RegExBuf, n) => {
   if (!more(buf)) {
     Ok(n)
   } else {
@@ -1344,8 +1344,8 @@ parseInteger = (buf: RegExBuf, n) => {
       Ok(_) => Ok(n),
     }
   }
-},
-parseMode = (buf: RegExBuf) => {
+}
+and parseMode = (buf: RegExBuf) => {
   let processState = ((cs, ml)) => {
     let withCs = match (cs) {
       None => buf.config,
@@ -1404,8 +1404,8 @@ parseMode = (buf: RegExBuf) => {
     }
   }
   help((None, None))
-},
-parseUnicodeCategories = (buf: RegExBuf, pC: String) => {
+}
+and parseUnicodeCategories = (buf: RegExBuf, pC: String) => {
   if (!more(buf)) {
     Err(parseErr(buf, "Expected unicode category", 0))
   } else {
@@ -1573,8 +1573,8 @@ parseUnicodeCategories = (buf: RegExBuf, pC: String) => {
       Ok(_) => Err(parseErr(buf, "Expected `{` after `\\" ++ pC ++ "`", 0)),
     }
   }
-},
-parseLiteral = (buf: RegExBuf) => {
+}
+and parseLiteral = (buf: RegExBuf) => {
   if (!more(buf)) {
     Err(parseErr(buf, "Expected literal", 0))
   } else {
@@ -1608,8 +1608,8 @@ parseLiteral = (buf: RegExBuf) => {
       },
     }
   }
-},
-parseBackslashLiteral = (buf: RegExBuf) => {
+}
+and parseBackslashLiteral = (buf: RegExBuf) => {
   if (!more(buf)) {
     // Special case: EOS after backslash matches null
     Err(parseErr(buf, "Expected to find escaped value after backslash", 0))
@@ -1672,8 +1672,8 @@ parseBackslashLiteral = (buf: RegExBuf) => {
       },
     }
   }
-},
-parseNonGreedy = (buf: RegExBuf) => {
+}
+and parseNonGreedy = (buf: RegExBuf) => {
   let checkNotNested = res => {
     if (!more(buf)) {
       res
@@ -1699,8 +1699,8 @@ parseNonGreedy = (buf: RegExBuf) => {
       Ok(_) => checkNotNested(Ok(false)),
     }
   }
-},
-parsePCE = (buf: RegExBuf) => {
+}
+and parsePCE = (buf: RegExBuf) => {
   match (parseAtom(buf)) {
     Err(e) => Err(e),
     Ok(atom) => {
@@ -1794,8 +1794,8 @@ parsePCE = (buf: RegExBuf) => {
       }
     },
   }
-},
-parsePCEs = (buf: RegExBuf, toplevel: Bool) => {
+}
+and parsePCEs = (buf: RegExBuf, toplevel: Bool) => {
   if (!more(buf)) {
     Ok([])
   } else {
@@ -1821,8 +1821,8 @@ parsePCEs = (buf: RegExBuf, toplevel: Bool) => {
       },
     }
   }
-},
-parseRegex = (buf: RegExBuf) => {
+}
+and parseRegex = (buf: RegExBuf) => {
   if (!more(buf)) {
     Ok(REEmpty)
   } else {
@@ -1857,8 +1857,8 @@ parseRegex = (buf: RegExBuf) => {
       },
     }
   }
-},
-parseRegexNonEmpty = (buf: RegExBuf) => {
+}
+and parseRegexNonEmpty = (buf: RegExBuf) => {
   match (parsePCEs(buf, false)) {
     Err(e) => Err(e),
     Ok(pces) => {

--- a/stdlib/runtime/atof/lemire.gr
+++ b/stdlib/runtime/atof/lemire.gr
@@ -94,8 +94,8 @@ let computeProductApprox = (q: WasmI64, w: WasmI64, precision: WasmI64) => {
   let index = q - _SMALLEST_POWER_OF_FIVE
   let n = 16n * WasmI32.wrapI64(index)
   from WasmI32 use { (+) }
-  let lo5 = WasmI64.load(get_POWERS5(), n),
-    hi5 = WasmI64.load(get_POWERS5(), n + 8n)
+  let lo5 = WasmI64.load(get_POWERS5(), n)
+  and hi5 = WasmI64.load(get_POWERS5(), n + 8n)
   from WasmI64 use { (+) }
   // From Rust:
   // Only need one multiplication as long as there is 1 zero but

--- a/stdlib/runtime/compare.gr
+++ b/stdlib/runtime/compare.gr
@@ -156,8 +156,8 @@ let rec heapCompareHelp = (heapTag, xptr, yptr) => {
       return tagSimpleNumber(xptr - yptr)
     },
   }
-},
-compareHelp = (x, y) => {
+}
+and compareHelp = (x, y) => {
   let xtag = x & Tags._GRAIN_GENERIC_TAG_MASK
   let ytag = y & Tags._GRAIN_GENERIC_TAG_MASK
   if ((xtag & ytag) != Tags._GRAIN_GENERIC_HEAP_TAG_TYPE) {

--- a/stdlib/runtime/equal.gr
+++ b/stdlib/runtime/equal.gr
@@ -196,8 +196,8 @@ let rec heapEqualHelp = (heapTag, xptr, yptr) => {
       xptr == yptr
     },
   }
-},
-equalHelp = (x, y) => {
+}
+and equalHelp = (x, y) => {
   if (
     (x & Tags._GRAIN_GENERIC_TAG_MASK) != 0n &&
     (y & Tags._GRAIN_GENERIC_TAG_MASK) != 0n

--- a/stdlib/runtime/gc.gr
+++ b/stdlib/runtime/gc.gr
@@ -109,8 +109,8 @@ let rec decRef = (userPtr: WasmI32, ignoreZeros: Bool) => {
   } else {
     userPtr
   }
-},
-decRefChildren = (userPtr: WasmI32) => {
+}
+and decRefChildren = (userPtr: WasmI32) => {
   match (WasmI32.load(userPtr, 0n)) {
     t when t == Tags._GRAIN_BOXED_NUM_HEAP_TAG => {
       let tag = WasmI32.load(userPtr, 4n)

--- a/stdlib/runtime/numbers.gr
+++ b/stdlib/runtime/numbers.gr
@@ -3007,16 +3007,16 @@ provide let (**) = (base, power) => {
         return WasmI32.toGrain(newFloat64(d / d)): Number
       } else if (yisint == 1n) s = -1.0W
     }
-    let mut t1 = 0.0W,
-      t2 = 0.0W,
-      p_h = 0.0W,
-      p_l = 0.0W,
-      r = 0.0W,
-      t = 0.0W,
-      u = 0.0W,
-      v = 0.0W,
-      w = 0.0W
-    let mut j = 0n, n = 0n
+    let mut t1 = 0.0W
+    and t2 = 0.0W
+    and p_h = 0.0W
+    and p_l = 0.0W
+    and r = 0.0W
+    and t = 0.0W
+    and u = 0.0W
+    and v = 0.0W
+    and w = 0.0W
+    let mut j = 0n and n = 0n
     if (iy > 0x41E00000n) {
       if (iy > 0x43F00000n) {
         if (ix <= 0x3FEFFFFFn) {
@@ -3053,12 +3053,12 @@ provide let (**) = (base, power) => {
         t2 = v - (t1 - u)
       }
     } else {
-      let mut ss = 0.0W,
-        s2 = 0.0W,
-        s_h = 0.0W,
-        s_l = 0.0W,
-        t_h = 0.0W,
-        t_l = 0.0W
+      let mut ss = 0.0W
+      and s2 = 0.0W
+      and s_h = 0.0W
+      and s_l = 0.0W
+      and t_h = 0.0W
+      and t_l = 0.0W
       n = 0n
       if (ix < 0x00100000n) {
         from WasmI64 use { (>>>) }

--- a/stdlib/runtime/numbers.gr
+++ b/stdlib/runtime/numbers.gr
@@ -3016,7 +3016,8 @@ provide let (**) = (base, power) => {
     and u = 0.0W
     and v = 0.0W
     and w = 0.0W
-    let mut j = 0n and n = 0n
+    let mut j = 0n
+    and n = 0n
     if (iy > 0x41E00000n) {
       if (iy > 0x43F00000n) {
         if (ix <= 0x3FEFFFFFn) {

--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -645,7 +645,14 @@ and tupleVariantToString = (ptr, variantName, extraIndents) => {
     join(strings)
   }
 }
-and recordToString = (ptr, recordArity, fields, contentOffset, extraIndents) => {
+and recordToString =
+  (
+    ptr,
+    recordArity,
+    fields,
+    contentOffset,
+    extraIndents,
+  ) => {
   let prevPadAmount = extraIndents * 2n
   let prevSpacePadding = if (prevPadAmount == 0n) {
     ""

--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -554,8 +554,8 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
       join(strings)
     },
   }
-},
-toStringHelp = (grainValue, extraIndents, toplevel) => {
+}
+and toStringHelp = (grainValue, extraIndents, toplevel) => {
   if ((grainValue & 1n) != 0n) {
     // Simple (unboxed) numbers
     NumberUtils.itoa32(grainValue >> 1n, 10n)
@@ -596,8 +596,8 @@ toStringHelp = (grainValue, extraIndents, toplevel) => {
       "<unknown value>"
     }
   }
-},
-listToString = (ptr, extraIndents) => {
+}
+and listToString = (ptr, extraIndents) => {
   let mut cur = ptr
   let mut isFirst = true
 
@@ -623,8 +623,8 @@ listToString = (ptr, extraIndents) => {
   strings = [rbrack, ...strings]
   let reversed = reverse(strings)
   join(reversed)
-},
-tupleVariantToString = (ptr, variantName, extraIndents) => {
+}
+and tupleVariantToString = (ptr, variantName, extraIndents) => {
   let variantArity = WasmI32.load(ptr, 16n)
   if (variantArity == 0n) {
     variantName
@@ -644,8 +644,8 @@ tupleVariantToString = (ptr, variantName, extraIndents) => {
 
     join(strings)
   }
-},
-recordToString = (ptr, recordArity, fields, contentOffset, extraIndents) => {
+}
+and recordToString = (ptr, recordArity, fields, contentOffset, extraIndents) => {
   let prevPadAmount = extraIndents * 2n
   let prevSpacePadding = if (prevPadAmount == 0n) {
     ""

--- a/stdlib/set.gr
+++ b/stdlib/set.gr
@@ -475,7 +475,7 @@ provide module Immutable {
   // implementation based on the paper "Implementing Sets Efficiently in a
   // Functional Language" by Stephen Adams
 
-  record Node<a> {
+  record rec Node<a> {
     key: a,
     size: Number,
     left: Set<a>,

--- a/stdlib/set.gr
+++ b/stdlib/set.gr
@@ -14,7 +14,7 @@ include "array"
 include "hash"
 from Hash use { hash }
 
-record Bucket<t> {
+record rec Bucket<t> {
   mut key: t,
   mut next: Option<Bucket<t>>,
 }
@@ -475,7 +475,7 @@ provide module Immutable {
   // implementation based on the paper "Implementing Sets Efficiently in a
   // Functional Language" by Stephen Adams
 
-  record Node<a> {
+  record rec Node<a> {
     key: a,
     size: Number,
     left: Set<a>,

--- a/stdlib/set.gr
+++ b/stdlib/set.gr
@@ -475,13 +475,13 @@ provide module Immutable {
   // implementation based on the paper "Implementing Sets Efficiently in a
   // Functional Language" by Stephen Adams
 
-  record rec Node<a> {
+  record Node<a> {
     key: a,
     size: Number,
     left: Set<a>,
     right: Set<a>,
-  },
-  abstract enum Set<a> {
+  }
+  and abstract enum Set<a> {
     Empty,
     Tree(Node<a>),
   }

--- a/stdlib/string.gr
+++ b/stdlib/string.gr
@@ -701,7 +701,9 @@ provide let contains = (search: String, string: String) => {
   string += 8n
   search += 8n
 
-  let mut j = 0n and k = 0n and ell = 0n
+  let mut j = 0n
+  and k = 0n
+  and ell = 0n
 
   if (m > n) {
     // Bail if pattern length is longer than input length
@@ -2021,7 +2023,8 @@ let trimString = (str: String, fromEnd: Bool) => {
   let mut stringPtr = WasmI32.fromGrain(str)
   let byteLength = WasmI32.load(stringPtr, 4n)
   stringPtr += 8n
-  let mut i = 0n and offset = 1n
+  let mut i = 0n
+  and offset = 1n
   if (fromEnd) {
     i = byteLength - 1n
     offset = -1n

--- a/stdlib/string.gr
+++ b/stdlib/string.gr
@@ -701,7 +701,7 @@ provide let contains = (search: String, string: String) => {
   string += 8n
   search += 8n
 
-  let mut j = 0n, k = 0n, ell = 0n
+  let mut j = 0n and k = 0n and ell = 0n
 
   if (m > n) {
     // Bail if pattern length is longer than input length
@@ -2021,7 +2021,7 @@ let trimString = (str: String, fromEnd: Bool) => {
   let mut stringPtr = WasmI32.fromGrain(str)
   let byteLength = WasmI32.load(stringPtr, 4n)
   stringPtr += 8n
-  let mut i = 0n, offset = 1n
+  let mut i = 0n and offset = 1n
   if (fromEnd) {
     i = byteLength - 1n
     offset = -1n


### PR DESCRIPTION
Requires that recursive type definitions use `rec` keyword

```
record rec T {
  x: T
}
```
Mutually recursive types are also self-recursive
```
record A {
  x: Number
}
and enum B {
  B(A)
}
```
Closes #1420 