### PR TITLE
chore(ci): Remove sed usage in stdlib release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,9 +103,8 @@ jobs:
       - name: Pack stdlib
         working-directory: ./stdlib
         # Runs `npm pack` and assigns the filename to an env var we can use later
-        # `sed` is used to workaround https://github.com/npm/cli/issues/3405
         run: |
-          echo "STDLIB_TAR=$(npm pack --json | jq -r '.[0].filename' | sed -r 's/@//g' | sed -r 's/\//-/g')" >> $GITHUB_ENV
+          echo "STDLIB_TAR=$(npm pack --json | jq -r '.[0].filename')" >> $GITHUB_ENV
 
       - name: Upload stdlib
         id: stdlib-upload


### PR DESCRIPTION
We're now using node 18 in CI so we can remove my sed workaround for an npm bug, which was fixed in 9.1.3 - I checked node 18.6 and it comes with npm 9.5.1