### PR TITLE
feat(compiler)!: Changed comma to `and` in recursive types and bindings

### DIFF
--- a/compiler/src/parsing/lexer.re
+++ b/compiler/src/parsing/lexer.re
@@ -337,6 +337,7 @@ let rec token = lexbuf => {
   | "," => positioned(COMMA)
   | ";" => positioned(SEMI)
   | "as" => positioned(AS)
+  | "and" => positioned(AND)
   | "(" => positioned(LPAREN)
   | ")" => positioned(RPAREN)
   | "{" => positioned(LBRACE)

--- a/compiler/src/parsing/parser.messages
+++ b/compiler/src/parsing/parser.messages
@@ -790,34 +790,26 @@ program: MODULE UIDENT EOL ENUM UIDENT LBRACE UIDENT LPAREN WHILE
 
 Expected one or more types to complete the variant definition.
 
-program: MODULE UIDENT EOL ENUM UIDENT LBRACE UIDENT RBRACE COMMA EOL WHILE
+program: MODULE UIDENT EOL TYPE UIDENT EQUAL UIDENT AND YIELD
 ##
-## Ends in an error in state: 986.
+## Ends in an error in state: 860.
 ##
-## separated_nonempty_list(comma,data_declaration_stmt) -> data_declaration_stmt comma . separated_nonempty_list(comma,data_declaration_stmt) [ SEMI EOL EOF ]
+## separated_nonempty_list(AND,data_declaration_stmt) -> data_declaration_stmt AND . separated_nonempty_list(AND,data_declaration_stmt) [ SEMI RBRACE EOL EOF ]
 ##
 ## The known suffix of the stack is as follows:
-## data_declaration_stmt comma
+## data_declaration_stmt AND
 ##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
-## In state 5, spurious reduction of production eols -> nonempty_list(eol)
-## In state 96, spurious reduction of production comma -> COMMA eols
+program: MODULE UIDENT EOL TYPE UIDENT EQUAL UIDENT AND PROVIDE YIELD
 ##
-program: MODULE UIDENT EOL ENUM UIDENT LBRACE UIDENT RBRACE COMMA PROVIDE WHILE
+## Ends in an error in state: 861.
 ##
-## Ends in an error in state: 987.
-##
-## data_declaration_stmt -> PROVIDE . data_declaration [ SEMI EOL EOF COMMA ]
+## data_declaration_stmt -> PROVIDE . data_declaration [ SEMI RBRACE EOL EOF AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## PROVIDE
 ##
 
-Mutually recursive type declarations are separated by commas, but cannot be mixed with other kinds of expressions.
+Mutually recursive type declarations are separated by `and`, but cannot be mixed with other kinds of expressions.
 
 program: MODULE UIDENT EOL ENUM UIDENT LBRACE UIDENT WHILE
 ##
@@ -861,7 +853,7 @@ program: MODULE UIDENT EOL ENUM UIDENT LBRACE UIDENT RBRACE WHILE
 ## data_declaration_stmt
 ##
 
-Expected a comma followed by more mutually-recursive type declarations or a newline character to complete the current one.
+Expected `and` followed by more mutually-recursive type declarations or a newline character to complete the current one.
 
 program: MODULE UIDENT EOL ENUM UIDENT LCARET LIDENT RCARET INFIX_80
 ##
@@ -4449,22 +4441,14 @@ program: MODULE UIDENT EOL LET UIDENT LPAREN WHILE
 
 Expected a comma-separated list of patterns.
 
-program: MODULE UIDENT EOL LET WASMI64 EQUAL WASMI64 COMMA EOL WHILE
+program: MODULE UIDENT EOL LET NUMBER_INT EQUAL UIDENT AND YIELD
 ##
-## Ends in an error in state: 433.
+## Ends in an error in state: 423.
 ##
-## lseparated_nonempty_list_inner(comma,value_bind) -> lseparated_nonempty_list_inner(comma,value_bind) comma . value_bind [ SEMI RBRACE EOL EOF COMMA ]
+## lseparated_nonempty_list_inner(AND,value_bind) -> lseparated_nonempty_list_inner(AND,value_bind) AND . value_bind [ SEMI RBRACE EOL EOF AND ]
 ##
 ## The known suffix of the stack is as follows:
-## lseparated_nonempty_list_inner(comma,value_bind) comma
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
-## In state 5, spurious reduction of production eols -> nonempty_list(eol)
-## In state 96, spurious reduction of production comma -> COMMA eols
+## lseparated_nonempty_list_inner(AND,value_bind) AND
 ##
 
 Expected a binding, e.g. `foo = 5`.

--- a/compiler/src/parsing/parser.mly
+++ b/compiler/src/parsing/parser.mly
@@ -38,6 +38,7 @@ module Grain_parsing = struct end
 %token <string> INFIX_ASSIGNMENT_10
 
 %token ENUM RECORD TYPE MODULE INCLUDE USE PROVIDE ABSTRACT FOREIGN WASM PRIMITIVE
+%token AND
 %token EXCEPT FROM STAR
 %token SLASH DASH PIPE
 %token EOL EOF
@@ -327,7 +328,7 @@ value_bind:
   | pattern equal expr { ValueBinding.mk ~loc:(to_loc $loc) $1 $3 }
 
 value_binds:
-  | lseparated_nonempty_list(comma, value_bind) { $1 }
+  | lseparated_nonempty_list(AND, value_bind) { $1 }
 
 as_prefix(X):
   | AS opt_eols X {$3}
@@ -362,7 +363,7 @@ data_declaration_stmt:
   | data_declaration { (NotProvided, $1) }
 
 data_declaration_stmts:
-  | separated_nonempty_list(comma, data_declaration_stmt) { $1 }
+  | separated_nonempty_list(AND, data_declaration_stmt) { $1 }
 
 provide_item:
   | TYPE aliasable(uid) { PProvideType { name=fst $2; alias = snd $2; loc=to_loc $loc} }

--- a/compiler/src/parsing/wrapped_lexer.re
+++ b/compiler/src/parsing/wrapped_lexer.re
@@ -316,7 +316,7 @@ let token = state => {
 };
 
 let token = state => {
-  // if-else and or-patterns hack
+  // if-else, or-patterns, and `and` hack
   let (tok, _, _) as triple = token(state);
   if (tok == EOL) {
     let fst = ((a, _, _)) => a;
@@ -328,6 +328,7 @@ let token = state => {
     };
 
     switch (fst(next_triple^)) {
+    | AND
     | ELSE
     | PIPE => next_triple^
     | _ =>

--- a/compiler/test/grainfmt/chained.expected.gr
+++ b/compiler/test/grainfmt/chained.expected.gr
@@ -1,25 +1,30 @@
 module Chained
 
-let g = 7, // g represents the precision desired, p is the values of p[i] to plug into Lanczos' formula
-  p = 8, // another comment
-  q = 32
+let g = 7
+// g represents the precision desired, p is the values of p[i] to plug into Lanczos' formula
+and p = 8
+// another comment
+and q = 32
 
 let myFunction2 = x => {
   let inter = x + 1
   "some string"
-},
-myFunction3 = y => {
+}
+and myFunction3 = y => {
   let myVal = 5
   "some string"
 }
 
-let g = 7, p = 8, q = 32
+let g = 7
+and p = 8
+and q = 32
 
 let myFunction2 = x => {
   let inter = x + 1
   "some string"
-}, // a comment
-myFunction3 = y => {
+}
+// a comment
+and myFunction3 = y => {
   let myVal = 5
   "some string"
 }

--- a/compiler/test/grainfmt/chained.input.gr
+++ b/compiler/test/grainfmt/chained.input.gr
@@ -1,28 +1,28 @@
 module Chained
 
 
-  let g = 7, // g represents the precision desired, p is the values of p[i] to plug into Lanczos' formula
-      p = 8, // another comment
-      q = 32
+  let g = 7 // g represents the precision desired, p is the values of p[i] to plug into Lanczos' formula
+  and p = 8 // another comment
+  and q = 32
 
 
 let myFunction2 = x => {
   let inter = x + 1
   "some string"
-}, myFunction3 = y => {
+} and myFunction3 = y => {
   let myVal = 5
   "some string"
 }
 
-  let g = 7, 
-      p = 8, 
-      q = 32
+  let g = 7 
+  and p = 8 
+  and q = 32
 
   let myFunction2 = x => {
   let inter = x + 1
   "some string"
-},  // a comment
-myFunction3 = y => {
+}  // a comment
+and myFunction3 = y => {
   let myVal = 5
   "some string"
 }

--- a/compiler/test/grainfmt/data_docs.expected.gr
+++ b/compiler/test/grainfmt/data_docs.expected.gr
@@ -3,21 +3,21 @@ module DataDocs
 enum EventType {
   Enter,
   Exit,
-},
+}
 /**
  *   An event is the start or end of a token amongst other events.
  *   Tokens can “contain” other tokens, even though they are stored in a flat
  *   list, through `enter`ing before them, and `exit`ing after them.
  */
-type Event = (EventType, Token, TokenizeContext),
+and type Event = (EventType, Token, TokenizeContext)
 /**
  *   Another event is the start or end of a token amongst other events.
  *   Tokens can “contain” other tokens, even though they are stored in a flat
  *   list, through `enter`ing before them, and `exit`ing after them.
  */
-enum EventType2 {
+and enum EventType2 {
   Enter2,
   Exit2,
-},
+}
 // line comment
-type Event2 = (EventType2, Token, TokenizeContext)
+and type Event2 = (EventType2, Token, TokenizeContext)

--- a/compiler/test/grainfmt/data_docs.input.gr
+++ b/compiler/test/grainfmt/data_docs.input.gr
@@ -3,13 +3,13 @@ module DataDocs
 enum EventType {
   Enter,
   Exit,
-},
+}
 /**
  *   An event is the start or end of a token amongst other events.
  *   Tokens can “contain” other tokens, even though they are stored in a flat
  *   list, through `enter`ing before them, and `exit`ing after them.
  */
-type Event = (EventType, Token, TokenizeContext),
+and type Event = (EventType, Token, TokenizeContext)
 /**
  *   Another event is the start or end of a token amongst other events.
  *   Tokens can “contain” other tokens, even though they are stored in a flat
@@ -17,9 +17,9 @@ type Event = (EventType, Token, TokenizeContext),
  */
 
 
-enum EventType2 {
+and enum EventType2 {
   Enter2,
   Exit2,
-},
+}
 // line comment
-type Event2 = (EventType2, Token, TokenizeContext)
+and type Event2 = (EventType2, Token, TokenizeContext)

--- a/compiler/test/grainfmt/enum_long.expected.gr
+++ b/compiler/test/grainfmt/enum_long.expected.gr
@@ -102,8 +102,8 @@ enum EvenNumber {
   OddPlusOne(OddNumber), // comment 1
   // comment 2
   // comment 3
-},
-enum OddNumber {
+}
+and enum OddNumber {
   // comment 4
   // comment 5
   EvenPlusOne(EvenNumber),

--- a/compiler/test/grainfmt/enum_long.input.gr
+++ b/compiler/test/grainfmt/enum_long.input.gr
@@ -14,8 +14,8 @@ enum EvenNumber {
   OddPlusOne(OddNumber), // comment 1
   // comment 2
   // comment 3
-},
-enum OddNumber {
+}
+and enum OddNumber {
   // comment 4
   // comment 5
   EvenPlusOne(EvenNumber),

--- a/compiler/test/grainfmt/enums.expected.gr
+++ b/compiler/test/grainfmt/enums.expected.gr
@@ -79,8 +79,8 @@ enum ParsedRegularExpression {
 
 record Node {
   node: AstValue,
-},
-enum AstValue {
+}
+and enum AstValue {
   NodeValue(Node),
   StringValue(String),
 }

--- a/compiler/test/grainfmt/enums.input.gr
+++ b/compiler/test/grainfmt/enums.input.gr
@@ -48,6 +48,6 @@ enum ParsedRegularExpression {
 }
 
 
-record Node { node: AstValue },
+record Node { node: AstValue }
 
-enum AstValue { NodeValue(Node), StringValue(String) }
+and enum AstValue { NodeValue(Node), StringValue(String) }

--- a/compiler/test/grainfmt/includes.expected.gr
+++ b/compiler/test/grainfmt/includes.expected.gr
@@ -30,7 +30,7 @@ include "runtime/unsafe/wasmi32"
 from WasmI32 use {
   eq, // comment1
   // comment 3
-  and as (&), // comment 2
+  and_ as (&), // comment 2
   or as (|),
   // no signed imports, as care should be taken to use signed or unsigned operators
 }

--- a/compiler/test/grainfmt/includes.input.gr
+++ b/compiler/test/grainfmt/includes.input.gr
@@ -28,7 +28,7 @@ include "runtime/unsafe/wasmi32"
 from WasmI32 use {
   eq, // comment1
   // comment 3
-  and as (&), // comment 2
+  and_ as (&), // comment 2
   or as (|)
   // no signed imports, as care should be taken to use signed or unsigned operators
 }

--- a/compiler/test/grainfmt/infix.expected.gr
+++ b/compiler/test/grainfmt/infix.expected.gr
@@ -1,8 +1,10 @@
 module Infix
 
 let trimString = (str: String, end: Bool) => {
-  let chars = [>], charsLength = 0
-  let mut i = 0, offset = 1
+  let chars = [>]
+  and charsLength = 0
+  let mut i = 0
+  and offset = 1
 
   for (; i < charsLength && i > -1; i += offset) {
     let currentChar = chars[i]

--- a/compiler/test/grainfmt/infix.input.gr
+++ b/compiler/test/grainfmt/infix.input.gr
@@ -1,8 +1,8 @@
 module Infix
 
 let trimString = (str: String, end: Bool) => {
-  let chars = [>], charsLength = 0
-  let mut i = 0, offset = 1
+  let chars = [>] and charsLength = 0
+  let mut i = 0 and offset = 1
  
   for (; i < charsLength && i > -1; i += offset) {
     let currentChar = chars[i];

--- a/compiler/test/grainfmt/lets.expected.gr
+++ b/compiler/test/grainfmt/lets.expected.gr
@@ -1,6 +1,11 @@
 module Lets
 
-let rec myFun1 = x => x + 1, myFun2 = x => x + 1
+let rec myFun1 = x =>
+  x +
+    1
+and myFun2 = x =>
+  x +
+    1
 
 let myBlock = {
   "some string"
@@ -9,8 +14,8 @@ let myBlock = {
 let myFunction2 = x => {
   let inter = x + 1
   "some string"
-},
-myFunction3 = y => {
+}
+and myFunction3 = y => {
   let myVal = 5
   "some string"
 }
@@ -31,7 +36,7 @@ let rotate = (count, list) => {
   append(end, beginning)
 }
 
-let qsize = (if (WasmI32.eqz(WasmI32.and(m + 1n, 1n))) {
+let qsize = (if (WasmI32.eqz(WasmI32.and_(m + 1n, 1n))) {
     m + 1n
   } else {
     m + 2n

--- a/compiler/test/grainfmt/lets.input.gr
+++ b/compiler/test/grainfmt/lets.input.gr
@@ -1,6 +1,6 @@
 module Lets
 
-let rec myFun1 = x => x + 1, myFun2 = x => x + 1
+let rec myFun1 = x => x + 1 and myFun2 = x => x + 1
 
 let myBlock = {
   "some string"
@@ -10,9 +10,9 @@ let myBlock = {
 let myFunction2 = (x) => {
   let inter = x + 1
   "some string"
-},
+}
 
-myFunction3 = (y) =>  {
+and myFunction3 = (y) =>  {
   let myVal = 5
   "some string"
 }
@@ -34,7 +34,7 @@ let rotate = (count, list) => {
   append(end, beginning)
 }
 
-let qsize = (if (WasmI32.eqz(WasmI32.and(m + 1n, 1n))) {
+let qsize = (if (WasmI32.eqz(WasmI32.and_(m + 1n, 1n))) {
     m + 1n
   } else {
     m + 2n

--- a/compiler/test/input/fib-bigint.gr
+++ b/compiler/test/input/fib-bigint.gr
@@ -6,8 +6,8 @@ let rec fib_help = (n, cur, next) => {
   } else {
     fib_help(n - 1, next, cur + next)
   }
-},
-fib = n => {
+}
+and fib = n => {
   fib_help(n, 0, 1)
 }
 

--- a/compiler/test/input/forward-decl.gr
+++ b/compiler/test/input/forward-decl.gr
@@ -8,8 +8,8 @@ let rec isEvenHelp = (n, b) => {
   } else {
     isOddHelp(n - 1, !b)
   }
-},
-isOddHelp = (n, b) => {
+}
+and isOddHelp = (n, b) => {
   if (n == 1) {
     b
   } else {
@@ -19,8 +19,8 @@ isOddHelp = (n, b) => {
 
 let isEven = n => {
   isEvenHelp(n, true)
-},
-isOdd = n => {
+}
+and isOdd = n => {
   isOddHelp(n, true)
 }
 

--- a/compiler/test/input/long_lists.gr
+++ b/compiler/test/input/long_lists.gr
@@ -12,8 +12,8 @@ let rec make_list = (x, n) => {
     }
   }
   helper(n, x, [])
-},
-loop = n => {
+}
+and loop = n => {
   if (n == 0) {
     true
   } else {

--- a/compiler/test/input/sinister-tail-call.gr
+++ b/compiler/test/input/sinister-tail-call.gr
@@ -9,19 +9,19 @@ let rec isEvenHelp = (n, b) => {
     // Note the different argument size
     isOdd(n - 1)
   }
-},
-isOddHelp = (n, b) => {
+}
+and isOddHelp = (n, b) => {
   if (n == 1) {
     b
   } else {
     // See above
     isEven(n - 1)
   }
-},
-isEven = n => {
+}
+and isEven = n => {
   isEvenHelp(n, true)
-},
-isOdd = n => {
+}
+and isOdd = n => {
   isOddHelp(n, true)
 }
 

--- a/compiler/test/suites/basic_functionality.re
+++ b/compiler/test/suites/basic_functionality.re
@@ -52,7 +52,7 @@ describe("basic functionality", ({test, testSkip}) => {
 
   assertSnapshot(
     "complex1",
-    "\n    let x = 2, y = 3, z = if (true) { 4 } else { 5 };\n    if (true) {\n      print(y)\n      y - (z + x)\n    } else {\n      print(8)\n      8\n    }\n    ",
+    "\n    let x = 2 and y = 3 and z = if (true) { 4 } else { 5 };\n    if (true) {\n      print(y)\n      y - (z + x)\n    } else {\n      print(8)\n      8\n    }\n    ",
   );
   assertSnapshot("complex2", "print(2 + 3)");
   assertSnapshot("binop1", "2 + 2");
@@ -123,7 +123,7 @@ describe("basic functionality", ({test, testSkip}) => {
   assertSnapshot("comp7", "if (2 == 2) {8} else {9}");
   assertSnapshot("comp8", "if (2 <= 2) {10} else {11}");
   assertSnapshot("comp9", "if (2 >= 2) {10} else {11}");
-  assertSnapshot("comp10", "let x = 2, y = 4; (y - 2) == x");
+  assertSnapshot("comp10", "let x = 2 and y = 4; (y - 2) == x");
   assertCompileError("comp11", "true == 2", "has type Number but");
   assertCompileError("comp12", "2 == false", "has type Bool but");
   assertSnapshot("comp13", "true == true");

--- a/compiler/test/suites/enums.re
+++ b/compiler/test/suites/enums.re
@@ -26,8 +26,8 @@ describe("enums", ({test, testSkip}) => {
     enum Tree<a> {
       Empty,
       Node(a, Forest<a>)
-    },
-    enum Forest<a> {
+    }
+    and enum Forest<a> {
       Nil,
       Cons(Tree<a>, Forest<a>)
     }

--- a/compiler/test/suites/functions.re
+++ b/compiler/test/suites/functions.re
@@ -25,17 +25,17 @@ describe("functions", ({test, testSkip}) => {
   assertRun("func_no_args", "let foo = (() => {print(5)});\nfoo()", "5\n");
   assertCompileError(
     "multi_bind",
-    "let x = 2, y = x + 1; y",
+    "let x = 2 and y = x + 1; y",
     "Unbound value x",
   );
-  assertSnapshot("multi_bind2", "let x = 2, y = 3; y");
+  assertSnapshot("multi_bind2", "let x = 2 and y = 3; y");
   assertSnapshot("curried_func", "let add = a => b => a + b; add(2)(3)");
   assertCompileError("unbound_fun", "2 + foo()", "unbound");
   assertCompileError("unbound_id_simple", "5 - x", "unbound");
   assertCompileError("unbound_id_let", "let x = x; 2 + 2", "unbound");
   assertCompileError(
     "shadow_multi",
-    "let x = 12, x = 14; x",
+    "let x = 12 and x = 14; x",
     "Variable x is bound several times",
   );
   assertSnapshot(
@@ -102,23 +102,23 @@ describe("functions", ({test, testSkip}) => {
   assertSnapshot("app_1", "((x) => {x})(1)");
   assertRun(
     "letrec_1",
-    "let rec x = ((n) => {if (n > 3) {n} else {x(n + 2)}}),\n                        y = ((n) => {x(n + 1)});\n                 print(y(2))",
+    "let rec x = ((n) => {if (n > 3) {n} else {x(n + 2)}})\n                        and y = ((n) => {x(n + 1)});\n                 print(y(2))",
     "5\n",
   );
   /* Check that recursion is order-independent */
   assertRun(
     "letrec_2",
-    "let rec y = ((n) => {x(n + 1)}),\n                        x = ((n) => {if (n > 3) {n} else {x(n + 2)}});\n                 print(y(2))",
+    "let rec y = ((n) => {x(n + 1)})\n                        and x = ((n) => {if (n > 3) {n} else {x(n + 2)}});\n                 print(y(2))",
     "5\n",
   );
   assertRun(
     "let_1",
-    "let rec x = ((n) => {n + 1}),\n                     y = (() => x(3)),\n                     z = ((n) => {x(n) + y()});\n               print(z(5))",
+    "let rec x = ((n) => {n + 1})\n                     and y = (() => x(3))\n                     and z = ((n) => {x(n) + y()});\n               print(z(5))",
     "10\n",
   );
   assertCompileError(
     "let_norec_1",
-    "let x = ((n) => {if (n > 3) {n} else {x(n + 2)}}),\n                        y = ((n) => {x(n + 1)});\n                 print(y(2))",
+    "let x = ((n) => {if (n > 3) {n} else {x(n + 2)}})\n                        and y = ((n) => {x(n + 1)});\n                 print(y(2))",
     "Unbound value x.",
   );
   assertCompileError(
@@ -144,7 +144,7 @@ describe("functions", ({test, testSkip}) => {
   );
   assertCompileError(
     "letrec_nonstatic_other",
-    "let rec x = ((z) => {z + 1}), y = x; y(2)",
+    "let rec x = ((z) => {z + 1}) and y = x; y(2)",
     "let rec may only be used with recursive function definitions",
   );
   assertCompileError("nonfunction_1", "let x = 5; x(3)", "type");
@@ -195,8 +195,8 @@ truc()|},
           } else {
             isOdd(n - 1)
           }
-        },
-        isOdd = n => {
+        }
+        and isOdd = n => {
           if (n <= 1) {
             n == 1
           } else {

--- a/compiler/test/suites/gc.re
+++ b/compiler/test/suites/gc.re
@@ -148,8 +148,8 @@ describe("garbage collection", ({test, testSkip}) => {
         }
       }
       helper(n, x, [])
-    },
-    loop = n => {
+    }
+    and loop = n => {
       if (n == 0) {
         true
       } else {

--- a/compiler/test/suites/optimizations.re
+++ b/compiler/test/suites/optimizations.re
@@ -64,7 +64,7 @@ describe("optimizations", ({test, testSkip}) => {
 
   assertSnapshot(
     "trs1",
-    "let f1 = ((x, y) => {x}),\n         f2 = ((x, y) => {y});\n       f1(1, 2)",
+    "let f1 = ((x, y) => {x})\n         and f2 = ((x, y) => {y});\n       f1(1, 2)",
   );
   assertRun(
     "regression_no_elim_impure_call",

--- a/compiler/test/suites/records.re
+++ b/compiler/test/suites/records.re
@@ -167,8 +167,8 @@ describe("records", ({test, testSkip}) => {
     {|
       record Bar {
         mut foo: Option<Foo>
-      },
-      record Foo {
+      }
+      and record Foo {
         mut bar: Option<Bar>
       }
 

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -1121,8 +1121,8 @@ provide module Immutable {
   // To be applied to numbers to bring them within the range [0, 32)
   let bitmask = branchingFactor - 1
 
-  type Tree<a> = Array<Node<a>>,
-  enum Node<a> {
+  type Tree<a> = Array<Node<a>>
+  and enum Node<a> {
     Tree(Tree<a>),
     Leaf(Array<a>),
   }

--- a/stdlib/map.gr
+++ b/stdlib/map.gr
@@ -525,8 +525,8 @@ provide module Immutable {
     size: Number,
     left: Map<k, v>,
     right: Map<k, v>,
-  },
-  abstract enum Map<k, v> {
+  }
+  and abstract enum Map<k, v> {
     Empty,
     Tree(Node<k, v>),
   }

--- a/stdlib/path.gr
+++ b/stdlib/path.gr
@@ -82,15 +82,15 @@ record TFileType<a> {
 enum Base {
   Rel(Number),
   Abs(AbsoluteRoot),
-},
-type PathInfo = (Base, FileType, List<String>),
-record TBase<a> {
+}
+and type PathInfo = (Base, FileType, List<String>)
+and record TBase<a> {
   base: Base,
-},
+}
 /**
  * Represents an absolute path's anchor point.
  */
-provide enum AbsoluteRoot {
+and provide enum AbsoluteRoot {
   Root,
   Drive(Char),
 }
@@ -129,11 +129,11 @@ abstract record Directory {
  * Represents a path typed on (`Absolute` or `Relative`) and (`File` or
  * `Directory`)
  */
-abstract type TypedPath<a, b> = (TBase<a>, TFileType<b>, List<String>),
+abstract type TypedPath<a, b> = (TBase<a>, TFileType<b>, List<String>)
 /**
  * Represents a system path.
  */
-provide enum Path {
+and provide enum Path {
   AbsoluteFile(TypedPath<Absolute, File>),
   AbsoluteDir(TypedPath<Absolute, Directory>),
   RelativeFile(TypedPath<Relative, File>),

--- a/stdlib/regex.gr
+++ b/stdlib/regex.gr
@@ -245,8 +245,8 @@ let rec rangeAdd = (rng: CharRange, v: CharRangeElt) => {
     _ when rangeContains(rng, v) => rng,
     _ => rangeUnion(rng, [(v, v)]),
   }
-},
-rangeUnion = (rng1, rng2) => {
+}
+and rangeUnion = (rng1, rng2) => {
   match ((rng1, rng2)) {
     ([], _) => rng2,
     (_, []) => rng1,
@@ -643,8 +643,8 @@ let rec parseRangeNot = (buf: RegExBuf) => {
       Ok(_) => parseRange(buf),
     }
   }
-},
-parseRange = (buf: RegExBuf) => {
+}
+and parseRange = (buf: RegExBuf) => {
   if (!more(buf)) {
     Err(parseErr(buf, "Missing closing `]`", 0))
   } else {
@@ -667,8 +667,8 @@ parseRange = (buf: RegExBuf) => {
       Ok(_) => parseRangeRest(buf, [], None, None),
     }
   }
-},
-parseClass = (buf: RegExBuf) => {
+}
+and parseClass = (buf: RegExBuf) => {
   if (!more(buf)) {
     Err(
       "no chars"
@@ -703,8 +703,8 @@ parseClass = (buf: RegExBuf) => {
       Ok(c) => Err("unknown class: " ++ toString(c)),
     }
   }
-},
-parsePosixCharClass = (buf: RegExBuf) => {
+}
+and parsePosixCharClass = (buf: RegExBuf) => {
   if (!more(buf)) {
     Err(parseErr(buf, "Missing POSIX character class after `[`", 0))
   } else {
@@ -820,8 +820,8 @@ parsePosixCharClass = (buf: RegExBuf) => {
         ),
     }
   }
-},
-parseRangeRest =
+}
+and parseRangeRest =
   (
     buf: RegExBuf,
     rng: CharRange,
@@ -973,8 +973,8 @@ parseRangeRest =
       },
     }
   }
-},
-parseRangeRestSpan =
+}
+and parseRangeRestSpan =
   (
     buf: RegExBuf,
     c,
@@ -1223,8 +1223,8 @@ let rec parseAtom = (buf: RegExBuf) => {
         _ => parseLiteral(buf),
       },
   }
-},
-parseLook = (buf: RegExBuf) => {
+}
+and parseLook = (buf: RegExBuf) => {
   let preNumGroups = unbox(buf.config.groupNumber)
   let spanNumGroups = () => unbox(buf.config.groupNumber) - preNumGroups
   // (isMatch, isAhead)
@@ -1290,8 +1290,8 @@ parseLook = (buf: RegExBuf) => {
       }
     },
   }
-},
-parseTest = (buf: RegExBuf) => {
+}
+and parseTest = (buf: RegExBuf) => {
   if (!more(buf)) {
     Err(parseErr(buf, "Expected test", 0))
   } else {
@@ -1328,8 +1328,8 @@ parseTest = (buf: RegExBuf) => {
         ),
     }
   }
-},
-parseInteger = (buf: RegExBuf, n) => {
+}
+and parseInteger = (buf: RegExBuf, n) => {
   if (!more(buf)) {
     Ok(n)
   } else {
@@ -1344,8 +1344,8 @@ parseInteger = (buf: RegExBuf, n) => {
       Ok(_) => Ok(n),
     }
   }
-},
-parseMode = (buf: RegExBuf) => {
+}
+and parseMode = (buf: RegExBuf) => {
   let processState = ((cs, ml)) => {
     let withCs = match (cs) {
       None => buf.config,
@@ -1404,8 +1404,8 @@ parseMode = (buf: RegExBuf) => {
     }
   }
   help((None, None))
-},
-parseUnicodeCategories = (buf: RegExBuf, pC: String) => {
+}
+and parseUnicodeCategories = (buf: RegExBuf, pC: String) => {
   if (!more(buf)) {
     Err(parseErr(buf, "Expected unicode category", 0))
   } else {
@@ -1573,8 +1573,8 @@ parseUnicodeCategories = (buf: RegExBuf, pC: String) => {
       Ok(_) => Err(parseErr(buf, "Expected `{` after `\\" ++ pC ++ "`", 0)),
     }
   }
-},
-parseLiteral = (buf: RegExBuf) => {
+}
+and parseLiteral = (buf: RegExBuf) => {
   if (!more(buf)) {
     Err(parseErr(buf, "Expected literal", 0))
   } else {
@@ -1608,8 +1608,8 @@ parseLiteral = (buf: RegExBuf) => {
       },
     }
   }
-},
-parseBackslashLiteral = (buf: RegExBuf) => {
+}
+and parseBackslashLiteral = (buf: RegExBuf) => {
   if (!more(buf)) {
     // Special case: EOS after backslash matches null
     Err(parseErr(buf, "Expected to find escaped value after backslash", 0))
@@ -1672,8 +1672,8 @@ parseBackslashLiteral = (buf: RegExBuf) => {
       },
     }
   }
-},
-parseNonGreedy = (buf: RegExBuf) => {
+}
+and parseNonGreedy = (buf: RegExBuf) => {
   let checkNotNested = res => {
     if (!more(buf)) {
       res
@@ -1699,8 +1699,8 @@ parseNonGreedy = (buf: RegExBuf) => {
       Ok(_) => checkNotNested(Ok(false)),
     }
   }
-},
-parsePCE = (buf: RegExBuf) => {
+}
+and parsePCE = (buf: RegExBuf) => {
   match (parseAtom(buf)) {
     Err(e) => Err(e),
     Ok(atom) => {
@@ -1794,8 +1794,8 @@ parsePCE = (buf: RegExBuf) => {
       }
     },
   }
-},
-parsePCEs = (buf: RegExBuf, toplevel: Bool) => {
+}
+and parsePCEs = (buf: RegExBuf, toplevel: Bool) => {
   if (!more(buf)) {
     Ok([])
   } else {
@@ -1821,8 +1821,8 @@ parsePCEs = (buf: RegExBuf, toplevel: Bool) => {
       },
     }
   }
-},
-parseRegex = (buf: RegExBuf) => {
+}
+and parseRegex = (buf: RegExBuf) => {
   if (!more(buf)) {
     Ok(REEmpty)
   } else {
@@ -1857,8 +1857,8 @@ parseRegex = (buf: RegExBuf) => {
       },
     }
   }
-},
-parseRegexNonEmpty = (buf: RegExBuf) => {
+}
+and parseRegexNonEmpty = (buf: RegExBuf) => {
   match (parsePCEs(buf, false)) {
     Err(e) => Err(e),
     Ok(pces) => {

--- a/stdlib/runtime/atof/lemire.gr
+++ b/stdlib/runtime/atof/lemire.gr
@@ -94,8 +94,8 @@ let computeProductApprox = (q: WasmI64, w: WasmI64, precision: WasmI64) => {
   let index = q - _SMALLEST_POWER_OF_FIVE
   let n = 16n * WasmI32.wrapI64(index)
   from WasmI32 use { (+) }
-  let lo5 = WasmI64.load(get_POWERS5(), n),
-    hi5 = WasmI64.load(get_POWERS5(), n + 8n)
+  let lo5 = WasmI64.load(get_POWERS5(), n)
+  and hi5 = WasmI64.load(get_POWERS5(), n + 8n)
   from WasmI64 use { (+) }
   // From Rust:
   // Only need one multiplication as long as there is 1 zero but

--- a/stdlib/runtime/compare.gr
+++ b/stdlib/runtime/compare.gr
@@ -156,8 +156,8 @@ let rec heapCompareHelp = (heapTag, xptr, yptr) => {
       return tagSimpleNumber(xptr - yptr)
     },
   }
-},
-compareHelp = (x, y) => {
+}
+and compareHelp = (x, y) => {
   let xtag = x & Tags._GRAIN_GENERIC_TAG_MASK
   let ytag = y & Tags._GRAIN_GENERIC_TAG_MASK
   if ((xtag & ytag) != Tags._GRAIN_GENERIC_HEAP_TAG_TYPE) {

--- a/stdlib/runtime/equal.gr
+++ b/stdlib/runtime/equal.gr
@@ -196,8 +196,8 @@ let rec heapEqualHelp = (heapTag, xptr, yptr) => {
       xptr == yptr
     },
   }
-},
-equalHelp = (x, y) => {
+}
+and equalHelp = (x, y) => {
   if (
     (x & Tags._GRAIN_GENERIC_TAG_MASK) != 0n &&
     (y & Tags._GRAIN_GENERIC_TAG_MASK) != 0n

--- a/stdlib/runtime/gc.gr
+++ b/stdlib/runtime/gc.gr
@@ -109,8 +109,8 @@ let rec decRef = (userPtr: WasmI32, ignoreZeros: Bool) => {
   } else {
     userPtr
   }
-},
-decRefChildren = (userPtr: WasmI32) => {
+}
+and decRefChildren = (userPtr: WasmI32) => {
   match (WasmI32.load(userPtr, 0n)) {
     t when t == Tags._GRAIN_BOXED_NUM_HEAP_TAG => {
       let tag = WasmI32.load(userPtr, 4n)

--- a/stdlib/runtime/numbers.gr
+++ b/stdlib/runtime/numbers.gr
@@ -3007,16 +3007,17 @@ provide let (**) = (base, power) => {
         return WasmI32.toGrain(newFloat64(d / d)): Number
       } else if (yisint == 1n) s = -1.0W
     }
-    let mut t1 = 0.0W,
-      t2 = 0.0W,
-      p_h = 0.0W,
-      p_l = 0.0W,
-      r = 0.0W,
-      t = 0.0W,
-      u = 0.0W,
-      v = 0.0W,
-      w = 0.0W
-    let mut j = 0n, n = 0n
+    let mut t1 = 0.0W
+    and t2 = 0.0W
+    and p_h = 0.0W
+    and p_l = 0.0W
+    and r = 0.0W
+    and t = 0.0W
+    and u = 0.0W
+    and v = 0.0W
+    and w = 0.0W
+    let mut j = 0n
+    and n = 0n
     if (iy > 0x41E00000n) {
       if (iy > 0x43F00000n) {
         if (ix <= 0x3FEFFFFFn) {
@@ -3053,12 +3054,12 @@ provide let (**) = (base, power) => {
         t2 = v - (t1 - u)
       }
     } else {
-      let mut ss = 0.0W,
-        s2 = 0.0W,
-        s_h = 0.0W,
-        s_l = 0.0W,
-        t_h = 0.0W,
-        t_l = 0.0W
+      let mut ss = 0.0W
+      and s2 = 0.0W
+      and s_h = 0.0W
+      and s_l = 0.0W
+      and t_h = 0.0W
+      and t_l = 0.0W
       n = 0n
       if (ix < 0x00100000n) {
         from WasmI64 use { (>>>) }

--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -554,8 +554,8 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
       join(strings)
     },
   }
-},
-toStringHelp = (grainValue, extraIndents, toplevel) => {
+}
+and toStringHelp = (grainValue, extraIndents, toplevel) => {
   if ((grainValue & 1n) != 0n) {
     // Simple (unboxed) numbers
     NumberUtils.itoa32(grainValue >> 1n, 10n)
@@ -596,8 +596,8 @@ toStringHelp = (grainValue, extraIndents, toplevel) => {
       "<unknown value>"
     }
   }
-},
-listToString = (ptr, extraIndents) => {
+}
+and listToString = (ptr, extraIndents) => {
   let mut cur = ptr
   let mut isFirst = true
 
@@ -623,8 +623,8 @@ listToString = (ptr, extraIndents) => {
   strings = [rbrack, ...strings]
   let reversed = reverse(strings)
   join(reversed)
-},
-tupleVariantToString = (ptr, variantName, extraIndents) => {
+}
+and tupleVariantToString = (ptr, variantName, extraIndents) => {
   let variantArity = WasmI32.load(ptr, 16n)
   if (variantArity == 0n) {
     variantName
@@ -644,8 +644,15 @@ tupleVariantToString = (ptr, variantName, extraIndents) => {
 
     join(strings)
   }
-},
-recordToString = (ptr, recordArity, fields, contentOffset, extraIndents) => {
+}
+and recordToString =
+  (
+    ptr,
+    recordArity,
+    fields,
+    contentOffset,
+    extraIndents,
+  ) => {
   let prevPadAmount = extraIndents * 2n
   let prevSpacePadding = if (prevPadAmount == 0n) {
     ""

--- a/stdlib/set.gr
+++ b/stdlib/set.gr
@@ -480,8 +480,8 @@ provide module Immutable {
     size: Number,
     left: Set<a>,
     right: Set<a>,
-  },
-  abstract enum Set<a> {
+  }
+  and abstract enum Set<a> {
     Empty,
     Tree(Node<a>),
   }

--- a/stdlib/string.gr
+++ b/stdlib/string.gr
@@ -701,7 +701,9 @@ provide let contains = (search: String, string: String) => {
   string += 8n
   search += 8n
 
-  let mut j = 0n, k = 0n, ell = 0n
+  let mut j = 0n
+  and k = 0n
+  and ell = 0n
 
   if (m > n) {
     // Bail if pattern length is longer than input length
@@ -2021,7 +2023,8 @@ let trimString = (str: String, fromEnd: Bool) => {
   let mut stringPtr = WasmI32.fromGrain(str)
   let byteLength = WasmI32.load(stringPtr, 4n)
   stringPtr += 8n
-  let mut i = 0n, offset = 1n
+  let mut i = 0n
+  and offset = 1n
   if (fromEnd) {
     i = byteLength - 1n
     offset = -1n


### PR DESCRIPTION
Old:
```
record A {
  // ...
},
enum B {
  // ...
}
```
New
```
record A {
  // ...
}
and enum B {
  // ...
}
```