### PR TITLE
feat(stdlib)!: Handle printing of reference cycles

### DIFF
--- a/compiler/test/suites/cycles.re
+++ b/compiler/test/suites/cycles.re
@@ -1,0 +1,136 @@
+open Grain_tests.TestFramework;
+open Grain_tests.Runner;
+
+describe("cyclic references", ({test, testSkip}) => {
+  let test_or_skip =
+    Sys.backend_type == Other("js_of_ocaml") ? testSkip : test;
+
+  let assertRun = makeRunner(test_or_skip);
+
+  assertRun(
+    "cycles1",
+    {|
+      record A {
+        mut a: Option<A>
+      }
+      let x = { a: None }
+      x.a = Some(x)
+      print(x)
+    |},
+    "<1>: {\n  a: Some(<cycle to <1>>)\n}\n",
+  );
+  assertRun(
+    "cycles2",
+    {|
+      record A {
+        val: Number,
+        mut a: Option<A>
+      }
+
+      let x = { val: 1, a: None }
+      let y = { val: 2, a: None }
+      let xOpt = Some(x)
+      let yOpt = Some(y)
+      x.a = yOpt
+      y.a = xOpt
+
+      print([x, y])
+    |},
+    "[<1>: {\n  val: 1,\n  a: Some({\n    val: 2,\n    a: Some(<cycle to <1>>)\n  })\n}, <2>: {\n  val: 2,\n  a: Some(<1>: {\n    val: 1,\n    a: Some(<cycle to <2>>)\n  })\n}]\n",
+  );
+  assertRun(
+    "cycles3",
+    {|
+      record A {
+        val: Number,
+        mut next: Option<A>
+      }
+
+      let a = { val: 1, next: None }
+      let aOpt = Some(a)
+      let b = Some({ val: 2, next: aOpt })
+      let c = Some({ val: 3, next: b })
+      let d = Some({ val: 4, next: c })
+      let e = Some({ val: 5, next: d })
+      a.next = e
+      print([aOpt, b, c, d, e])
+    |},
+    {|[Some(<1>: {
+  val: 1,
+  next: Some({
+    val: 5,
+    next: Some({
+      val: 4,
+      next: Some({
+        val: 3,
+        next: Some({
+          val: 2,
+          next: Some(<cycle to <1>>)
+        })
+      })
+    })
+  })
+}), Some(<2>: {
+  val: 2,
+  next: Some(<1>: {
+    val: 1,
+    next: Some({
+      val: 5,
+      next: Some({
+        val: 4,
+        next: Some({
+          val: 3,
+          next: Some(<cycle to <2>>)
+        })
+      })
+    })
+  })
+}), Some(<3>: {
+  val: 3,
+  next: Some(<2>: {
+    val: 2,
+    next: Some(<1>: {
+      val: 1,
+      next: Some({
+        val: 5,
+        next: Some({
+          val: 4,
+          next: Some(<cycle to <3>>)
+        })
+      })
+    })
+  })
+}), Some(<4>: {
+  val: 4,
+  next: Some(<3>: {
+    val: 3,
+    next: Some(<2>: {
+      val: 2,
+      next: Some(<1>: {
+        val: 1,
+        next: Some({
+          val: 5,
+          next: Some(<cycle to <4>>)
+        })
+      })
+    })
+  })
+}), Some(<5>: {
+  val: 5,
+  next: Some(<4>: {
+    val: 4,
+    next: Some(<3>: {
+      val: 3,
+      next: Some(<2>: {
+        val: 2,
+        next: Some(<1>: {
+          val: 1,
+          next: Some(<cycle to <5>>)
+        })
+      })
+    })
+  })
+})]
+|},
+  );
+});

--- a/compiler/test/suites/cycles.re
+++ b/compiler/test/suites/cycles.re
@@ -10,7 +10,7 @@ describe("cyclic references", ({test, testSkip}) => {
   assertRun(
     "cycles1",
     {|
-      record A {
+      record rec A {
         mut a: Option<A>
       }
       let x = { a: None }
@@ -22,7 +22,7 @@ describe("cyclic references", ({test, testSkip}) => {
   assertRun(
     "cycles2",
     {|
-      record A {
+      record rec A {
         val: Number,
         mut a: Option<A>
       }
@@ -41,7 +41,7 @@ describe("cyclic references", ({test, testSkip}) => {
   assertRun(
     "cycles3",
     {|
-      record A {
+      record rec A {
         val: Number,
         mut next: Option<A>
       }
@@ -136,7 +136,7 @@ describe("cyclic references", ({test, testSkip}) => {
   assertRun(
     "cycles4",
     {|
-      enum R {
+      enum rec R {
         Rec(Box<Option<R>>),
       }
 
@@ -151,7 +151,7 @@ describe("cyclic references", ({test, testSkip}) => {
   assertRun(
     "cycles5",
     {|
-      enum R {
+      enum rec R {
         Rec(Array<Option<R>>),
       }
 

--- a/compiler/test/suites/cycles.re
+++ b/compiler/test/suites/cycles.re
@@ -17,7 +17,7 @@ describe("cyclic references", ({test, testSkip}) => {
       x.a = Some(x)
       print(x)
     |},
-    "<1>: {\n  a: Some(<cycle to <1>>)\n}\n",
+    "<1> {\n  a: Some(<cycle to <1>>)\n}\n",
   );
   assertRun(
     "cycles2",
@@ -36,7 +36,7 @@ describe("cyclic references", ({test, testSkip}) => {
 
       print([x, y])
     |},
-    "[<1>: {\n  val: 1,\n  a: Some({\n    val: 2,\n    a: Some(<cycle to <1>>)\n  })\n}, <2>: {\n  val: 2,\n  a: Some(<1>: {\n    val: 1,\n    a: Some(<cycle to <2>>)\n  })\n}]\n",
+    "[<1> {\n  val: 1,\n  a: Some({\n    val: 2,\n    a: Some(<cycle to <1>>)\n  })\n}, <2> {\n  val: 2,\n  a: Some(<1> {\n    val: 1,\n    a: Some(<cycle to <2>>)\n  })\n}]\n",
   );
   assertRun(
     "cycles3",
@@ -55,7 +55,7 @@ describe("cyclic references", ({test, testSkip}) => {
       a.next = e
       print([aOpt, b, c, d, e])
     |},
-    {|[Some(<1>: {
+    {|[Some(<1> {
   val: 1,
   next: Some({
     val: 5,
@@ -70,9 +70,9 @@ describe("cyclic references", ({test, testSkip}) => {
       })
     })
   })
-}), Some(<2>: {
+}), Some(<2> {
   val: 2,
-  next: Some(<1>: {
+  next: Some(<1> {
     val: 1,
     next: Some({
       val: 5,
@@ -85,11 +85,11 @@ describe("cyclic references", ({test, testSkip}) => {
       })
     })
   })
-}), Some(<3>: {
+}), Some(<3> {
   val: 3,
-  next: Some(<2>: {
+  next: Some(<2> {
     val: 2,
-    next: Some(<1>: {
+    next: Some(<1> {
       val: 1,
       next: Some({
         val: 5,
@@ -100,13 +100,13 @@ describe("cyclic references", ({test, testSkip}) => {
       })
     })
   })
-}), Some(<4>: {
+}), Some(<4> {
   val: 4,
-  next: Some(<3>: {
+  next: Some(<3> {
     val: 3,
-    next: Some(<2>: {
+    next: Some(<2> {
       val: 2,
-      next: Some(<1>: {
+      next: Some(<1> {
         val: 1,
         next: Some({
           val: 5,
@@ -115,15 +115,15 @@ describe("cyclic references", ({test, testSkip}) => {
       })
     })
   })
-}), Some(<5>: {
+}), Some(<5> {
   val: 5,
-  next: Some(<4>: {
+  next: Some(<4> {
     val: 4,
-    next: Some(<3>: {
+    next: Some(<3> {
       val: 3,
-      next: Some(<2>: {
+      next: Some(<2> {
         val: 2,
-        next: Some(<1>: {
+        next: Some(<1> {
           val: 1,
           next: Some(<cycle to <5>>)
         })
@@ -132,5 +132,34 @@ describe("cyclic references", ({test, testSkip}) => {
   })
 })]
 |},
+  );
+  assertRun(
+    "cycles4",
+    {|
+      enum R {
+        Rec(Box<Option<R>>),
+      }
+
+      let a = box(None)
+      let b = Rec(a)
+      a := Some(b)
+      print(a)
+      print(unbox(a))
+    |},
+    "<1> box(Some(Rec(<cycle to <1>>)))\nSome(Rec(<1> box(Some(Rec(<cycle to <1>>)))))\n",
+  );
+  assertRun(
+    "cycles5",
+    {|
+      enum R {
+        Rec(Array<Option<R>>),
+      }
+
+      let a = [> None]
+      let b = Rec(a)
+      a[0] = Some(b)
+      print(a)
+    |},
+    "<1> [> Some(Rec(<cycle to <1>>))]\n",
   );
 });

--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -79,6 +79,75 @@ let _OK = "Ok"
 let _ERR = "Err"
 
 @unsafe
+let _VEC_LEN_OFFSET = 0n
+@unsafe
+let _VEC_CAP_OFFSET = 4n
+@unsafe
+let _VEC_DATA_OFFSET = 8n
+
+// Resizable arrays: <num items> <capacity> <...data>
+@unsafe
+let makeVec = () => {
+  let initCap = 4n
+  let vec = Memory.malloc(8n + initCap * 4n)
+  WasmI32.store(vec, 0n, _VEC_LEN_OFFSET)
+  WasmI32.store(vec, initCap, _VEC_CAP_OFFSET)
+  let vecBox = Memory.malloc(4n)
+  WasmI32.store(vecBox, vec, 0n)
+  vecBox
+}
+
+@unsafe
+let freeVec = vecBox => {
+  let vecPtr = WasmI32.load(vecBox, 0n)
+  Memory.free(vecPtr)
+  Memory.free(vecBox)
+}
+
+@unsafe
+let vecPush = (vecBox, val) => {
+  let mut vecPtr = WasmI32.load(vecBox, 0n)
+  let len = WasmI32.load(vecPtr, _VEC_LEN_OFFSET)
+  let cap = WasmI32.load(vecPtr, _VEC_CAP_OFFSET)
+  if (len == cap) {
+    let newCap = cap * 2n
+    let newVec = Memory.malloc(8n + newCap * 4n)
+    Memory.copy(newVec, vecPtr, 8n + cap * 4n)
+    WasmI32.store(newVec, newCap, _VEC_CAP_OFFSET)
+    Memory.free(vecPtr)
+    WasmI32.store(vecBox, newVec, 0n)
+    vecPtr = newVec
+  }
+  WasmI32.store(vecPtr + len * 4n, val, _VEC_DATA_OFFSET)
+  WasmI32.store(vecPtr, len + 1n, _VEC_LEN_OFFSET)
+}
+
+@unsafe
+let vecPop = vecBox => {
+  let vecPtr = WasmI32.load(vecBox, 0n)
+  let len = WasmI32.load(vecPtr, _VEC_LEN_OFFSET)
+  WasmI32.store(vecPtr, len - 1n, _VEC_LEN_OFFSET)
+}
+
+@unsafe
+let vecLen = vecBox => {
+  let vecPtr = WasmI32.load(vecBox, 0n)
+  WasmI32.load(vecPtr, _VEC_LEN_OFFSET)
+}
+
+@unsafe
+let vecLookup = (vecBox, val) => {
+  let vecPtr = WasmI32.load(vecBox, 0n)
+  let len = WasmI32.load(vecPtr, _VEC_LEN_OFFSET)
+  for (let mut i = 0n; i < len; i += 1n) {
+    if (WasmI32.load(vecPtr + i * 4n, _VEC_DATA_OFFSET) == val) {
+      return i
+    }
+  }
+  return -1n
+}
+
+@unsafe
 let isListVariant = variant => {
   let typeId = WasmI32.load(variant, 8n) >> 1n
   typeId == _LIST_ID
@@ -346,9 +415,19 @@ let usvToString = usv => {
 }
 
 @unsafe
-let rec heapValueToString = (ptr, extraIndents, toplevel) => {
+let rec heapValueToString = (ptr, extraIndents, toplevel, visited, cycles) => {
+  if (vecLookup(visited, ptr) != -1n) {
+    let mut cycleNum = vecLookup(cycles, ptr)
+    if (cycleNum == -1n) {
+      cycleNum = vecLen(cycles)
+      vecPush(cycles, ptr)
+    }
+    cycleNum += 1n
+    let numStr = NumberUtils.itoa32(cycleNum, 10n)
+    return join(["<cycle to <", numStr, ">>"])
+  }
   let tag = WasmI32.load(ptr, 0n)
-  match (tag) {
+  return match (tag) {
     t when t == Tags._GRAIN_STRING_HEAP_TAG => {
       // In both cases, we incRef ptr so we can use it again via WasmI32.toGrain
       Memory.incRef(ptr)
@@ -406,10 +485,12 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
         tupleVariantToString(
           ptr,
           WasmI32.toGrain(builtinVariantName),
-          extraIndents
+          extraIndents,
+          visited,
+          cycles
         )
       } else if (isListVariant(ptr)) {
-        listToString(ptr, extraIndents)
+        listToString(ptr, extraIndents, visited, cycles)
       } else {
         let variantPtr = getVariantMetadata(ptr)
         if (variantPtr == -1n) {
@@ -430,14 +511,22 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
               recordArity,
               recordVariantFields,
               20n,
-              extraIndents
+              extraIndents,
+              visited,
+              cycles
             )
             Memory.decRef(recordVariantFields)
             let strings = [variantName, recordString]
 
             join(strings)
           } else {
-            tupleVariantToString(ptr, variantName, extraIndents)
+            tupleVariantToString(
+              ptr,
+              variantName,
+              extraIndents,
+              visited,
+              cycles
+            )
           }
         }
       }
@@ -448,9 +537,25 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
       if (fields == -1n) {
         "<record value>"
       } else {
-        let result = recordToString(ptr, recordArity, fields, 16n, extraIndents)
+        vecPush(visited, ptr)
+        let result = recordToString(
+          ptr,
+          recordArity,
+          fields,
+          16n,
+          extraIndents,
+          visited,
+          cycles
+        )
+        let cycleLen = vecLookup(cycles, ptr)
+        let cycleNumPrefix = if (cycleLen != -1n) {
+          join(["<", NumberUtils.itoa32(cycleLen + 1n, 10n), ">: "])
+        } else {
+          ""
+        }
         Memory.decRef(fields)
-        result
+        vecPop(visited)
+        join([cycleNumPrefix, result])
       }
     },
     t when t == Tags._GRAIN_ARRAY_HEAP_TAG => {
@@ -459,7 +564,13 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
       let mut strings = [rbrack]
       let comspace = ", "
       for (let mut i = arity * 4n - 4n; i >= 0n; i -= 4n) {
-        let item = toStringHelp(WasmI32.load(ptr + i, 8n), extraIndents, false)
+        let item = toStringHelp(
+          WasmI32.load(ptr + i, 8n),
+          extraIndents,
+          false,
+          visited,
+          cycles
+        )
         strings = [item, ...strings]
         if (i > 0n) {
           strings = [comspace, ...strings]
@@ -520,7 +631,9 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
           let item = toStringHelp(
             WasmI32.load(ptr + i, 8n),
             extraIndents,
-            false
+            false,
+            visited,
+            cycles
           )
           strings = [item, ...strings]
           if (i > 0n) {
@@ -554,14 +667,14 @@ let rec heapValueToString = (ptr, extraIndents, toplevel) => {
     },
   }
 }
-and toStringHelp = (grainValue, extraIndents, toplevel) => {
+and toStringHelp = (grainValue, extraIndents, toplevel, visited, cycles) => {
   if ((grainValue & 1n) != 0n) {
     // Simple (unboxed) numbers
     NumberUtils.itoa32(grainValue >> 1n, 10n)
   } else {
     let tag = grainValue & 7n
     if (tag == Tags._GRAIN_GENERIC_HEAP_TAG_TYPE) {
-      heapValueToString(grainValue, extraIndents, toplevel)
+      heapValueToString(grainValue, extraIndents, toplevel, visited, cycles)
     } else if (tag == Tags._GRAIN_SHORTVAL_TAG_TYPE) {
       let shortVal = grainValue >> 8n
       let shortValTag = (grainValue & 0xF8n) >> 3n
@@ -596,7 +709,7 @@ and toStringHelp = (grainValue, extraIndents, toplevel) => {
     }
   }
 }
-and listToString = (ptr, extraIndents) => {
+and listToString = (ptr, extraIndents, visited, cycles) => {
   let mut cur = ptr
   let mut isFirst = true
 
@@ -613,7 +726,13 @@ and listToString = (ptr, extraIndents) => {
         strings = [commaspace, ...strings]
       }
       isFirst = false
-      let item = toStringHelp(WasmI32.load(cur, 20n), extraIndents, false)
+      let item = toStringHelp(
+        WasmI32.load(cur, 20n),
+        extraIndents,
+        false,
+        visited,
+        cycles
+      )
       strings = [item, ...strings]
       cur = WasmI32.load(cur, 24n)
     }
@@ -623,7 +742,14 @@ and listToString = (ptr, extraIndents) => {
   let reversed = reverse(strings)
   join(reversed)
 }
-and tupleVariantToString = (ptr, variantName, extraIndents) => {
+and tupleVariantToString =
+  (
+    ptr,
+    variantName,
+    extraIndents,
+    visited,
+    cycles,
+  ) => {
   let variantArity = WasmI32.load(ptr, 16n)
   if (variantArity == 0n) {
     variantName
@@ -632,7 +758,13 @@ and tupleVariantToString = (ptr, variantName, extraIndents) => {
     let rparen = ")"
     let mut strings = [rparen]
     for (let mut i = variantArity * 4n - 4n; i >= 0n; i -= 4n) {
-      let tmp = toStringHelp(WasmI32.load(ptr + i, 20n), extraIndents, false)
+      let tmp = toStringHelp(
+        WasmI32.load(ptr + i, 20n),
+        extraIndents,
+        false,
+        visited,
+        cycles
+      )
       strings = [tmp, ...strings]
       if (i > 0n) {
         strings = [comspace, ...strings]
@@ -651,6 +783,8 @@ and recordToString =
     fields,
     contentOffset,
     extraIndents,
+    visited,
+    cycles,
   ) => {
   let prevPadAmount = extraIndents * 2n
   let prevSpacePadding = if (prevPadAmount == 0n) {
@@ -678,7 +812,9 @@ and recordToString =
     let fieldValue = toStringHelp(
       WasmI32.load(ptr + i, contentOffset),
       extraIndents + 1n,
-      false
+      false,
+      visited,
+      cycles
     )
     strings = [spacePadding, fieldName, colspace, fieldValue, ...strings]
     if (i > 0n) {
@@ -703,7 +839,11 @@ and recordToString =
 @unsafe
 provide let toString = value => {
   let ptr = WasmI32.fromGrain(value)
-  let string = toStringHelp(ptr, 0n, true)
+  let visited = makeVec()
+  let cycles = makeVec()
+  let string = toStringHelp(ptr, 0n, true, visited, cycles)
+  freeVec(visited)
+  freeVec(cycles)
   // Prevent the tail call to allow the value to stay alive
   // while we operate on the raw pointer
   ignore(value)

--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -78,6 +78,7 @@ let _NONE = "None"
 let _OK = "Ok"
 let _ERR = "Err"
 
+// Resizable arrays: <num items> <capacity> <...data>
 @unsafe
 let _VEC_LEN_OFFSET = 0n
 @unsafe
@@ -85,28 +86,41 @@ let _VEC_CAP_OFFSET = 4n
 @unsafe
 let _VEC_DATA_OFFSET = 8n
 
-// Resizable arrays: <num items> <capacity> <...data>
 @unsafe
-let makeVec = () => {
-  let initCap = 4n
-  let vec = Memory.malloc(8n + initCap * 4n)
-  WasmI32.store(vec, 0n, _VEC_LEN_OFFSET)
-  WasmI32.store(vec, initCap, _VEC_CAP_OFFSET)
+let _VISITED_BIT = 0x80000000n
+
+@unsafe
+let makeVecBox = () => {
   let vecBox = Memory.malloc(4n)
-  WasmI32.store(vecBox, vec, 0n)
+  WasmI32.store(vecBox, 0n, 0n)
   vecBox
 }
 
 @unsafe
-let freeVec = vecBox => {
+let initVec = vecBox => {
+  let initCap = 4n
+  let vec = Memory.malloc(8n + initCap * 4n)
+  WasmI32.store(vec, 0n, _VEC_LEN_OFFSET)
+  WasmI32.store(vec, initCap, _VEC_CAP_OFFSET)
+  WasmI32.store(vecBox, vec, 0n)
+  vec
+}
+
+@unsafe
+let freeVecBox = vecBox => {
   let vecPtr = WasmI32.load(vecBox, 0n)
-  Memory.free(vecPtr)
+  if (vecPtr != 0n) {
+    Memory.free(vecPtr)
+  }
   Memory.free(vecBox)
 }
 
 @unsafe
 let vecPush = (vecBox, val) => {
   let mut vecPtr = WasmI32.load(vecBox, 0n)
+  if (vecPtr == 0n) {
+    vecPtr = initVec(vecBox)
+  }
   let len = WasmI32.load(vecPtr, _VEC_LEN_OFFSET)
   let cap = WasmI32.load(vecPtr, _VEC_CAP_OFFSET)
   if (len == cap) {
@@ -123,22 +137,19 @@ let vecPush = (vecBox, val) => {
 }
 
 @unsafe
-let vecPop = vecBox => {
-  let vecPtr = WasmI32.load(vecBox, 0n)
-  let len = WasmI32.load(vecPtr, _VEC_LEN_OFFSET)
-  WasmI32.store(vecPtr, len - 1n, _VEC_LEN_OFFSET)
-}
-
-@unsafe
 let vecLen = vecBox => {
   let vecPtr = WasmI32.load(vecBox, 0n)
-  WasmI32.load(vecPtr, _VEC_LEN_OFFSET)
+  if (vecPtr == 0n) {
+    0n
+  } else {
+    WasmI32.load(vecPtr, _VEC_LEN_OFFSET)
+  }
 }
 
 @unsafe
-let vecLookup = (vecBox, val) => {
+let vecFindIndex = (vecBox, val) => {
   let vecPtr = WasmI32.load(vecBox, 0n)
-  let len = WasmI32.load(vecPtr, _VEC_LEN_OFFSET)
+  let len = vecLen(vecBox)
   for (let mut i = 0n; i < len; i += 1n) {
     if (WasmI32.load(vecPtr + i * 4n, _VEC_DATA_OFFSET) == val) {
       return i
@@ -415,19 +426,30 @@ let usvToString = usv => {
 }
 
 @unsafe
-let rec heapValueToString = (ptr, extraIndents, toplevel, visited, cycles) => {
-  if (vecLookup(visited, ptr) != -1n) {
-    let mut cycleNum = vecLookup(cycles, ptr)
-    if (cycleNum == -1n) {
-      cycleNum = vecLen(cycles)
-      vecPush(cycles, ptr)
-    }
-    cycleNum += 1n
-    let numStr = NumberUtils.itoa32(cycleNum, 10n)
-    return join(["<cycle to <", numStr, ">>"])
+let reportCycle = (ptr, cycles) => {
+  let mut cycleNum = vecFindIndex(cycles, ptr)
+  if (cycleNum == -1n) {
+    cycleNum = vecLen(cycles)
+    vecPush(cycles, ptr)
   }
+  let numStr = NumberUtils.itoa32(cycleNum + 1n, 10n)
+  join(["<cycle to <", numStr, ">>"])
+}
+
+@unsafe
+let cyclePrefix = (ptr, cycles) => {
+  let cycleNum = vecFindIndex(cycles, ptr)
+  if (cycleNum != -1n) {
+    join(["<", NumberUtils.itoa32(cycleNum + 1n, 10n), "> "])
+  } else {
+    ""
+  }
+}
+
+@unsafe
+let rec heapValueToString = (ptr, extraIndents, toplevel, cycles) => {
   let tag = WasmI32.load(ptr, 0n)
-  return match (tag) {
+  match (tag) {
     t when t == Tags._GRAIN_STRING_HEAP_TAG => {
       // In both cases, we incRef ptr so we can use it again via WasmI32.toGrain
       Memory.incRef(ptr)
@@ -486,11 +508,10 @@ let rec heapValueToString = (ptr, extraIndents, toplevel, visited, cycles) => {
           ptr,
           WasmI32.toGrain(builtinVariantName),
           extraIndents,
-          visited,
           cycles
         )
       } else if (isListVariant(ptr)) {
-        listToString(ptr, extraIndents, visited, cycles)
+        listToString(ptr, extraIndents, cycles)
       } else {
         let variantPtr = getVariantMetadata(ptr)
         if (variantPtr == -1n) {
@@ -512,7 +533,6 @@ let rec heapValueToString = (ptr, extraIndents, toplevel, visited, cycles) => {
               recordVariantFields,
               20n,
               extraIndents,
-              visited,
               cycles
             )
             Memory.decRef(recordVariantFields)
@@ -520,13 +540,7 @@ let rec heapValueToString = (ptr, extraIndents, toplevel, visited, cycles) => {
 
             join(strings)
           } else {
-            tupleVariantToString(
-              ptr,
-              variantName,
-              extraIndents,
-              visited,
-              cycles
-            )
+            tupleVariantToString(ptr, variantName, extraIndents, cycles)
           }
         }
       }
@@ -537,49 +551,51 @@ let rec heapValueToString = (ptr, extraIndents, toplevel, visited, cycles) => {
       if (fields == -1n) {
         "<record value>"
       } else {
-        vecPush(visited, ptr)
-        let result = recordToString(
-          ptr,
-          recordArity,
-          fields,
-          16n,
-          extraIndents,
-          visited,
-          cycles
-        )
-        let cycleLen = vecLookup(cycles, ptr)
-        let cycleNumPrefix = if (cycleLen != -1n) {
-          join(["<", NumberUtils.itoa32(cycleLen + 1n, 10n), ">: "])
+        if ((recordArity & _VISITED_BIT) != 0n) {
+          reportCycle(ptr, cycles)
         } else {
-          ""
+          WasmI32.store(ptr, _VISITED_BIT | recordArity, 12n)
+          let result = recordToString(
+            ptr,
+            recordArity,
+            fields,
+            16n,
+            extraIndents,
+            cycles
+          )
+          Memory.decRef(fields)
+          WasmI32.store(ptr, recordArity, 12n)
+          join([cyclePrefix(ptr, cycles), result])
         }
-        Memory.decRef(fields)
-        vecPop(visited)
-        join([cycleNumPrefix, result])
       }
     },
     t when t == Tags._GRAIN_ARRAY_HEAP_TAG => {
       let arity = WasmI32.load(ptr, 4n)
-      let rbrack = "]"
-      let mut strings = [rbrack]
-      let comspace = ", "
-      for (let mut i = arity * 4n - 4n; i >= 0n; i -= 4n) {
-        let item = toStringHelp(
-          WasmI32.load(ptr + i, 8n),
-          extraIndents,
-          false,
-          visited,
-          cycles
-        )
-        strings = [item, ...strings]
-        if (i > 0n) {
-          strings = [comspace, ...strings]
+      if ((arity & _VISITED_BIT) != 0n) {
+        reportCycle(ptr, cycles)
+      } else {
+        WasmI32.store(ptr, _VISITED_BIT | arity, 4n)
+        let rbrack = "]"
+        let mut strings = [rbrack]
+        let comspace = ", "
+        for (let mut i = arity * 4n - 4n; i >= 0n; i -= 4n) {
+          let item = toStringHelp(
+            WasmI32.load(ptr + i, 8n),
+            extraIndents,
+            false,
+            cycles
+          )
+          strings = [item, ...strings]
+          if (i > 0n) {
+            strings = [comspace, ...strings]
+          }
         }
-      }
-      let lbrack = "[> "
-      strings = [lbrack, ...strings]
+        WasmI32.store(ptr, arity, 4n)
+        let lbrack = "[> "
+        strings = [lbrack, ...strings]
 
-      join(strings)
+        join([cyclePrefix(ptr, cycles), ...strings])
+      }
     },
     t when t == Tags._GRAIN_BOXED_NUM_HEAP_TAG => {
       let numberTag = WasmI32.load(ptr, 4n)
@@ -619,10 +635,10 @@ let rec heapValueToString = (ptr, extraIndents, toplevel, visited, cycles) => {
     },
     t when t == Tags._GRAIN_TUPLE_HEAP_TAG => {
       let tupleLength = WasmI32.load(ptr, 4n)
-      if ((tupleLength & 0x80000000n) != 0n) {
-        "<cyclic tuple>"
+      if ((tupleLength & _VISITED_BIT) != 0n) {
+        reportCycle(ptr, cycles)
       } else {
-        WasmI32.store(ptr, 0x80000000n | tupleLength, 4n)
+        WasmI32.store(ptr, _VISITED_BIT | tupleLength, 4n)
         let comspace = ", "
         let rparen = ")"
         let mut lparen = "("
@@ -632,7 +648,6 @@ let rec heapValueToString = (ptr, extraIndents, toplevel, visited, cycles) => {
             WasmI32.load(ptr + i, 8n),
             extraIndents,
             false,
-            visited,
             cycles
           )
           strings = [item, ...strings]
@@ -649,7 +664,7 @@ let rec heapValueToString = (ptr, extraIndents, toplevel, visited, cycles) => {
           // are stored as a unary tuple, so we keep this in case one gets printed
           strings = ["box", ...strings]
         }
-        join(strings)
+        join([cyclePrefix(ptr, cycles), ...strings])
       }
     },
     t when t == Tags._GRAIN_LAMBDA_HEAP_TAG => {
@@ -667,14 +682,14 @@ let rec heapValueToString = (ptr, extraIndents, toplevel, visited, cycles) => {
     },
   }
 }
-and toStringHelp = (grainValue, extraIndents, toplevel, visited, cycles) => {
+and toStringHelp = (grainValue, extraIndents, toplevel, cycles) => {
   if ((grainValue & 1n) != 0n) {
     // Simple (unboxed) numbers
     NumberUtils.itoa32(grainValue >> 1n, 10n)
   } else {
     let tag = grainValue & 7n
     if (tag == Tags._GRAIN_GENERIC_HEAP_TAG_TYPE) {
-      heapValueToString(grainValue, extraIndents, toplevel, visited, cycles)
+      heapValueToString(grainValue, extraIndents, toplevel, cycles)
     } else if (tag == Tags._GRAIN_SHORTVAL_TAG_TYPE) {
       let shortVal = grainValue >> 8n
       let shortValTag = (grainValue & 0xF8n) >> 3n
@@ -709,7 +724,7 @@ and toStringHelp = (grainValue, extraIndents, toplevel, visited, cycles) => {
     }
   }
 }
-and listToString = (ptr, extraIndents, visited, cycles) => {
+and listToString = (ptr, extraIndents, cycles) => {
   let mut cur = ptr
   let mut isFirst = true
 
@@ -730,7 +745,6 @@ and listToString = (ptr, extraIndents, visited, cycles) => {
         WasmI32.load(cur, 20n),
         extraIndents,
         false,
-        visited,
         cycles
       )
       strings = [item, ...strings]
@@ -742,14 +756,7 @@ and listToString = (ptr, extraIndents, visited, cycles) => {
   let reversed = reverse(strings)
   join(reversed)
 }
-and tupleVariantToString =
-  (
-    ptr,
-    variantName,
-    extraIndents,
-    visited,
-    cycles,
-  ) => {
+and tupleVariantToString = (ptr, variantName, extraIndents, cycles) => {
   let variantArity = WasmI32.load(ptr, 16n)
   if (variantArity == 0n) {
     variantName
@@ -762,7 +769,6 @@ and tupleVariantToString =
         WasmI32.load(ptr + i, 20n),
         extraIndents,
         false,
-        visited,
         cycles
       )
       strings = [tmp, ...strings]
@@ -783,7 +789,6 @@ and recordToString =
     fields,
     contentOffset,
     extraIndents,
-    visited,
     cycles,
   ) => {
   let prevPadAmount = extraIndents * 2n
@@ -813,7 +818,6 @@ and recordToString =
       WasmI32.load(ptr + i, contentOffset),
       extraIndents + 1n,
       false,
-      visited,
       cycles
     )
     strings = [spacePadding, fieldName, colspace, fieldValue, ...strings]
@@ -839,11 +843,9 @@ and recordToString =
 @unsafe
 provide let toString = value => {
   let ptr = WasmI32.fromGrain(value)
-  let visited = makeVec()
-  let cycles = makeVec()
-  let string = toStringHelp(ptr, 0n, true, visited, cycles)
-  freeVec(visited)
-  freeVec(cycles)
+  let cycles = makeVecBox()
+  let string = toStringHelp(ptr, 0n, true, cycles)
+  freeVecBox(cycles)
   // Prevent the tail call to allow the value to stay alive
   // while we operate on the raw pointer
   ignore(value)


### PR DESCRIPTION
Closes #1841 

I used a style of reporting cycles similar to Node.js where references are labeled with numbers whenever there is a cycle. For example:
```
record A {
  val: Number,
  mut next: Option<A>
}

let a = { val: 1, next: None }
let aOpt = Some(a)
a.next = aOpt
print(a)

// output:
<1>: {
  val: 1,
  next: Some(<cycle to <1>>)
}
```