### PR TITLE
chore: Update license year

### DIFF
--- a/js-runner/LICENSE
+++ b/js-runner/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-2022 Oscar Spencer <oscar@grain-lang.org> and Philip Blair <philip@grain-lang.org>
+Copyright (c) 2017-2023 Oscar Spencer <oscar@grain-lang.org> and Philip Blair <philip@grain-lang.org>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/stdlib/LICENSE
+++ b/stdlib/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-2022 Oscar Spencer <oscar@grain-lang.org> and Philip Blair <philip@grain-lang.org>
+Copyright (c) 2017-2023 Oscar Spencer <oscar@grain-lang.org> and Philip Blair <philip@grain-lang.org>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This changes the license year from `2022` to `2023` in the stdlib and js-runner license's looks like we missed it when we changed the main copyright notice.