### PR TITLE
fix(stdlib)!: Remove extra space when converting Bytes to String

### DIFF
--- a/compiler/test/suites/strings.re
+++ b/compiler/test/suites/strings.re
@@ -296,6 +296,11 @@ bar", 1))|},
 
   // Bytes literals
   assertRun("bytes_literal", {|print(b"abc")|}, "<bytes: 61 62 63>\n");
+  assertRun(
+    "bytes_literal",
+    {|print(b"111111111111111111111111111111111111111111111111111111111111111111111111")|},
+    "<bytes: 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31...>\n",
+  );
   assertCompileError(
     "bytes_literal_err1",
     {|print(b"abc\u1234")|},

--- a/compiler/test/suites/strings.re
+++ b/compiler/test/suites/strings.re
@@ -299,7 +299,7 @@ bar", 1))|},
   assertRun(
     "bytes_literal_long",
     {|print(b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefg")|},
-    "<bytes: 41 42 43 44 45 46 47 48 49 4a 4b 4c 4d 4e 4f 50 51 52 53 54 55 56 57 58 59 5a 61 62 63 64 65 66 67...>\n",
+    "<bytes: 41 42 43 44 45 46 47 48 49 4a 4b 4c 4d 4e 4f 50 51 52 53 54 55 56 57 58 59 5a 61 62 63 64 65 66...>\n",
   );
   assertCompileError(
     "bytes_literal_err1",

--- a/compiler/test/suites/strings.re
+++ b/compiler/test/suites/strings.re
@@ -297,9 +297,9 @@ bar", 1))|},
   // Bytes literals
   assertRun("bytes_literal", {|print(b"abc")|}, "<bytes: 61 62 63>\n");
   assertRun(
-    "bytes_literal",
-    {|print(b"111111111111111111111111111111111111111111111111111111111111111111111111")|},
-    "<bytes: 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31 31...>\n",
+    "bytes_literal_long",
+    {|print(b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefg")|},
+    "<bytes: 41 42 43 44 45 46 47 48 49 4a 4b 4c 4d 4e 4f 50 51 52 53 54 55 56 57 58 59 5a 61 62 63 64 65 66 67...>\n",
   );
   assertCompileError(
     "bytes_literal_err1",

--- a/compiler/test/suites/strings.re
+++ b/compiler/test/suites/strings.re
@@ -295,7 +295,7 @@ bar", 1))|},
   );
 
   // Bytes literals
-  assertRun("bytes_literal", {|print(b"abc")|}, "<bytes: 61 62 63 >\n");
+  assertRun("bytes_literal", {|print(b"abc")|}, "<bytes: 61 62 63>\n");
   assertCompileError(
     "bytes_literal_err1",
     {|print(b"abc\u1234")|},

--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -367,9 +367,10 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
         needsEllipsis = true
       }
       let headBytes = 8n // <bytes:
+      // This is two digits and a space for each byte, minus one space for the last byte
       let hexBytes = numBytes * 3n - 1n
       let tailBytes = if (needsEllipsis) {
-        5n // ...>
+        4n // ...>
       } else {
         1n // >
       }

--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -367,7 +367,7 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
         needsEllipsis = true
       }
       let headBytes = 8n // <bytes:
-      let hexBytes = numBytes * 3n
+      let hexBytes = numBytes * 3n - 1n
       let tailBytes = if (needsEllipsis) {
         5n // ...>
       } else {


### PR DESCRIPTION
Closes: #1799 
This pr removes the trailing space when printing bytes literals, it looked off with the trailing space before the space seemed to have come from when we caculate the string length we do `numBytes * 3` two chars for the hex and 1 char for the space and then we use memory.Fill to fill the string with spaces this by subtracting one from the `numBytes * 3` we get rid of the spot for the trailing space.

Breaking: This changes that behaviour of `toString` and `print` to a user.


Note: I did not see any test for the `...` behaviour or print should i add a test under the test for bytes_literals printing to test strings taht are too long?