### PR TITLE
feat(compiler)!: Make types nonrecursive by default

### DIFF
--- a/compiler/src/formatting/format.re
+++ b/compiler/src/formatting/format.re
@@ -4379,6 +4379,11 @@ let rec print_data =
       Doc.concat([
         Doc.text("type"),
         Doc.space,
+        if (data.pdata_rec == Recursive) {
+          Doc.text("rec ");
+        } else {
+          Doc.nil;
+        },
         Doc.text(data.pdata_name.txt),
         Doc.group(
           Doc.concat([
@@ -4448,6 +4453,11 @@ let rec print_data =
       Doc.concat([
         Doc.text("type"),
         Doc.space,
+        if (data.pdata_rec == Recursive) {
+          Doc.text("rec ");
+        } else {
+          Doc.nil;
+        },
         Doc.group(Doc.concat([Doc.text(data.pdata_name.txt), ...params])),
         switch (data.pdata_manifest) {
         | Some(manifest) =>
@@ -4623,6 +4633,11 @@ let rec print_data =
       Doc.concat([
         Doc.text("enum"),
         Doc.space,
+        if (data.pdata_rec == Recursive) {
+          Doc.text("rec ");
+        } else {
+          Doc.nil;
+        },
         Doc.text(nameloc.txt),
         switch (data.pdata_params) {
         | [] => Doc.space
@@ -4738,6 +4753,11 @@ let rec print_data =
       Doc.concat([
         Doc.text("record"),
         Doc.space,
+        if (data.pdata_rec == Recursive) {
+          Doc.text("rec ");
+        } else {
+          Doc.nil;
+        },
         Doc.text(nameloc.txt),
         switch (data.pdata_params) {
         | [] => Doc.space

--- a/compiler/src/parsing/ast_helper.re
+++ b/compiler/src/parsing/ast_helper.re
@@ -141,10 +141,10 @@ module LabelDeclaration = {
 };
 
 module DataDeclaration = {
-  let mk = (~loc=?, r, n, t, k, m) => {
+  let mk = (~loc=?, ~rec_flag=Nonrecursive, n, t, k, m) => {
     let loc = Option.value(~default=Location.dummy_loc, loc);
     {
-      pdata_rec: r,
+      pdata_rec: rec_flag,
       pdata_name: n,
       pdata_params: t,
       pdata_kind: k,
@@ -152,12 +152,12 @@ module DataDeclaration = {
       pdata_loc: loc,
     };
   };
-  let abstract = (~loc=?, r, n, t, m) =>
-    mk(~loc?, r, n, t, PDataAbstract, m);
-  let variant = (~loc=?, r, n, t, cdl) =>
-    mk(~loc?, r, n, t, PDataVariant(cdl), None);
-  let record = (~loc=?, r, n, t, ldl) =>
-    mk(~loc?, r, n, t, PDataRecord(ldl), None);
+  let abstract = (~loc=?, ~rec_flag=?, n, t, m) =>
+    mk(~loc?, ~rec_flag?, n, t, PDataAbstract, m);
+  let variant = (~loc=?, ~rec_flag=?, n, t, cdl) =>
+    mk(~loc?, ~rec_flag?, n, t, PDataVariant(cdl), None);
+  let record = (~loc=?, ~rec_flag=?, n, t, ldl) =>
+    mk(~loc?, ~rec_flag?, n, t, PDataRecord(ldl), None);
 };
 
 module Exception = {

--- a/compiler/src/parsing/ast_helper.re
+++ b/compiler/src/parsing/ast_helper.re
@@ -141,9 +141,10 @@ module LabelDeclaration = {
 };
 
 module DataDeclaration = {
-  let mk = (~loc=?, n, t, k, m) => {
+  let mk = (~loc=?, r, n, t, k, m) => {
     let loc = Option.value(~default=Location.dummy_loc, loc);
     {
+      pdata_rec: r,
       pdata_name: n,
       pdata_params: t,
       pdata_kind: k,
@@ -151,11 +152,12 @@ module DataDeclaration = {
       pdata_loc: loc,
     };
   };
-  let abstract = (~loc=?, n, t, m) => mk(~loc?, n, t, PDataAbstract, m);
-  let variant = (~loc=?, n, t, cdl) =>
-    mk(~loc?, n, t, PDataVariant(cdl), None);
-  let record = (~loc=?, n, t, ldl) =>
-    mk(~loc?, n, t, PDataRecord(ldl), None);
+  let abstract = (~loc=?, r, n, t, m) =>
+    mk(~loc?, r, n, t, PDataAbstract, m);
+  let variant = (~loc=?, r, n, t, cdl) =>
+    mk(~loc?, r, n, t, PDataVariant(cdl), None);
+  let record = (~loc=?, r, n, t, ldl) =>
+    mk(~loc?, r, n, t, PDataRecord(ldl), None);
 };
 
 module Exception = {

--- a/compiler/src/parsing/ast_helper.rei
+++ b/compiler/src/parsing/ast_helper.rei
@@ -90,7 +90,7 @@ module DataDeclaration: {
   let mk:
     (
       ~loc: loc=?,
-      rec_flag,
+      ~rec_flag: rec_flag=?,
       str,
       list(parsed_type),
       data_kind,
@@ -98,12 +98,18 @@ module DataDeclaration: {
     ) =>
     data_declaration;
   let abstract:
-    (~loc: loc=?, rec_flag, str, list(parsed_type), option(parsed_type)) =>
+    (
+      ~loc: loc=?,
+      ~rec_flag: rec_flag=?,
+      str,
+      list(parsed_type),
+      option(parsed_type)
+    ) =>
     data_declaration;
   let variant:
     (
       ~loc: loc=?,
-      rec_flag,
+      ~rec_flag: rec_flag=?,
       str,
       list(parsed_type),
       list(constructor_declaration)
@@ -112,7 +118,7 @@ module DataDeclaration: {
   let record:
     (
       ~loc: loc=?,
-      rec_flag,
+      ~rec_flag: rec_flag=?,
       str,
       list(parsed_type),
       list(label_declaration)

--- a/compiler/src/parsing/ast_helper.rei
+++ b/compiler/src/parsing/ast_helper.rei
@@ -88,16 +88,35 @@ module LabelDeclaration: {
 
 module DataDeclaration: {
   let mk:
-    (~loc: loc=?, str, list(parsed_type), data_kind, option(parsed_type)) =>
+    (
+      ~loc: loc=?,
+      rec_flag,
+      str,
+      list(parsed_type),
+      data_kind,
+      option(parsed_type)
+    ) =>
     data_declaration;
   let abstract:
-    (~loc: loc=?, str, list(parsed_type), option(parsed_type)) =>
+    (~loc: loc=?, rec_flag, str, list(parsed_type), option(parsed_type)) =>
     data_declaration;
   let variant:
-    (~loc: loc=?, str, list(parsed_type), list(constructor_declaration)) =>
+    (
+      ~loc: loc=?,
+      rec_flag,
+      str,
+      list(parsed_type),
+      list(constructor_declaration)
+    ) =>
     data_declaration;
   let record:
-    (~loc: loc=?, str, list(parsed_type), list(label_declaration)) =>
+    (
+      ~loc: loc=?,
+      rec_flag,
+      str,
+      list(parsed_type),
+      list(label_declaration)
+    ) =>
     data_declaration;
 };
 

--- a/compiler/src/parsing/ast_mapper.re
+++ b/compiler/src/parsing/ast_mapper.re
@@ -316,17 +316,17 @@ module D = {
     let sargs = List.map(sub.typ(sub), args);
     let sman = Option.map(sub.typ(sub), man);
     switch (kind) {
-    | PDataAbstract => abstract(~loc, rec_flag, sname, sargs, sman)
+    | PDataAbstract => abstract(~loc, ~rec_flag, sname, sargs, sman)
     | PDataVariant(cdl) =>
       variant(
         ~loc,
-        rec_flag,
+        ~rec_flag,
         sname,
         sargs,
         List.map(sub.constructor(sub), cdl),
       )
     | PDataRecord(ldl) =>
-      record(~loc, rec_flag, sname, sargs, List.map(sub.label(sub), ldl))
+      record(~loc, ~rec_flag, sname, sargs, List.map(sub.label(sub), ldl))
     };
   };
 };

--- a/compiler/src/parsing/ast_mapper.re
+++ b/compiler/src/parsing/ast_mapper.re
@@ -302,6 +302,7 @@ module D = {
       (
         sub,
         {
+          pdata_rec: rec_flag,
           pdata_name: name,
           pdata_params: args,
           pdata_kind: kind,
@@ -315,11 +316,17 @@ module D = {
     let sargs = List.map(sub.typ(sub), args);
     let sman = Option.map(sub.typ(sub), man);
     switch (kind) {
-    | PDataAbstract => abstract(~loc, sname, sargs, sman)
+    | PDataAbstract => abstract(~loc, rec_flag, sname, sargs, sman)
     | PDataVariant(cdl) =>
-      variant(~loc, sname, sargs, List.map(sub.constructor(sub), cdl))
+      variant(
+        ~loc,
+        rec_flag,
+        sname,
+        sargs,
+        List.map(sub.constructor(sub), cdl),
+      )
     | PDataRecord(ldl) =>
-      record(~loc, sname, sargs, List.map(sub.label(sub), ldl))
+      record(~loc, rec_flag, sname, sargs, List.map(sub.label(sub), ldl))
     };
   };
 };

--- a/compiler/src/parsing/parser.messages
+++ b/compiler/src/parsing/parser.messages
@@ -811,6 +811,18 @@ program: MODULE UIDENT EOL TYPE UIDENT EQUAL UIDENT AND PROVIDE YIELD
 
 Mutually recursive type declarations are separated by `and`, but cannot be mixed with other kinds of expressions.
 
+program: MODULE UIDENT EOL TYPE REC YIELD
+##
+## Ends in an error in state: 744.
+##
+## data_declaration -> TYPE option(rec_flag) . UIDENT option(id_vec) equal typ [ SEMI RBRACE EOL EOF COMMA ]
+##
+## The known suffix of the stack is as follows:
+## TYPE option(rec_flag)
+##
+
+Expected a capitalized type name.
+
 program: MODULE UIDENT EOL ENUM UIDENT LBRACE UIDENT WHILE
 ##
 ## Ends in an error in state: 949.
@@ -899,6 +911,18 @@ program: MODULE UIDENT EOL ENUM WHILE
 ##
 ## The known suffix of the stack is as follows:
 ## ENUM
+##
+
+Expected `rec` or a capitalized name for the enum declaration.
+
+program: MODULE UIDENT EOL ENUM REC YIELD
+##
+## Ends in an error in state: 805.
+##
+## data_declaration -> ENUM option(rec_flag) . UIDENT option(id_vec) data_constructors [ SEMI RBRACE EOL EOF COMMA ]
+##
+## The known suffix of the stack is as follows:
+## ENUM option(rec_flag)
 ##
 
 Expected a capitalized name for the enum declaration.
@@ -5123,6 +5147,18 @@ program: MODULE UIDENT EOL RECORD WHILE
 ##
 ## The known suffix of the stack is as follows:
 ## RECORD
+##
+
+Expected `rec` or a capitalized name for the record type.
+
+program: MODULE UIDENT EOL RECORD REC YIELD
+##
+## Ends in an error in state: 759.
+##
+## data_declaration -> RECORD option(rec_flag) . UIDENT option(id_vec) data_record_body [ SEMI RBRACE EOL EOF COMMA ]
+##
+## The known suffix of the stack is as follows:
+## RECORD option(rec_flag)
 ##
 
 Expected a capitalized identifier for the record type.

--- a/compiler/src/parsing/parser.mly
+++ b/compiler/src/parsing/parser.mly
@@ -411,10 +411,13 @@ id_typ:
 id_vec:
   | lcaret lseparated_nonempty_list(comma, id_typ) comma? rcaret {$2}
 
+rec_flag:
+  | REC { Recursive }
+
 data_declaration:
-  | TYPE REC? UIDENT id_vec? equal typ { DataDeclaration.abstract ~loc:(to_loc $loc) (if Option.is_some $2 then Recursive else Nonrecursive) (mkstr $loc($3) $3) (Option.value ~default:[] $4) (Some $6) }
-  | ENUM REC? UIDENT id_vec? data_constructors { DataDeclaration.variant ~loc:(to_loc $loc) (if Option.is_some $2 then Recursive else Nonrecursive) (mkstr $loc($3) $3) (Option.value ~default:[] $4) $5 }
-  | RECORD REC? UIDENT id_vec? data_record_body { DataDeclaration.record ~loc:(to_loc $loc) (if Option.is_some $2 then Recursive else Nonrecursive) (mkstr $loc($3) $3) (Option.value ~default:[] $4) $5 }
+  | TYPE rec_flag? UIDENT id_vec? equal typ { DataDeclaration.abstract ~loc:(to_loc $loc) ?rec_flag:$2 (mkstr $loc($3) $3) (Option.value ~default:[] $4) (Some $6) }
+  | ENUM rec_flag? UIDENT id_vec? data_constructors { DataDeclaration.variant ~loc:(to_loc $loc) ?rec_flag:$2 (mkstr $loc($3) $3) (Option.value ~default:[] $4) $5 }
+  | RECORD rec_flag? UIDENT id_vec? data_record_body { DataDeclaration.record ~loc:(to_loc $loc) ?rec_flag:$2 (mkstr $loc($3) $3) (Option.value ~default:[] $4) $5 }
 
 unop_expr:
   | prefix_op non_assign_expr { Expression.apply ~loc:(to_loc $loc) (mkid_expr $loc($1) [mkstr $loc($1) $1]) [{paa_label=Unlabeled; paa_expr=$2; paa_loc=(to_loc $loc($2))}] }

--- a/compiler/src/parsing/parser.mly
+++ b/compiler/src/parsing/parser.mly
@@ -412,9 +412,9 @@ id_vec:
   | lcaret lseparated_nonempty_list(comma, id_typ) comma? rcaret {$2}
 
 data_declaration:
-  | TYPE UIDENT id_vec? equal typ { DataDeclaration.abstract ~loc:(to_loc $loc) (mkstr $loc($2) $2) (Option.value ~default:[] $3) (Some $5) }
-  | ENUM UIDENT id_vec? data_constructors { DataDeclaration.variant ~loc:(to_loc $loc) (mkstr $loc($2) $2) (Option.value ~default:[] $3) $4 }
-  | RECORD UIDENT id_vec? data_record_body { DataDeclaration.record ~loc:(to_loc $loc) (mkstr $loc($2) $2) (Option.value ~default:[] $3) $4 }
+  | TYPE REC? UIDENT id_vec? equal typ { DataDeclaration.abstract ~loc:(to_loc $loc) (if Option.is_some $2 then Recursive else Nonrecursive) (mkstr $loc($3) $3) (Option.value ~default:[] $4) (Some $6) }
+  | ENUM REC? UIDENT id_vec? data_constructors { DataDeclaration.variant ~loc:(to_loc $loc) (if Option.is_some $2 then Recursive else Nonrecursive) (mkstr $loc($3) $3) (Option.value ~default:[] $4) $5 }
+  | RECORD REC? UIDENT id_vec? data_record_body { DataDeclaration.record ~loc:(to_loc $loc) (if Option.is_some $2 then Recursive else Nonrecursive) (mkstr $loc($3) $3) (Option.value ~default:[] $4) $5 }
 
 unop_expr:
   | prefix_op non_assign_expr { Expression.apply ~loc:(to_loc $loc) (mkid_expr $loc($1) [mkstr $loc($1) $1]) [{paa_label=Unlabeled; paa_expr=$2; paa_loc=(to_loc $loc($2))}] }

--- a/compiler/src/parsing/parsetree.re
+++ b/compiler/src/parsing/parsetree.re
@@ -116,6 +116,7 @@ type data_declaration = {
   pdata_params: list(parsed_type),
   pdata_kind: data_kind,
   pdata_manifest: option(parsed_type),
+  pdata_rec: rec_flag,
   [@sexp_drop_if sexp_locs_disabled]
   pdata_loc: Location.t,
 };

--- a/compiler/src/parsing/well_formedness.re
+++ b/compiler/src/parsing/well_formedness.re
@@ -19,7 +19,9 @@ type wferr =
   | ReturnStatementOutsideFunction(Location.t)
   | MismatchedReturnStyles(Location.t)
   | LocalIncludeStatement(Location.t)
-  | ProvidedMultipleTimes(string, Location.t);
+  | ProvidedMultipleTimes(string, Location.t)
+  | MutualRecTypesMissingRec(Location.t)
+  | MutualRecExtraneousNonfirstRec(Location.t);
 
 exception Error(wferr);
 
@@ -91,6 +93,16 @@ let prepare_error =
           ~loc,
           "%s was provided multiple times, but can only be provided once.",
           name,
+        )
+      | MutualRecTypesMissingRec(loc) =>
+        errorf(
+          ~loc,
+          "Mutually recursive type groups must include `rec` on the first type in the group.",
+        )
+      | MutualRecExtraneousNonfirstRec(loc) =>
+        errorf(
+          ~loc,
+          "The `rec` keyword should only appear on the first type in the mutually recursive type group.",
         )
     )
   );
@@ -773,6 +785,37 @@ let provided_multiple_times = (errs, super) => {
   };
 };
 
+let mutual_rec_type_improper_rec_keyword = (errs, super) => {
+  let enter_toplevel_stmt = ({ptop_desc: desc, ptop_loc: loc} as e) => {
+    switch (desc) {
+    | PTopData([(_, first_decl), ...[_, ..._] as rest_decls]) =>
+      if (first_decl.pdata_rec != Recursive) {
+        errs := [MutualRecTypesMissingRec(loc), ...errs^];
+      } else {
+        List.iter(
+          ((_, decl)) =>
+            switch (decl) {
+            | {pdata_rec: Recursive} =>
+              errs := [MutualRecExtraneousNonfirstRec(loc), ...errs^]
+            | _ => ()
+            },
+          rest_decls,
+        );
+      }
+    | _ => ()
+    };
+    super.enter_toplevel_stmt(e);
+  };
+
+  {
+    errs,
+    iter_hooks: {
+      ...super,
+      enter_toplevel_stmt,
+    },
+  };
+};
+
 let compose_well_formedness = ({errs, iter_hooks}, cur) =>
   cur(errs, iter_hooks);
 
@@ -789,6 +832,7 @@ let well_formedness_checks = [
   malformed_return_statements,
   no_local_include,
   provided_multiple_times,
+  mutual_rec_type_improper_rec_keyword,
 ];
 
 let well_formedness_checker = () =>

--- a/compiler/src/typed/typemod.re
+++ b/compiler/src/typed/typemod.re
@@ -50,7 +50,8 @@ type error =
   | Scoping_pack(Identifier.t, type_expr)
   | Recursive_module_require_explicit_type
   | Apply_generative
-  | Cannot_scrape_alias(Path.t);
+  | Cannot_scrape_alias(Path.t)
+  | Nonrecursive_type_with_recursion(Identifier.t);
 
 exception Error(Location.t, Env.t, error);
 exception Error_forward(Location.error);
@@ -393,11 +394,35 @@ let rec type_module = (~toplevel=false, anchor, env, statements) => {
   };
 
   let process_datas = (env, data_decls, attributes, loc) => {
+    // A well-formedness check would have detected issues with improper use of
+    // `rec` on mutually-recursive types
+    let rec_flag =
+      switch (data_decls) {
+      | [(_, {pdata_rec: Recursive}), ..._] => Recursive
+      | _ => Nonrecursive
+      };
     let (decls, newenv) =
-      Typedecl.transl_data_decl(env, Recursive, data_decls);
+      try(Typedecl.transl_data_decl(env, rec_flag, data_decls)) {
+      | Typetexp.Error(_, _, Typetexp.Unbound_type_constructor(_)) =>
+        // Hack to detect if `rec` should be included on this type: if it does
+        // not raise an exception in `Recursive` mode but does otherwise,
+        // suggest that `rec` be used
+        switch (Typedecl.transl_data_decl(env, Recursive, data_decls)) {
+        | exception exn => raise(exn)
+        | _ =>
+          let (_, {pdata_name: type_name}) = List.hd(data_decls);
+          raise(
+            Error(
+              loc,
+              env,
+              Nonrecursive_type_with_recursion(IdentName(type_name)),
+            ),
+          );
+        }
+      };
     let ty_decls =
       map2_rec_type_with_row_types(
-        ~rec_flag=Recursive,
+        ~rec_flag,
         (rs, info, e) => {
           switch (e) {
           | NotProvided => None
@@ -1180,7 +1205,14 @@ let report_error = ppf =>
   | Apply_generative =>
     fprintf(ppf, "This is a generative functor. It can only be applied to ()")
   | Cannot_scrape_alias(p) =>
-    fprintf(ppf, "This is an alias for module %a, which is missing", path, p);
+    fprintf(ppf, "This is an alias for module %a, which is missing", path, p)
+  | Nonrecursive_type_with_recursion(lid) =>
+    fprintf(
+      ppf,
+      "Unbound type constructor %a. Hint: you are probably missing the `rec` keyword on this type",
+      identifier,
+      lid,
+    );
 
 let report_error = (env, ppf, err) =>
   Printtyp.wrap_printing_env(~error=true, env, () => report_error(ppf, err));

--- a/compiler/src/typed/typemod.re
+++ b/compiler/src/typed/typemod.re
@@ -1209,7 +1209,7 @@ let report_error = ppf =>
   | Nonrecursive_type_with_recursion(lid) =>
     fprintf(
       ppf,
-      "Unbound type constructor %a. Hint: you are probably missing the `rec` keyword on this type",
+      "Unbound type constructor %a. Are you missing the `rec` keyword on this type?",
       identifier,
       lid,
     );

--- a/compiler/src/typed/typemod.rei
+++ b/compiler/src/typed/typemod.rei
@@ -28,7 +28,8 @@ type error =
   | Scoping_pack(Identifier.t, type_expr)
   | Recursive_module_require_explicit_type
   | Apply_generative
-  | Cannot_scrape_alias(Path.t);
+  | Cannot_scrape_alias(Path.t)
+  | Nonrecursive_type_with_recursion(Identifier.t);
 
 exception Error(Location.t, Env.t, error);
 exception Error_forward(Location.error);

--- a/compiler/test/__snapshots__/records.02af5946.0.snapshot
+++ b/compiler/test/__snapshots__/records.02af5946.0.snapshot
@@ -61,5 +61,5 @@ records › record_definition_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1220
+ ;; custom section \"cmi\", size 1218
 )

--- a/compiler/test/__snapshots__/records.2dc39420.0.snapshot
+++ b/compiler/test/__snapshots__/records.2dc39420.0.snapshot
@@ -61,5 +61,5 @@ records › record_pun
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1156
+ ;; custom section \"cmi\", size 1154
 )

--- a/compiler/test/__snapshots__/records.5f340064.0.snapshot
+++ b/compiler/test/__snapshots__/records.5f340064.0.snapshot
@@ -61,5 +61,5 @@ records › record_value_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1200
+ ;; custom section \"cmi\", size 1198
 )

--- a/compiler/test/__snapshots__/records.60c7acc4.0.snapshot
+++ b/compiler/test/__snapshots__/records.60c7acc4.0.snapshot
@@ -65,5 +65,5 @@ records › record_pun_mixed_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1647
+ ;; custom section \"cmi\", size 1645
 )

--- a/compiler/test/__snapshots__/records.89d08e01.0.snapshot
+++ b/compiler/test/__snapshots__/records.89d08e01.0.snapshot
@@ -61,5 +61,5 @@ records › record_pun_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1192
+ ;; custom section \"cmi\", size 1190
 )

--- a/compiler/test/__snapshots__/records.a9c472b1.0.snapshot
+++ b/compiler/test/__snapshots__/records.a9c472b1.0.snapshot
@@ -96,5 +96,5 @@ records › record_multiple_fields_definition_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 2221
+ ;; custom section \"cmi\", size 2219
 )

--- a/compiler/test/__snapshots__/records.d34c4740.0.snapshot
+++ b/compiler/test/__snapshots__/records.d34c4740.0.snapshot
@@ -65,5 +65,5 @@ records › record_pun_mixed
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1593
+ ;; custom section \"cmi\", size 1591
 )

--- a/compiler/test/__snapshots__/records.d44e8007.0.snapshot
+++ b/compiler/test/__snapshots__/records.d44e8007.0.snapshot
@@ -65,5 +65,5 @@ records › record_pun_mixed_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1605
+ ;; custom section \"cmi\", size 1603
 )

--- a/compiler/test/__snapshots__/records.e4326567.0.snapshot
+++ b/compiler/test/__snapshots__/records.e4326567.0.snapshot
@@ -96,5 +96,5 @@ records › record_multiple_fields_both_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 2173
+ ;; custom section \"cmi\", size 2171
 )

--- a/compiler/test/__snapshots__/records.e5b56da8.0.snapshot
+++ b/compiler/test/__snapshots__/records.e5b56da8.0.snapshot
@@ -61,5 +61,5 @@ records › record_both_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1196
+ ;; custom section \"cmi\", size 1194
 )

--- a/compiler/test/__snapshots__/records.e705a980.0.snapshot
+++ b/compiler/test/__snapshots__/records.e705a980.0.snapshot
@@ -65,5 +65,5 @@ records › record_pun_multiple
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1611
+ ;; custom section \"cmi\", size 1609
 )

--- a/compiler/test/__snapshots__/records.f6e43cdb.0.snapshot
+++ b/compiler/test/__snapshots__/records.f6e43cdb.0.snapshot
@@ -65,5 +65,5 @@ records › record_pun_multiple_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1665
+ ;; custom section \"cmi\", size 1663
 )

--- a/compiler/test/__snapshots__/records.f6feee77.0.snapshot
+++ b/compiler/test/__snapshots__/records.f6feee77.0.snapshot
@@ -96,5 +96,5 @@ records › record_multiple_fields_value_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 2181
+ ;; custom section \"cmi\", size 2179
 )

--- a/compiler/test/__snapshots__/records.fae50a8e.0.snapshot
+++ b/compiler/test/__snapshots__/records.fae50a8e.0.snapshot
@@ -65,5 +65,5 @@ records › record_pun_mixed_2_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1659
+ ;; custom section \"cmi\", size 1657
 )

--- a/compiler/test/input/basicenum.gr
+++ b/compiler/test/input/basicenum.gr
@@ -1,6 +1,6 @@
 module BasicNum
 
-enum List<a> {
+enum rec List<a> {
   Empty,
   Cons(a, List<a>),
 }

--- a/compiler/test/input/mixedPatternMatching.gr
+++ b/compiler/test/input/mixedPatternMatching.gr
@@ -8,7 +8,7 @@ provide record Rec {
   bar: String,
 }
 
-provide enum Poly {
+provide enum rec Poly {
   PList(List<Number>),
   PArray(Array<Poly>),
   PAssoc(Rec),

--- a/compiler/test/input/recursive-equal-box.gr
+++ b/compiler/test/input/recursive-equal-box.gr
@@ -1,6 +1,6 @@
 module RecursiveEqualBox
 
-provide enum R {
+provide enum rec R {
   Atom,
   Recursive(Box<Option<R>>),
 }
@@ -18,7 +18,7 @@ u := Some(w)
 
 assert x == w
 
-provide record Rec {
+provide record rec Rec {
   int: Number,
   r: Box<Option<Rec>>,
 }

--- a/compiler/test/input/recursive-equal-mut.gr
+++ b/compiler/test/input/recursive-equal-mut.gr
@@ -3,7 +3,7 @@ module RecursiveEqualMut
 // Note: This file doesn't include the Recursive type test
 // because it isn't achievable with `let mut`
 
-provide record Rec {
+provide record rec Rec {
   int: Number,
   mut r: Option<Rec>,
 }

--- a/compiler/test/stdlib/hash.test.gr
+++ b/compiler/test/stdlib/hash.test.gr
@@ -109,7 +109,7 @@ let charList = Array.toList(chars)
 assert uniq(List.map(Hash.hash, charList))
 Array.forEach(c => assert Hash.hash(c) == Hash.hash(c), chars)
 
-enum Variants {
+enum rec Variants {
   A,
   B,
   C,

--- a/compiler/test/stdlib/marshal.test.gr
+++ b/compiler/test/stdlib/marshal.test.gr
@@ -31,7 +31,7 @@ assert roundtripOk([> 1l, 2l, 3l])
 assert roundtripOk([1, 2, 3])
 assert roundtripOk([1l, 2l, 3l])
 
-enum Foo<a> {
+enum rec Foo<a> {
   Bar,
   Baz(a),
   Qux(String, a),
@@ -67,7 +67,7 @@ let closureTest = () => {
 
 closureTest()
 
-record Cyclic {
+record rec Cyclic {
   mut self: List<Cyclic>,
 }
 

--- a/compiler/test/suites/basic_functionality.re
+++ b/compiler/test/suites/basic_functionality.re
@@ -257,7 +257,6 @@ describe("basic functionality", ({test, testSkip}) => {
               (
                 Asttypes.NotProvided,
                 DataDeclaration.variant(
-                  Parsetree.Nonrecursive,
                   Location.mknoloc("Caipirinha"),
                   [],
                   [
@@ -289,7 +288,6 @@ describe("basic functionality", ({test, testSkip}) => {
               (
                 Asttypes.NotProvided,
                 DataDeclaration.abstract(
-                  Parsetree.Nonrecursive,
                   Location.mknoloc("Über"),
                   [],
                   Some(

--- a/compiler/test/suites/basic_functionality.re
+++ b/compiler/test/suites/basic_functionality.re
@@ -257,6 +257,7 @@ describe("basic functionality", ({test, testSkip}) => {
               (
                 Asttypes.NotProvided,
                 DataDeclaration.variant(
+                  Parsetree.Nonrecursive,
                   Location.mknoloc("Caipirinha"),
                   [],
                   [
@@ -288,6 +289,7 @@ describe("basic functionality", ({test, testSkip}) => {
               (
                 Asttypes.NotProvided,
                 DataDeclaration.abstract(
+                  Parsetree.Nonrecursive,
                   Location.mknoloc("Über"),
                   [],
                   Some(

--- a/compiler/test/suites/enums.re
+++ b/compiler/test/suites/enums.re
@@ -23,7 +23,7 @@ describe("enums", ({test, testSkip}) => {
   );
   // Taken from https://en.wikipedia.org/wiki/Recursive_data_type#Mutually_recursive_data_types
   let recursive_contents = {|
-    enum Tree<a> {
+    enum rec Tree<a> {
       Empty,
       Node(a, Forest<a>)
     }

--- a/compiler/test/suites/records.re
+++ b/compiler/test/suites/records.re
@@ -165,7 +165,7 @@ describe("records", ({test, testSkip}) => {
   assertSnapshot(
     "record_recursive_data_definition",
     {|
-      record Bar {
+      record rec Bar {
         mut foo: Option<Foo>
       }
       and record Foo {

--- a/compiler/test/suites/types.re
+++ b/compiler/test/suites/types.re
@@ -366,3 +366,59 @@ describe("abstract types", ({test, testSkip}) => {
     "abc\n",
   );
 });
+
+describe("recursive types", ({test, testSkip}) => {
+  let test_or_skip =
+    Sys.backend_type == Other("js_of_ocaml") ? testSkip : test;
+
+  let assertCompileError = makeCompileErrorRunner(test);
+  let assertRun = makeRunner(test_or_skip);
+
+  assertCompileError(
+    "type_rec_incorrect_1",
+    {|
+      record Oops {
+        x: Oops
+      }
+    |},
+    "Unbound type constructor Oops. Hint: you are probably missing the `rec` keyword on this type",
+  );
+  assertCompileError(
+    "type_rec_incorrect_2",
+    {|
+      record T {
+        x: Number
+      },
+      enum T2 {
+        T2(Number)
+      }
+    |},
+    "Mutually recursive type groups must include `rec` on the first type in the group.",
+  );
+  assertCompileError(
+    "type_rec_incorrect_3",
+    {|
+      record rec T {
+        x: Number
+      },
+      enum rec T2 {
+        T2(Number)
+      }
+    |},
+    "The `rec` keyword should only appear on the first type in the mutually recursive type group.",
+  );
+  assertRun(
+    "type_rec_correct",
+    {|
+      record rec T {
+        x: T
+      },
+      enum T2 {
+        T2(T2),
+        Val(Number)
+      }
+      print(T2(T2(Val(1))))
+    |},
+    "T2(T2(Val(1)))\n",
+  );
+});

--- a/compiler/test/suites/types.re
+++ b/compiler/test/suites/types.re
@@ -408,7 +408,7 @@ describe("recursive types", ({test, testSkip}) => {
     "The `rec` keyword should only appear on the first type in the mutually recursive type group.",
   );
   assertRun(
-    "type_rec_correct",
+    "type_rec_correct_1",
     {|
       record rec T {
         x: T
@@ -420,5 +420,16 @@ describe("recursive types", ({test, testSkip}) => {
       print(T2(T2(Val(1))))
     |},
     "T2(T2(Val(1)))\n",
+  );
+  assertRun(
+    "type_rec_correct_2",
+    {|
+      record T {
+        x: Number
+      }
+      type T = T
+      print({ x: 1 }: T)
+    |},
+    "{\n  x: 1\n}\n",
   );
 });

--- a/compiler/test/suites/types.re
+++ b/compiler/test/suites/types.re
@@ -381,7 +381,7 @@ describe("recursive types", ({test, testSkip}) => {
         x: Oops
       }
     |},
-    "Unbound type constructor Oops. Hint: you are probably missing the `rec` keyword on this type",
+    "Unbound type constructor Oops. Are you missing the `rec` keyword on this type?",
   );
   assertCompileError(
     "type_rec_incorrect_2",

--- a/compiler/test/suites/types.re
+++ b/compiler/test/suites/types.re
@@ -388,8 +388,8 @@ describe("recursive types", ({test, testSkip}) => {
     {|
       record T {
         x: Number
-      },
-      enum T2 {
+      }
+      and enum T2 {
         T2(Number)
       }
     |},
@@ -400,8 +400,8 @@ describe("recursive types", ({test, testSkip}) => {
     {|
       record rec T {
         x: Number
-      },
-      enum rec T2 {
+      }
+      and enum rec T2 {
         T2(Number)
       }
     |},
@@ -412,8 +412,8 @@ describe("recursive types", ({test, testSkip}) => {
     {|
       record rec T {
         x: T
-      },
-      enum T2 {
+      }
+      and enum T2 {
         T2(T2),
         Val(Number)
       }

--- a/compiler/test/test-libs/tlists.gr
+++ b/compiler/test/test-libs/tlists.gr
@@ -1,6 +1,6 @@
 module TLists
 
-provide enum TList<a> {
+provide enum rec TList<a> {
   Empty,
   Cons(a, TList<a>),
 }

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -1121,7 +1121,7 @@ provide module Immutable {
   // To be applied to numbers to bring them within the range [0, 32)
   let bitmask = branchingFactor - 1
 
-  type Tree<a> = Array<Node<a>>
+  type rec Tree<a> = Array<Node<a>>
   and enum Node<a> {
     Tree(Tree<a>),
     Leaf(Array<a>),

--- a/stdlib/map.gr
+++ b/stdlib/map.gr
@@ -20,7 +20,7 @@ include "runtime/unsafe/memory"
 include "runtime/unsafe/wasmi32"
 
 // TODO: Consider implementing this as List<(Box<k>, Box<v>)>
-record Bucket<k, v> {
+record rec Bucket<k, v> {
   mut key: k,
   mut value: v,
   mut next: Option<Bucket<k, v>>,
@@ -519,7 +519,7 @@ provide let getInternalStats = map => {
 provide module Immutable {
   // implementation based on the paper "Implementing Sets Efficiently in a
   // Functional Language" by Stephen Adams
-  record Node<k, v> {
+  record rec Node<k, v> {
     key: k,
     val: v,
     size: Number,

--- a/stdlib/path.gr
+++ b/stdlib/path.gr
@@ -79,7 +79,7 @@ record TFileType<a> {
 }
 
 // Rel(Number) represents the number of directories up from the base point
-enum Base {
+enum rec Base {
   Rel(Number),
   Abs(AbsoluteRoot),
 }
@@ -129,7 +129,7 @@ abstract record Directory {
  * Represents a path typed on (`Absolute` or `Relative`) and (`File` or
  * `Directory`)
  */
-abstract type TypedPath<a, b> = (TBase<a>, TFileType<b>, List<String>)
+abstract type rec TypedPath<a, b> = (TBase<a>, TFileType<b>, List<String>)
 /**
  * Represents a system path.
  */

--- a/stdlib/priorityqueue.gr
+++ b/stdlib/priorityqueue.gr
@@ -264,7 +264,7 @@ provide module Immutable {
   // as described in the paper "Optimal Purely Functional Priority Queues" by Chris Okasaki.
 
   // rank is a stand-in for height of this skew binomial tree
-  record Node<a> {
+  record rec Node<a> {
     val: a,
     rank: Number,
     children: List<Node<a>>,

--- a/stdlib/regex.gr
+++ b/stdlib/regex.gr
@@ -407,7 +407,7 @@ enum UnicodeCategory {
   OtherPrivateUse,
 }
 
-enum ParsedRegularExpression {
+enum rec ParsedRegularExpression {
   RENever,
   REEmpty,
   REAny,

--- a/stdlib/set.gr
+++ b/stdlib/set.gr
@@ -14,7 +14,7 @@ include "array"
 include "hash"
 from Hash use { hash }
 
-record Bucket<t> {
+record rec Bucket<t> {
   mut key: t,
   mut next: Option<Bucket<t>>,
 }
@@ -475,7 +475,7 @@ provide module Immutable {
   // implementation based on the paper "Implementing Sets Efficiently in a
   // Functional Language" by Stephen Adams
 
-  record Node<a> {
+  record rec Node<a> {
     key: a,
     size: Number,
     left: Set<a>,


### PR DESCRIPTION
Requires that recursive type definitions use rec keyword
```
record rec T {
  x: T
}
```
Mutually recursive types also need `rec`
```
record rec A {
  x: Number
}
and enum B {
  B(A)
}
```
Closes https://github.com/grain-lang/grain/issues/1420