### PR TITLE
feat(Compiler)!: Change Grain Artifact Name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ _build/
 .installed-pkgs
 notes.org
 node_modules/
+*.grartifact
 *.wasm
 *.wasm.map
 *.wat

--- a/compiler/src/typed/module_resolution.re
+++ b/compiler/src/typed/module_resolution.re
@@ -50,7 +50,7 @@ let read_file_cmi = f => {
 };
 
 let get_output_name = name => {
-  Filepath.String.remove_extension(name) ++ ".gr.wasm";
+  Filepath.String.remove_extension(name) ++ ".grartifact";
 };
 
 let find_ext_in_dir = (dir, name) => {
@@ -177,7 +177,7 @@ let resolve_unit = (~search_path=?, ~cache=true, ~base_dir=?, unit_name) => {
   ) {
   | (true, Some(res)) => res
   | _ =>
-    let exts = [".gr", ".gr.wasm"];
+    let exts = [".gr", ".gr.wasm", ".grartifact"];
     let (_, dir, basename, _) =
       find_in_path_uncap(~exts, base_dir, path, unit_name);
     if (cache) {
@@ -205,7 +205,7 @@ let locate_module = (~disable_relpath=false, base_dir, path, unit_name) => {
     let grain_src_exts = [".gr"];
     let (dir, m) =
       switch (
-        find_in_path_uncap(~exts=[".gr.wasm"], base_dir, path, unit_name)
+        find_in_path_uncap(~exts=[".grartifact"], base_dir, path, unit_name)
       ) {
       | (objpath, dir, basename, ext) =>
         ignore(log_resolution(unit_name, dir, basename));

--- a/compiler/test/TestFramework.re
+++ b/compiler/test/TestFramework.re
@@ -38,6 +38,7 @@ let clean_grain_output = stdlib_dir =>
     file => {
       let filename = Filepath.to_string(file);
       if (Filepath.String.check_suffix(filename, ".gr.wasm")
+          || Filepath.String.check_suffix(filename, ".grartifact")
           || Filepath.String.check_suffix(filename, ".gr.wat")
           || Filepath.String.check_suffix(filename, ".gr.modsig")) {
         Fs.rmExn(file);


### PR DESCRIPTION
This change modifies the grain compiler to produce the artifact files with the extension `.grartifact` instead of `.gr.wasm` the output of the compiler can still be found at `.gr.wasm` though so it is just for the intermediate build files.

We should make this change before 0.6 given its breaking nature and the fact that without the ability to run grain programs in unlinked mode there is really no reason to give the false impression that grain libs are valid wasm modules.

This will need to be rewritten after #1842 