### PR TITLE
chore(stdlib): Make memory base test less strict

### DIFF
--- a/compiler/test/input/memoryBase/asserts.gr
+++ b/compiler/test/input/memoryBase/asserts.gr
@@ -10,9 +10,10 @@ primitive typeMetadata = "@heap.type_metadata"
 
 @unsafe
 let doTest = () => {
-  from WasmI32 use { (==) }
-  assert heapStart() == 0x1101A8n
+  from WasmI32 use { (==), (>), (<) }
   assert typeMetadata() == 0x110008n
+  assert heapStart() > 0x110008n
+  assert heapStart() < 0x110308n
 }
 
 doTest()


### PR DESCRIPTION
This test would need to be updated every time we change a type in the runtime or Pervasives, which is cumbersome.