### PR TITLE
feat(compiler): Providing, including, reproviding exceptions

### DIFF
--- a/compiler/src/formatting/format.re
+++ b/compiler/src/formatting/format.re
@@ -3917,7 +3917,8 @@ and print_expression_inner =
               switch (item) {
               | PUseValue({loc})
               | PUseModule({loc})
-              | PUseType({loc}) => loc
+              | PUseType({loc})
+              | PUseException({loc}) => loc
               };
             };
 
@@ -3961,6 +3962,8 @@ and print_expression_inner =
                 Doc.concat([Doc.text("module "), item_name(name, alias)])
               | PUseType({name, alias}) =>
                 Doc.concat([Doc.text("type "), item_name(name, alias)])
+              | PUseException({name, alias}) =>
+                Doc.concat([Doc.text("exception "), item_name(name, alias)])
               };
             };
 
@@ -5068,6 +5071,7 @@ let rec toplevel_print =
             switch (item) {
             | PProvideValue({loc})
             | PProvideModule({loc})
+            | PProvideException({loc})
             | PProvideType({loc}) => loc
             };
           };
@@ -5112,6 +5116,8 @@ let rec toplevel_print =
               Doc.concat([Doc.text("module "), item_name(name, alias)])
             | PProvideType({name, alias}) =>
               Doc.concat([Doc.text("type "), item_name(name, alias)])
+            | PProvideException({name, alias}) =>
+              Doc.concat([Doc.text("exception "), item_name(name, alias)])
             };
           };
 

--- a/compiler/src/language_server/definition.re
+++ b/compiler/src/language_server/definition.re
@@ -71,6 +71,7 @@ let process =
     | [Pattern({definition}), ..._]
     | [Type({definition}), ..._]
     | [Declaration({definition}), ..._]
+    | [Exception({definition}), ..._]
     | [Module({definition}), ..._] =>
       switch (definition) {
       | None => send_no_result(~id)

--- a/compiler/src/language_server/hover.re
+++ b/compiler/src/language_server/hover.re
@@ -125,6 +125,13 @@ let declaration_lens = (ident: Ident.t, decl: Types.type_declaration) => {
   grain_type_code_block(Printtyp.string_of_type_declaration(~ident, decl));
 };
 
+let exception_declaration_lens =
+    (ident: Ident.t, ext: Types.extension_constructor) => {
+  grain_type_code_block(
+    Printtyp.string_of_extension_constructor(~ident, ext),
+  );
+};
+
 let process =
     (
       ~id: Protocol.message_id,
@@ -160,6 +167,12 @@ let process =
         ~id,
         ~range=Utils.loc_to_range(loc),
         declaration_lens(ident, decl),
+      )
+    | [Exception({ident, ext, loc}), ..._] =>
+      send_hover(
+        ~id,
+        ~range=Utils.loc_to_range(loc),
+        exception_declaration_lens(ident, ext),
       )
     | [Module({path, decl, loc}), ..._] =>
       send_hover(~id, ~range=Utils.loc_to_range(loc), module_lens(decl))

--- a/compiler/src/language_server/sourcetree.re
+++ b/compiler/src/language_server/sourcetree.re
@@ -157,6 +157,12 @@ module type Sourcetree = {
         loc: Location.t,
         definition: option(Location.t),
       })
+    | Exception({
+        ident: Ident.t,
+        ext: Types.extension_constructor,
+        loc: Location.t,
+        definition: option(Location.t),
+      })
     | Module({
         path: Path.t,
         decl: Types.module_declaration,
@@ -233,6 +239,12 @@ module Sourcetree: Sourcetree = {
     | Declaration({
         ident: Ident.t,
         decl: Types.type_declaration,
+        loc: Location.t,
+        definition: option(Location.t),
+      })
+    | Exception({
+        ident: Ident.t,
+        ext: Types.extension_constructor,
         loc: Location.t,
         definition: option(Location.t),
       })
@@ -385,6 +397,15 @@ module Sourcetree: Sourcetree = {
                                    value_type: value.val_type,
                                    loc,
                                    definition: Some(value.val_loc),
+                                 }),
+                               )
+                             | TUseException({name, ext, loc}) => (
+                                 loc_to_interval(loc),
+                                 Exception({
+                                   ident: Ident.create(name),
+                                   ext,
+                                   loc,
+                                   definition: Some(ext.ext_loc),
                                  }),
                                )
                              }

--- a/compiler/src/middle_end/linearize.re
+++ b/compiler/src/middle_end/linearize.re
@@ -13,7 +13,7 @@ let compile_constructor_tag =
     fun
     | CstrConstant(i) => i
     | CstrBlock(i) => i
-    | CstrExtension(i, _, _) => i
+    | CstrExtension(i, _, _, _) => i
     | CstrUnboxed =>
       failwith("compile_constructor_tag: cannot compile CstrUnboxed")
   );

--- a/compiler/src/parsing/ast_mapper.re
+++ b/compiler/src/parsing/ast_mapper.re
@@ -190,6 +190,12 @@ module E = {
                     alias: Option.map(map_identifier(sub), alias),
                     loc: sub.location(sub, loc),
                   })
+                | PUseException({name, alias, loc}) =>
+                  PUseException({
+                    name: map_identifier(sub, name),
+                    alias: Option.map(map_identifier(sub), alias),
+                    loc: sub.location(sub, loc),
+                  })
                 | PUseModule({name, alias, loc}) =>
                   PUseModule({
                     name: map_identifier(sub, name),
@@ -428,6 +434,12 @@ module Pr = {
         switch (item) {
         | PProvideType({name, alias, loc}) =>
           PProvideType({
+            name: map_identifier(sub, name),
+            alias: Option.map(map_identifier(sub), alias),
+            loc: sub.location(sub, loc),
+          })
+        | PProvideException({name, alias, loc}) =>
+          PProvideException({
             name: map_identifier(sub, name),
             alias: Option.map(map_identifier(sub), alias),
             loc: sub.location(sub, loc),

--- a/compiler/src/parsing/parser.messages
+++ b/compiler/src/parsing/parser.messages
@@ -455,6 +455,18 @@ program: MODULE UIDENT EOL FROM UIDENT USE LBRACE MODULE YIELD
 
 Expected an uppercase type identifier.
 
+program: MODULE UIDENT EOL FROM UIDENT USE LBRACE EXCEPTION YIELD
+##
+## Ends in an error in state: 57.
+##
+## use_item -> EXCEPTION . aliasable(uid) [ RBRACE EOL COMMA ]
+##
+## The known suffix of the stack is as follows:
+## EXCEPTION
+##
+
+Expected an uppercase exception identifier.
+
 program: MODULE UIDENT EOL PROVIDE LBRACE MODULE UIDENT YIELD
 ##
 ## Ends in an error in state: 49.
@@ -557,6 +569,18 @@ program: MODULE UIDENT EOL PROVIDE LBRACE TYPE YIELD
 ##
 
 Expected a type identifier to provide.
+
+program: MODULE UIDENT EOL PROVIDE LBRACE EXCEPTION YIELD
+##
+## Ends in an error in state: 825.
+##
+## provide_item -> EXCEPTION . aliasable(uid) [ RBRACE EOL COMMA ]
+##
+## The known suffix of the stack is as follows:
+## EXCEPTION
+##
+
+Expected an exception identifier to provide.
 
 program: MODULE UIDENT EOL FROM UIDENT USE LBRACE LIDENT AS LIDENT YIELD
 ##

--- a/compiler/src/parsing/parser.mly
+++ b/compiler/src/parsing/parser.mly
@@ -343,6 +343,7 @@ aliasable(X):
 use_item:
   | TYPE aliasable(uid) { PUseType { name=fst $2; alias = snd $2; loc=to_loc $loc} }
   | MODULE aliasable(uid) { PUseModule { name=fst $2; alias = snd $2; loc=to_loc $loc} }
+  | EXCEPTION aliasable(uid) { PUseException { name=fst $2; alias = snd $2; loc=to_loc $loc} }
   | aliasable(lid) { PUseValue { name=fst $1; alias = snd $1; loc=to_loc $loc} }
 
 use_items:
@@ -372,6 +373,7 @@ data_declaration_stmts:
 provide_item:
   | TYPE aliasable(uid) { PProvideType { name=fst $2; alias = snd $2; loc=to_loc $loc} }
   | MODULE aliasable(uid) { PProvideModule { name=fst $2; alias = snd $2; loc=to_loc $loc} }
+  | EXCEPTION aliasable(uid) { PProvideException { name=fst $2; alias = snd $2; loc=to_loc $loc} }
   | aliasable(lid) { PProvideValue { name=fst $1; alias = snd $1; loc=to_loc $loc} }
 
 provide_items:

--- a/compiler/src/parsing/parsetree.re
+++ b/compiler/src/parsing/parsetree.re
@@ -464,6 +464,11 @@ and use_item =
       alias: option(loc(Identifier.t)),
       loc: Location.t,
     })
+  | PUseException({
+      name: loc(Identifier.t),
+      alias: option(loc(Identifier.t)),
+      loc: Location.t,
+    })
   | PUseModule({
       name: loc(Identifier.t),
       alias: option(loc(Identifier.t)),
@@ -591,6 +596,11 @@ type value_description = {
 [@deriving (sexp, yojson)]
 type provide_item =
   | PProvideType({
+      name: loc(Identifier.t),
+      alias: option(loc(Identifier.t)),
+      loc: Location.t,
+    })
+  | PProvideException({
       name: loc(Identifier.t),
       alias: option(loc(Identifier.t)),
       loc: Location.t,

--- a/compiler/src/parsing/parsetree_iter.re
+++ b/compiler/src/parsing/parsetree_iter.re
@@ -124,6 +124,7 @@ and iter_provide = (hooks, items) => {
     item => {
       switch (item) {
       | PProvideType({name, alias, loc})
+      | PProvideException({name, alias, loc})
       | PProvideModule({name, alias, loc})
       | PProvideValue({name, alias, loc}) =>
         iter_ident(hooks, name);
@@ -290,6 +291,7 @@ and iter_expression =
         item => {
           switch (item) {
           | PUseType({name, alias, loc})
+          | PUseException({name, alias, loc})
           | PUseModule({name, alias, loc})
           | PUseValue({name, alias, loc}) =>
             iter_ident(hooks, name);

--- a/compiler/src/parsing/well_formedness.re
+++ b/compiler/src/parsing/well_formedness.re
@@ -597,6 +597,7 @@ let no_local_include = (errs, super) => {
 type provided_multiple_times_ctx = {
   modules: Hashtbl.t(string, unit),
   types: Hashtbl.t(string, unit),
+  exceptions: Hashtbl.t(string, unit),
   values: Hashtbl.t(string, unit),
 };
 
@@ -637,6 +638,7 @@ let provided_multiple_times = (errs, super) => {
       {
         modules: Hashtbl.create(64),
         types: Hashtbl.create(64),
+        exceptions: Hashtbl.create(64),
         values: Hashtbl.create(64),
       },
     ]);
@@ -647,6 +649,7 @@ let provided_multiple_times = (errs, super) => {
         {
           modules: Hashtbl.create(64),
           types: Hashtbl.create(64),
+          exceptions: Hashtbl.create(64),
           values: Hashtbl.create(64),
         },
         ...ctx^,
@@ -660,7 +663,7 @@ let provided_multiple_times = (errs, super) => {
   };
 
   let enter_toplevel_stmt = ({ptop_desc: desc} as top) => {
-    let {values, modules, types} = List.hd(ctx^);
+    let {values, modules, types, exceptions} = List.hd(ctx^);
     switch (desc) {
     | PTopModule(Provided | Abstract, {pmod_name, pmod_loc}) =>
       if (Hashtbl.mem(modules, pmod_name.txt)) {
@@ -744,6 +747,13 @@ let provided_multiple_times = (errs, super) => {
               errs := [ProvidedMultipleTimes(name, loc), ...errs^];
             } else {
               Hashtbl.add(types, name, ());
+            };
+          | PProvideException({name, alias, loc}) =>
+            let (_, name) = apply_alias(name, alias);
+            if (Hashtbl.mem(exceptions, name)) {
+              errs := [ProvidedMultipleTimes(name, loc), ...errs^];
+            } else {
+              Hashtbl.add(exceptions, name, ());
             };
           | PProvideModule({name, alias, loc}) =>
             let (_, name) = apply_alias(name, alias);

--- a/compiler/src/typed/datarepr.re
+++ b/compiler/src/typed/datarepr.re
@@ -156,7 +156,7 @@ let extension_descr = (path_ext, ext) => {
     cstr_existentials: existentials,
     cstr_args,
     cstr_arity: List.length(cstr_args),
-    cstr_tag: CstrExtension(ext.ext_name.stamp, path_ext, cstr_ext_type),
+    cstr_tag: CstrExtension(ext.ext_name.stamp, path_ext, cstr_ext_type, ext),
     cstr_consts: (-1),
     cstr_nonconsts: (-1),
     cstr_loc: ext.ext_loc,

--- a/compiler/src/typed/env.rei
+++ b/compiler/src/typed/env.rei
@@ -39,6 +39,7 @@ type error =
   | Value_not_found_in_module(Location.t, string, string)
   | Module_not_found_in_module(Location.t, string, string, option(string))
   | Type_not_found_in_module(Location.t, string, string)
+  | Exception_not_found_in_module(Location.t, string, string)
   | Illegal_value_name(Location.t, string)
   | Cyclic_dependencies(string, dependency_chain);
 

--- a/compiler/src/typed/printtyp.re
+++ b/compiler/src/typed/printtyp.re
@@ -1026,13 +1026,17 @@ let tree_of_extension_constructor = (id, ext, es) => {
 let extension_constructor = (id, ppf, ext) =>
   Oprint.out_sig_item^(
     ppf,
-    tree_of_extension_constructor(id, ext, TExtFirst),
+    tree_of_extension_constructor(id, ext, TExtException),
   );
 
 let extension_only_constructor = (id, ppf, ext) => {
   let name = Ident.name(id);
   let args = tree_of_constructor_arguments(ext.ext_args);
   Format.fprintf(ppf, "@[<hv>%a@]", Oprint.out_constr^, (name, args, None));
+};
+
+let string_of_extension_constructor = (~ident, ext) => {
+  asprintf("%a", extension_constructor(ident), ext);
 };
 
 /* Print a value declaration */

--- a/compiler/src/typed/printtyp.rei
+++ b/compiler/src/typed/printtyp.rei
@@ -57,6 +57,8 @@ let tree_of_type_declaration:
 let type_declaration: (Ident.t, formatter, type_declaration) => unit;
 let string_of_type_declaration: (~ident: Ident.t, type_declaration) => string;
 let extension_constructor: (Ident.t, formatter, extension_constructor) => unit;
+let string_of_extension_constructor:
+  (~ident: Ident.t, extension_constructor) => string;
 let tree_of_module:
   (Ident.t, ~ellipsis: bool=?, module_type, rec_status) => out_sig_item;
 let modtype: (formatter, module_type) => unit;

--- a/compiler/src/typed/typedecl.re
+++ b/compiler/src/typed/typedecl.re
@@ -959,7 +959,7 @@ let transl_extension_constructor =
       };
       let path =
         switch (cdescr.cstr_tag) {
-        | CstrExtension(_, path, _) => path
+        | CstrExtension(_, path, _, _) => path
         | _ => assert(false)
         };
 

--- a/compiler/src/typed/typemod.re
+++ b/compiler/src/typed/typemod.re
@@ -665,6 +665,15 @@ let rec type_module = (~toplevel=false, anchor, env, statements) => {
             | None => Ident.create(name.txt)
             };
           ([TSigType(id, type_, TRecNot), ...sigs], stmts);
+        | PProvideException({name: {txt: IdentName(name)}, alias, loc}) =>
+          let ext = Typetexp.find_exception(env, loc, IdentName(name));
+          let id =
+            switch (alias) {
+            | Some({txt: IdentName(alias)}) => Ident.create(alias.txt)
+            | Some(_) => failwith("Impossible: invalid alias")
+            | None => Ident.create(name.txt)
+            };
+          ([TSigTypeExt(id, ext, TExtException), ...sigs], stmts);
         | PProvideModule({name: {txt: IdentName(name)}, alias, loc}) =>
           let (mod_path, mod_decl) =
             Typetexp.find_module(env, loc, IdentName(name));

--- a/compiler/src/typed/types.re
+++ b/compiler/src/typed/types.re
@@ -146,10 +146,26 @@ type extension_constructor_type =
   | CstrExtensionBlock;
 
 [@deriving (sexp, yojson)]
+type extension_constructor = {
+  ext_type_path: Path.t,
+  ext_type_params: list(type_expr),
+  ext_args: constructor_arguments,
+  ext_repr: val_repr,
+  ext_name: Ident.t,
+  [@sexp_drop_if sexp_locs_disabled]
+  ext_loc: Location.t,
+};
+
+[@deriving (sexp, yojson)]
 type constructor_tag =
   | CstrConstant(int)
   | CstrBlock(int)
-  | CstrExtension(int, Path.t, extension_constructor_type)
+  | CstrExtension(
+      int,
+      Path.t,
+      extension_constructor_type,
+      extension_constructor,
+    )
   | CstrUnboxed;
 
 [@deriving (sexp, yojson)]
@@ -199,17 +215,6 @@ type value_description = {
   val_global: bool,
   [@sexp_drop_if sexp_locs_disabled] [@default Location.dummy_loc]
   val_loc: Location.t,
-};
-
-[@deriving (sexp, yojson)]
-type extension_constructor = {
-  ext_type_path: Path.t,
-  ext_type_params: list(type_expr),
-  ext_args: constructor_arguments,
-  ext_repr: val_repr,
-  ext_name: Ident.t,
-  [@sexp_drop_if sexp_locs_disabled]
-  ext_loc: Location.t,
 };
 
 [@deriving (sexp, yojson)]
@@ -265,6 +270,11 @@ and use_item =
       declaration: type_declaration,
       loc: Location.t,
     })
+  | TUseException({
+      name: string,
+      ext: extension_constructor,
+      loc: Location.t,
+    })
   | TUseModule({
       name: string,
       declaration: module_declaration,
@@ -287,8 +297,8 @@ let equal_tag = (t1, t2) =>
   switch (t1, t2) {
   | (CstrBlock(i1), CstrBlock(i2))
   | (CstrConstant(i1), CstrConstant(i2)) => i1 == i2
-  | (CstrExtension(i1, p1, b1), CstrExtension(i2, p2, b2)) =>
-    i1 == i2 && Path.same(p1, p2) && b1 == b2
+  | (CstrExtension(i1, p1, b1, e1), CstrExtension(i2, p2, b2, e2)) =>
+    i1 == i2 && Path.same(p1, p2) && b1 == b2 && e1 == e2
   | (CstrUnboxed, CstrUnboxed) => true
   | _ => false
   };

--- a/compiler/src/typed/typetexp.rei
+++ b/compiler/src/typed/typetexp.rei
@@ -59,6 +59,7 @@ type error =
   | Unbound_value(Identifier.t)
   | Unbound_value_in_module(Identifier.t, string)
   | Unbound_constructor(Identifier.t)
+  | Unbound_exception(Identifier.t)
   | Unbound_label(Identifier.t)
   | Unbound_module(Identifier.t)
   | Unbound_class(Identifier.t)
@@ -97,6 +98,7 @@ let find_type:
   (Env.t, Location.t, Identifier.t) => (Path.t, type_declaration);
 let find_constructor:
   (Env.t, Location.t, Identifier.t) => constructor_description;
+let find_exception: (Env.t, Location.t, Identifier.t) => extension_constructor;
 let find_all_constructors:
   (Env.t, Location.t, Identifier.t) =>
   list((constructor_description, unit => unit));

--- a/compiler/test/grainfmt/includes.expected.gr
+++ b/compiler/test/grainfmt/includes.expected.gr
@@ -15,12 +15,13 @@ from Opt use {
   type Opt,
   type Opt as OptAlias,
 }
-from Opt use { /* comment1 */ /* comment2 */ /* comment3 */ /* comment4 */ /* comment5 */ /* comment6 */ /* comment7 */ /* comment8 */
+from Opt use { /* comment1 */ /* comment2 */ /* comment3 */ /* comment4 */ /* comment5 */ /* comment6 */ /* comment7 */ /* comment8 */ /* comment9 */
   module MutableOpt,
   module ImmutableOpt as Imm,
   type Opt,
   type Opt as OptAlias,
   exception Exc as E,
+  exception Exc2,
 }
 
 include "runtime/unsafe/wasmi32"

--- a/compiler/test/grainfmt/includes.expected.gr
+++ b/compiler/test/grainfmt/includes.expected.gr
@@ -15,11 +15,12 @@ from Opt use {
   type Opt,
   type Opt as OptAlias,
 }
-from Opt use { /* comment1 */ /* comment2 */ /* comment3 */ /* comment4 */ /* comment5 */ /* comment6 */ /* comment7 */
+from Opt use { /* comment1 */ /* comment2 */ /* comment3 */ /* comment4 */ /* comment5 */ /* comment6 */ /* comment7 */ /* comment8 */
   module MutableOpt,
   module ImmutableOpt as Imm,
   type Opt,
   type Opt as OptAlias,
+  exception Exc as E,
 }
 
 include "runtime/unsafe/wasmi32"
@@ -41,3 +42,5 @@ from WasmI32 use {
 }
 
 provide foreign wasm promise_results_count: () => WasmI64 as promiseResultsCount from "env"
+
+provide { exception MyExc as E2 }

--- a/compiler/test/grainfmt/includes.input.gr
+++ b/compiler/test/grainfmt/includes.input.gr
@@ -11,7 +11,7 @@ include /* special include */ "array"
 include "array" as  /* special include */ Foo
 from List use { length, map, forEach as each }
 from Opt use { module MutableOpt, module ImmutableOpt as Imm, type Opt, type Opt as OptAlias }
-from Opt use { module MutableOpt, /* comment1 */ module ImmutableOpt /* comment2 */ as /* comment3 */ Imm /* comment4 */, /* comment5 */ type /* comment6 */ Opt, type Opt as /* comment7 */ OptAlias, exception Exc as /* comment8 */ E }
+from Opt use { module MutableOpt, /* comment1 */ module ImmutableOpt /* comment2 */ as /* comment3 */ Imm /* comment4 */, /* comment5 */ type /* comment6 */ Opt, type Opt as /* comment7 */ OptAlias, exception Exc as /* comment8 */ E, exception Exc2 /* comment9 */ }
 
 include "runtime/unsafe/wasmi32"
 from WasmI32 use { 

--- a/compiler/test/grainfmt/includes.input.gr
+++ b/compiler/test/grainfmt/includes.input.gr
@@ -11,7 +11,7 @@ include /* special include */ "array"
 include "array" as  /* special include */ Foo
 from List use { length, map, forEach as each }
 from Opt use { module MutableOpt, module ImmutableOpt as Imm, type Opt, type Opt as OptAlias }
-from Opt use { module MutableOpt, /* comment1 */ module ImmutableOpt /* comment2 */ as /* comment3 */ Imm /* comment4 */, /* comment5 */ type /* comment6 */ Opt, type Opt as /* comment7 */ OptAlias }
+from Opt use { module MutableOpt, /* comment1 */ module ImmutableOpt /* comment2 */ as /* comment3 */ Imm /* comment4 */, /* comment5 */ type /* comment6 */ Opt, type Opt as /* comment7 */ OptAlias, exception Exc as /* comment8 */ E }
 
 include "runtime/unsafe/wasmi32"
 from WasmI32 use { 
@@ -34,3 +34,5 @@ from WasmI32 use {
 }
 
 provide foreign wasm promise_results_count: () => WasmI64 as promiseResultsCount from "env"
+
+provide {exception MyExc as E2}

--- a/compiler/test/suites/provides.re
+++ b/compiler/test/suites/provides.re
@@ -2,6 +2,9 @@ open Grain_tests.TestFramework;
 open Grain_tests.Runner;
 
 describe("provides", ({test, testSkip}) => {
+  let test_or_skip =
+    Sys.backend_type == Other("js_of_ocaml") ? testSkip : test;
+
   let assertSnapshot = makeSnapshotRunner(test);
   let assertStartSectionSnapshot =
     makeSnapshotRunner(
@@ -9,7 +12,7 @@ describe("provides", ({test, testSkip}) => {
       test,
     );
   let assertCompileError = makeCompileErrorRunner(test);
-  let assertRunError = makeErrorRunner(test);
+  let assertRunError = makeErrorRunner(test_or_skip);
   let assertHasWasmExport = (name, prog, expectedExports) => {
     test(
       name,

--- a/compiler/test/suites/provides.re
+++ b/compiler/test/suites/provides.re
@@ -9,6 +9,7 @@ describe("provides", ({test, testSkip}) => {
       test,
     );
   let assertCompileError = makeCompileErrorRunner(test);
+  let assertRunError = makeErrorRunner(test);
   let assertHasWasmExport = (name, prog, expectedExports) => {
     test(
       name,
@@ -157,6 +158,21 @@ describe("provides", ({test, testSkip}) => {
     "multiple_provides_9",
     "let foo = 1; let bar = 2; provide {foo, foo as bar, bar as foo}",
     "provided multiple times",
+  );
+  assertRunError(
+    "provide_exceptions1",
+    "include \"provideException\"; from ProvideException use *; let f = () => if (true) { throw MyException }; f()",
+    "OriginalException",
+  );
+  assertRunError(
+    "provide_exceptions2",
+    "include \"reprovideException\"; from ReprovideException use *; let f = () => if (true) { throw MyException }; f()",
+    "OriginalException",
+  );
+  assertRunError(
+    "provide_exceptions3",
+    "include \"reprovideException\"; from ReprovideException use { exception MyException as E }; let f = () => if (true) { throw E }; f()",
+    "OriginalException",
   );
 
   assertSnapshot("let_rec_provide", "provide let rec foo = () => 5");

--- a/compiler/test/test-libs/provideException.gr
+++ b/compiler/test/test-libs/provideException.gr
@@ -2,4 +2,6 @@ module ProvideException
 
 exception OriginalException
 
-provide { exception OriginalException as MyException }
+let excVal1 = OriginalException
+
+provide { exception OriginalException as MyException, excVal1 }

--- a/compiler/test/test-libs/provideException.gr
+++ b/compiler/test/test-libs/provideException.gr
@@ -1,0 +1,5 @@
+module ProvideException
+
+exception OriginalException
+
+provide { exception OriginalException as MyException }

--- a/compiler/test/test-libs/reprovideException.gr
+++ b/compiler/test/test-libs/reprovideException.gr
@@ -1,6 +1,8 @@
 module ReprovideException
 
 include "./provideException"
-from ProvideException use { exception MyException }
+from ProvideException use { exception MyException, excVal1 }
 
-provide { exception MyException }
+let excVal2 = ProvideException.MyException
+
+provide { exception MyException, excVal1, excVal2 }

--- a/compiler/test/test-libs/reprovideException.gr
+++ b/compiler/test/test-libs/reprovideException.gr
@@ -1,0 +1,6 @@
+module ReprovideException
+
+include "./provideException"
+from ProvideException use { exception MyException }
+
+provide { exception MyException }


### PR DESCRIPTION
Closes #1053

Syntax:
```
// provider.gr
provide exception MyException
// OR
exception MyException
provide { exception MyException }

// includer.gr
include "./provider"
from Provider use { exception MyException }
// can re-provide
provide { exception MyException }
```