### PR TITLE
feat(compiler)!: Reduce size of runtime heap

### DIFF
--- a/docs/contributor/runtime.md
+++ b/docs/contributor/runtime.md
@@ -4,7 +4,7 @@ When we speak of the Grain runtime, we largely mean the memory allocator, garbag
 
 ## The Runtime Heap
 
-Currently, the Grain runtime heap spans half a WebAssembly page of memory. The low 1K of memory is reserved for Binaryen optimizations, the next few bytes are reserved for some static pointers (which we'll go over next), and the rest of half-page is space used for runtime allocations. It's important to note that this space is unmanaged. After all, we don't have a memory manager yet—we want to compile the memory manager. Allocations are done just by incrementing a bytes counter. This means that no space can be reclaimed—as such, runtime modules should do no dynamic allocations. Ideally, the only allocations that should occur are for the closures of top-level functions that are used by other modules.
+Currently, the Grain runtime heap reserves 2048 bytes of WebAssembly memory. The low 1K of memory is reserved for Binaryen optimizations, the next few bytes are reserved for some static pointers (which we'll go over next), and the rest of the space is used for runtime allocations. It's important to note that this space is unmanaged. After all, we don't have a memory manager yet—we want to compile the memory manager. Allocations are done just by incrementing a bytes counter. This means that no space can be reclaimed—as such, runtime modules should do no dynamic allocations. Ideally, the only allocations that should occur are for the closures of top-level functions that are used by other modules.
 
 ## Static Runtime Pointers
 

--- a/stdlib/runtime/malloc.gr
+++ b/stdlib/runtime/malloc.gr
@@ -76,7 +76,7 @@ let logMallocHeaderSize = 3n
  */
 let mut heapSize = 0n
 
-provide let _RESERVED_RUNTIME_SPACE = 0x4000n
+provide let _RESERVED_RUNTIME_SPACE = 0x800n
 
 /**
  * The base the heap. The block at this address will be size 0 and


### PR DESCRIPTION
Since #1410 was landed, far less memory is used in programs run in runtime mode. I did an audit, and it seems that we now only use ~650 bytes, so I reduced the reserved runtime size from 16384 bytes down to 2048 bytes. This is helpful when running in some memory-constrained runtimes, like wasm4.