### PR TITLE
feat(cli)!: Allow specifying WASI environment variables and CLI args

### DIFF
--- a/cli/bin/exec.js
+++ b/cli/bin/exec.js
@@ -129,13 +129,25 @@ function execGrainrun(file, options, program, execOpts = { stdio: "inherit" }) {
     preopens[guestDir] = hostDir;
   });
 
+  const rawArgs = process.argv;
+  const endOptsIndex = rawArgs.findIndex((x) => x === "--");
+  const args = rawArgs.slice(endOptsIndex === -1 ? Infinity : endOptsIndex + 1);
+
+  const cliEnv = {};
+  options.env?.forEach((env) => {
+    const [name, ...rest] = env.split("=");
+    const val = rest.join("=");
+    cliEnv[name] = val;
+  });
+
   const env = {
+    ...cliEnv,
     PREOPENS: JSON.stringify(preopens),
     NODE_OPTIONS: `--experimental-wasi-unstable-preview1 --no-warnings`,
   };
 
   try {
-    execSync(`${grainrun} ${file}`, { ...execOpts, env });
+    execSync(`${grainrun} ${file} ${args.join(" ")}`, { ...execOpts, env });
   } catch (e) {
     process.exit(e.status);
   }

--- a/cli/bin/exec.js
+++ b/cli/bin/exec.js
@@ -122,16 +122,18 @@ function getGrainrun() {
 
 const grainrun = getGrainrun();
 
-function execGrainrun(file, options, program, execOpts = { stdio: "inherit" }) {
+function execGrainrun(
+  unprocessedArgs,
+  file,
+  options,
+  program,
+  execOpts = { stdio: "inherit" }
+) {
   const preopens = {};
   options.dir?.forEach((preopen) => {
     const [guestDir, hostDir = guestDir] = preopen.split("=");
     preopens[guestDir] = hostDir;
   });
-
-  const rawArgs = process.argv;
-  const endOptsIndex = rawArgs.findIndex((x) => x === "--");
-  const args = rawArgs.slice(endOptsIndex === -1 ? Infinity : endOptsIndex + 1);
 
   const cliEnv = {};
   options.env?.forEach((env) => {
@@ -147,7 +149,10 @@ function execGrainrun(file, options, program, execOpts = { stdio: "inherit" }) {
   };
 
   try {
-    execSync(`${grainrun} ${file} ${args.join(" ")}`, { ...execOpts, env });
+    execSync(`${grainrun} ${file} ${unprocessedArgs.join(" ")}`, {
+      ...execOpts,
+      env,
+    });
   } catch (e) {
     process.exit(e.status);
   }

--- a/cli/bin/exec.js
+++ b/cli/bin/exec.js
@@ -141,7 +141,7 @@ function execGrainrun(file, options, program, execOpts = { stdio: "inherit" }) {
   });
 
   const env = {
-    ...cliEnv,
+    ENV_VARS: JSON.stringify(cliEnv),
     PREOPENS: JSON.stringify(preopens),
     NODE_OPTIONS: `--experimental-wasi-unstable-preview1 --no-warnings`,
   };

--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -107,6 +107,7 @@ class GrainCommand extends commander.Command {
     );
     cmd.forwardOption("--import-memory", "import the memory from `env.memory`");
     cmd.option("--dir <dir...>", "directory to preopen");
+    cmd.option("--env <env...>", "WASI environment variables");
     cmd.forwardOption(
       "--compilation-mode <mode>",
       "compilation mode (advanced use only)"
@@ -178,11 +179,8 @@ program
   .forwardOption("-o <filename>", "output filename")
   .action(function (file, options, program) {
     exec.grainc(file, options, program);
-    if (options.o) {
-      exec.grainrun(options.o, options, program);
-    } else {
-      exec.grainrun(file.replace(/\.gr$/, ".gr.wasm"), options, program);
-    }
+    const outFile = options.o ?? file.replace(/\.gr$/, ".gr.wasm");
+    exec.grainrun(outFile, options, program);
   });
 
 program

--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -165,6 +165,13 @@ class GrainCommand extends commander.Command {
   }
 }
 
+let endOptsI = process.argv.findIndex((x) => x === "--");
+if (endOptsI === -1) {
+  endOptsI = Infinity;
+}
+const argsToProcess = process.argv.slice(0, endOptsI);
+const unprocessedArgs = process.argv.slice(endOptsI + 1);
+
 const program = new GrainCommand();
 
 program
@@ -180,7 +187,7 @@ program
   .action(function (file, options, program) {
     exec.grainc(file, options, program);
     const outFile = options.o ?? file.replace(/\.gr$/, ".gr.wasm");
-    exec.grainrun(outFile, options, program);
+    exec.grainrun(unprocessedArgs, outFile, options, program);
   });
 
 program
@@ -193,7 +200,7 @@ program
 program
   .command("run <file>")
   .description("run a wasm file via grain's WASI runner")
-  .action(exec.grainrun);
+  .action((...args) => exec.grainrun(unprocessedArgs, ...args));
 
 program
   .command("lsp")
@@ -216,4 +223,4 @@ program
   .forwardOption("-o <file|dir>", "output file or directory")
   .action(exec.grainformat);
 
-program.parse(process.argv);
+program.parse(argsToProcess);

--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -223,5 +223,4 @@ program
   .forwardOption("-o <file|dir>", "output file or directory")
   .action(exec.grainformat);
 
-console.log({allArgs: process.argv, argsToProcess, unprocessedArgs})
 program.parse(argsToProcess);

--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -223,4 +223,5 @@ program
   .forwardOption("-o <file|dir>", "output file or directory")
   .action(exec.grainformat);
 
+console.log({allArgs: process.argv, argsToProcess, unprocessedArgs})
 program.parse(argsToProcess);

--- a/cli/bin/grainrun.js
+++ b/cli/bin/grainrun.js
@@ -17,13 +17,11 @@ const { WASI } = require("wasi");
 const { argv, env } = require("process");
 
 const preopens = JSON.parse(env.PREOPENS);
-
-delete env.PREOPENS;
-delete env.NODE_OPTIONS;
+const envVars = JSON.parse(env.ENV_VARS);
 
 const wasi = new WASI({
   args: argv.slice(2),
-  env,
+  env: envVars,
   preopens,
 });
 

--- a/compiler/test/runner.re
+++ b/compiler/test/runner.re
@@ -290,7 +290,8 @@ let makeNoWarningRunner = (test, name, prog) => {
   });
 };
 
-let makeRunner = (test, ~num_pages=?, ~config_fn=?, ~extra_args=?, name, prog, expected) => {
+let makeRunner =
+    (test, ~num_pages=?, ~config_fn=?, ~extra_args=?, name, prog, expected) => {
   test(name, ({expect}) => {
     Config.preserve_all_configs(() => {
       ignore @@ compile(~num_pages?, ~config_fn?, name, module_header ++ prog);

--- a/compiler/test/runner.re
+++ b/compiler/test/runner.re
@@ -179,6 +179,15 @@ let run = (~num_pages=?, ~extra_args=[||], file) => {
       Filepath.to_string(test_data_dir),
     );
 
+  let extra_args =
+    Array.map(
+      arg =>
+        switch (Sys.win32, arg) {
+        | (true, "--") => "`--"
+        | _ => arg
+        },
+      extra_args,
+    );
   let cmd =
     Array.concat([
       [|"grain", "run"|],

--- a/compiler/test/runner.re
+++ b/compiler/test/runner.re
@@ -158,7 +158,7 @@ let open_process = args => {
   (code, out, err);
 };
 
-let run = (~num_pages=?, file) => {
+let run = (~num_pages=?, ~extra_args=[||], file) => {
   let mem_flags =
     switch (num_pages) {
     | Some(x) => [|
@@ -185,6 +185,7 @@ let run = (~num_pages=?, file) => {
       mem_flags,
       [|"-S", stdlib, "-I", Filepath.to_string(test_libs_dir), preopen|],
       [|file|],
+      extra_args,
     ]);
 
   let (code, out, err) = open_process(cmd);
@@ -289,11 +290,11 @@ let makeNoWarningRunner = (test, name, prog) => {
   });
 };
 
-let makeRunner = (test, ~num_pages=?, ~config_fn=?, name, prog, expected) => {
+let makeRunner = (test, ~num_pages=?, ~config_fn=?, ~extra_args=?, name, prog, expected) => {
   test(name, ({expect}) => {
     Config.preserve_all_configs(() => {
       ignore @@ compile(~num_pages?, ~config_fn?, name, module_header ++ prog);
-      let (result, _) = run(~num_pages?, wasmfile(name));
+      let (result, _) = run(~num_pages?, ~extra_args?, wasmfile(name));
       expect.string(result).toEqual(expected);
     })
   });

--- a/compiler/test/stdlib/sys.process.test.gr
+++ b/compiler/test/stdlib/sys.process.test.gr
@@ -11,7 +11,7 @@ match (Process.argv()) {
 
 // Just a smoke test
 match (Process.env()) {
-  Ok(arr) => assert Array.length(arr) > 0,
+  Ok(arr) => assert Array.length(arr) == 0,
   Err(err) => throw err,
 }
 

--- a/compiler/test/suites/wasi_args.re
+++ b/compiler/test/suites/wasi_args.re
@@ -17,13 +17,7 @@ describe("wasi args and env", ({test, testSkip}) => {
     _ => print("Error reading args")
   }
   match (Process.env()) {
-    Ok(env) => {
-      print(Array.filter(var => {
-        let s = x => String.startsWith(x, var)
-        // ignore "extraneous" environment variables that get injected automatically
-        s("FOO=") || s("BAR=") || s("BAZ=")
-      }, env))
-    },
+    Ok(env) => print(env),
     _ => print("Error reading env")
   }
   |};

--- a/compiler/test/suites/wasi_args.re
+++ b/compiler/test/suites/wasi_args.re
@@ -20,7 +20,8 @@ describe("wasi args and env", ({test, testSkip}) => {
     Ok(env) => {
       print(Array.filter(var => {
         let s = x => String.startsWith(x, var)
-        !(s("PWD=") || s("SHLVL=") || s("_="))
+        // ignore "extraneous" environment variables that get injected automatically
+        s("FOO=") || s("BAR=") || s("BAZ=")
       }, env))
     },
     _ => print("Error reading env")

--- a/compiler/test/suites/wasi_args.re
+++ b/compiler/test/suites/wasi_args.re
@@ -1,0 +1,66 @@
+open Grain_tests.TestFramework;
+open Grain_tests.Runner;
+
+describe("wasi args and env", ({test, testSkip}) => {
+  let test_or_skip =
+    Sys.backend_type == Other("js_of_ocaml") ? testSkip : test;
+
+  let assertRun = makeRunner(test_or_skip);
+
+  let print_wasi_info = {|
+  include "sys/process"
+  include "array"
+  include "string"
+
+  match (Process.argv()) {
+    Ok(args) => print(Array.slice(1, args)),
+    _ => print("Error reading args")
+  }
+  match (Process.env()) {
+    Ok(env) => {
+      print(Array.filter(var => {
+        let s = x => String.startsWith(x, var)
+        !(s("PWD=") || s("SHLVL=") || s("_="))
+      }, env))
+    },
+    _ => print("Error reading env")
+  }
+  |};
+
+  assertRun(
+    ~extra_args=[|"--", "a", "b"|],
+    "print_args1",
+    print_wasi_info,
+    "[> \"a\", \"b\"]\n[> ]\n",
+  );
+  assertRun(
+    ~extra_args=[|"a", "b"|],
+    "print_args2",
+    print_wasi_info,
+    "[> ]\n[> ]\n",
+  );
+  assertRun(
+    ~extra_args=[|"--env=FOO=bar", "a", "b"|],
+    "print_args3",
+    print_wasi_info,
+    "[> ]\n[> \"FOO=bar\"]\n",
+  );
+  assertRun(
+    ~extra_args=[|"--env", "FOO=bar", "BAR=baz", "BAZ"|],
+    "print_args4",
+    print_wasi_info,
+    "[> ]\n[> \"FOO=bar\", \"BAR=baz\", \"BAZ=\"]\n",
+  );
+  assertRun(
+    ~extra_args=[|"--env", "FOO=bar", "--", "a", "b"|],
+    "print_args5",
+    print_wasi_info,
+    "[> \"a\", \"b\"]\n[> \"FOO=bar\"]\n",
+  );
+  assertRun(
+    ~extra_args=[|"--", "a", "b", "--env", "FOO=bar"|],
+    "print_args6",
+    print_wasi_info,
+    "[> \"a\", \"b\", \"--env\", \"FOO=bar\"]\n[> ]\n",
+  );
+});

--- a/stdlib/sys/process.gr
+++ b/stdlib/sys/process.gr
@@ -152,9 +152,9 @@ provide let env = () => {
   let envc = WasmI32.load(envcPtr, 0n)
   let envvBufSize = WasmI32.load(envvBufSizePtr, 0n)
 
-  if (envc == 0n) {
+  if (WasmI32.eqz(envc)) {
     Memory.free(envcPtr)
-    return Ok(WasmI32.toGrain(allocateArray(0n)): Array<String>)
+    return Ok([>]: Array<String>)
   }
 
   let envvPtr = Memory.malloc(envc * 4n)

--- a/stdlib/sys/process.gr
+++ b/stdlib/sys/process.gr
@@ -152,6 +152,11 @@ provide let env = () => {
   let envc = WasmI32.load(envcPtr, 0n)
   let envvBufSize = WasmI32.load(envvBufSizePtr, 0n)
 
+  if (envc == 0n) {
+    Memory.free(envcPtr)
+    return Ok(WasmI32.toGrain(allocateArray(0n)): Array<String>)
+  }
+
   let envvPtr = Memory.malloc(envc * 4n)
   let envvBufPtr = Memory.malloc(envvBufSize)
 


### PR DESCRIPTION
Closes #1822 
Closes #1823 

Examples:
```
grain a.gr --env=FOO=bar
grain a.gr --env FOO=bar FOO2=baz -- arg1 arg2
grain a.gr arg1 arg2   # will not pass args to WASI, -- required
```