### PR TITLE
chore(ci): Always run actions on node v18

### DIFF
--- a/.github/workflows/build-js.yml
+++ b/.github/workflows/build-js.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: ">=18.15"
+          node-version: ">=18.15 <19"
           check-latest: true
           cache: "npm"
 

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: ">=18.15"
+          node-version: ">=18.15 <19"
           check-latest: true
           cache: "npm"
 

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -30,7 +30,7 @@ jobs:
         if: steps.esy-cache.outputs.cache-hit != 'true'
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: ">=18.15"
+          node-version: ">=18.15 <19"
           check-latest: true
           cache: "npm"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: ">=18.15"
+          node-version: ">=18.15 <19"
           check-latest: true
           cache: "npm"
 
@@ -167,7 +167,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: ">=18.15"
+          node-version: ">=18.15 <19"
           check-latest: true
           registry-url: "https://registry.npmjs.org"
 


### PR DESCRIPTION
It seems that my range was too broad and we started pulling down node 20, which pkg can't build.