### PR TITLE
feat(compiler)!: Change `->` to `=>` in type signatures

### DIFF
--- a/compiler/src/formatting/format.re
+++ b/compiler/src/formatting/format.re
@@ -1792,7 +1792,7 @@ and print_type =
         },
       ),
       Doc.space,
-      Doc.text("->"),
+      Doc.text("=>"),
       Doc.space,
       print_type(~original_source, ~comments, parsed_type),
     ])

--- a/compiler/src/parsing/lexer.re
+++ b/compiler/src/parsing/lexer.re
@@ -309,7 +309,6 @@ let rec token = lexbuf => {
   | "/" => positioned(SLASH)
   | "|" => positioned(PIPE)
   | "-" => positioned(DASH)
-  | "->" => positioned(ARROW)
   | "=>" => positioned(THICKARROW)
   | "type" => positioned(TYPE)
   | "enum" => positioned(ENUM)

--- a/compiler/src/parsing/lexer.re
+++ b/compiler/src/parsing/lexer.re
@@ -309,6 +309,7 @@ let rec token = lexbuf => {
   | "/" => positioned(SLASH)
   | "|" => positioned(PIPE)
   | "-" => positioned(DASH)
+  | "->" => positioned(ARROW)
   | "=>" => positioned(THICKARROW)
   | "type" => positioned(TYPE)
   | "enum" => positioned(ENUM)

--- a/compiler/src/parsing/parser.messages
+++ b/compiler/src/parsing/parser.messages
@@ -348,7 +348,7 @@ program: MODULE UIDENT EOL FOREIGN WASM LIDENT COLON UIDENT AS LIDENT YIELD
 ## The known suffix of the stack is as follows:
 ## FOREIGN WASM id_str COLON typ option(as_prefix(id_str))
 ##
-program: MODULE UIDENT EOL FOREIGN WASM LIDENT COLON EOL LIDENT ARROW
+program: MODULE UIDENT EOL FOREIGN WASM LIDENT COLON EOL LIDENT THICKARROW
 ##
 ## Ends in an error in state: 757.
 ##
@@ -366,7 +366,7 @@ program: MODULE UIDENT EOL FOREIGN WASM LIDENT COLON EOL UIDENT AS LIDENT YIELD
 ## The known suffix of the stack is as follows:
 ## FOREIGN WASM id_str COLON eols typ option(as_prefix(id_str))
 ##
-program: MODULE UIDENT EOL FOREIGN WASM LIDENT COLON LIDENT ARROW
+program: MODULE UIDENT EOL FOREIGN WASM LIDENT COLON LIDENT THICKARROW
 ##
 ## Ends in an error in state: 749.
 ##
@@ -2884,7 +2884,7 @@ program: MODULE UIDENT EOL UIDENT LPAREN COMMA WHILE
 ## In state 43, spurious reduction of production comma -> COMMA
 ## In state 275, spurious reduction of production option(comma) -> comma
 ##
-program: MODULE UIDENT EOL UIDENT LPAREN UIDENT ARROW
+program: MODULE UIDENT EOL UIDENT LPAREN UIDENT THICKARROW
 ##
 ## Ends in an error in state: 473.
 ##
@@ -3324,7 +3324,7 @@ program: MODULE UIDENT EOL LBRACE BREAK RBRACE LBRACK WASMI64 THICKARROW
 ## In state 243, spurious reduction of production non_stmt_expr -> annotated_expr
 ## In state 62, spurious reduction of production expr -> non_stmt_expr
 ##
-program: MODULE UIDENT EOL PREFIX_150 LBRACK RBRACK LBRACK BIGINT ARROW
+program: MODULE UIDENT EOL PREFIX_150 LBRACK RBRACK LBRACK BIGINT THICKARROW
 ##
 ## Ends in an error in state: 560.
 ##
@@ -3420,7 +3420,7 @@ program: MODULE UIDENT EOL LBRACE LIDENT COMMA EOL LIDENT COLON BREAK WHILE
 ## The known suffix of the stack is as follows:
 ## punned_record_field comma lseparated_nonempty_list_inner(comma,record_field)
 ##
-program: MODULE UIDENT EOL LBRACE ELLIPSIS BIGINT COMMA ELLIPSIS BIGINT ARROW
+program: MODULE UIDENT EOL LBRACE ELLIPSIS BIGINT COMMA ELLIPSIS BIGINT THICKARROW
 ##
 ## Ends in an error in state: 227.
 ##
@@ -3447,7 +3447,7 @@ program: MODULE UIDENT EOL LBRACE ELLIPSIS BIGINT COMMA ELLIPSIS BIGINT ARROW
 
 Expected a comma followed by more record fields or an immediate `}` to complete the record expression.
 
-program: MODULE UIDENT EOL UIDENT LBRACE ELLIPSIS UIDENT ARROW
+program: MODULE UIDENT EOL UIDENT LBRACE ELLIPSIS UIDENT THICKARROW
 ##
 ## Ends in an error in state: 488.
 ##
@@ -3535,7 +3535,7 @@ program: MODULE UIDENT EOL LBRACE LIDENT COMMA LIDENT COMMA EOL WHILE
 
 Expected more record fields or an immediate `}` to complete the record expression.
 
-program: MODULE UIDENT EOL LBRACE ELLIPSIS BIGINT ARROW
+program: MODULE UIDENT EOL LBRACE ELLIPSIS BIGINT THICKARROW
 ##
 ## Ends in an error in state: 222.
 ##
@@ -4402,7 +4402,7 @@ program: MODULE UIDENT EOL LET UIDENT DOT EOL WHILE
 ##
 ## Ends in an error in state: 92.
 ##
-## lseparated_nonempty_list_inner(dot,type_id_str) -> lseparated_nonempty_list_inner(dot,type_id_str) DOT eols . type_id_str [ WHEN THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LPAREN LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 FROM EQUAL EOL EOF ELSE DOT DASH COMMA COLON AS ARROW ]
+## lseparated_nonempty_list_inner(dot,type_id_str) -> lseparated_nonempty_list_inner(dot,type_id_str) DOT eols . type_id_str [ WHEN THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LPAREN LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 FROM EQUAL EOL EOF ELSE DOT DASH COMMA COLON AS THICKARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## lseparated_nonempty_list_inner(dot,type_id_str) DOT eols
@@ -4418,8 +4418,8 @@ program: MODULE UIDENT EOL LET UIDENT DOT WHILE
 ##
 ## Ends in an error in state: 90.
 ##
-## lseparated_nonempty_list_inner(dot,type_id_str) -> lseparated_nonempty_list_inner(dot,type_id_str) DOT . type_id_str [ WHEN THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LPAREN LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 FROM EQUAL EOL EOF ELSE DOT DASH COMMA COLON AS ARROW ]
-## lseparated_nonempty_list_inner(dot,type_id_str) -> lseparated_nonempty_list_inner(dot,type_id_str) DOT . eols type_id_str [ WHEN THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LPAREN LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 FROM EQUAL EOL EOF ELSE DOT DASH COMMA COLON AS ARROW ]
+## lseparated_nonempty_list_inner(dot,type_id_str) -> lseparated_nonempty_list_inner(dot,type_id_str) DOT . type_id_str [ WHEN THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LPAREN LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 FROM EQUAL EOL EOF ELSE DOT DASH COMMA COLON AS THICKARROW ]
+## lseparated_nonempty_list_inner(dot,type_id_str) -> lseparated_nonempty_list_inner(dot,type_id_str) DOT . eols type_id_str [ WHEN THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LPAREN LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 FROM EQUAL EOL EOF ELSE DOT DASH COMMA COLON AS THICKARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## lseparated_nonempty_list_inner(dot,type_id_str) DOT
@@ -4603,7 +4603,7 @@ program: MODULE UIDENT EOL LPAREN WASMI64 EOL WHILE
 ##
 ## Ends in an error in state: 113.
 ##
-## rparen -> eols . RPAREN [ WHILE WHEN WASMI64 WASMI32 WASMF64 WASMF32 VOID UIDENT TYPE TRUE THROW THICKARROW STRING STAR SLASH SEMI RPAREN RECORD RCARET RBRACK RBRACE PREFIX_150 PIPE NUMBER_INT NUMBER_FLOAT MATCH LPAREN LIDENT LET LCARET LBRACKRCARET LBRACK LBRACE INT64 INT32 INFIX_ASSIGNMENT_10 INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 INCLUDE IF GETS FUN FROM FOR FLOAT64 FLOAT32 FALSE FAIL PROVIDE EQUAL EOL EOF ENUM ELSE DOT DASH CONTINUE COMMA COLON CHAR BREAK BIGINT AT ASSERT AS ARROW ]
+## rparen -> eols . RPAREN [ WHILE WHEN WASMI64 WASMI32 WASMF64 WASMF32 VOID UIDENT TYPE TRUE THROW THICKARROW STRING STAR SLASH SEMI RPAREN RECORD RCARET RBRACK RBRACE PREFIX_150 PIPE NUMBER_INT NUMBER_FLOAT MATCH LPAREN LIDENT LET LCARET LBRACKRCARET LBRACK LBRACE INT64 INT32 INFIX_ASSIGNMENT_10 INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 INCLUDE IF GETS FUN FROM FOR FLOAT64 FLOAT32 FALSE FAIL PROVIDE EQUAL EOL EOF ENUM ELSE DOT DASH CONTINUE COMMA COLON CHAR BREAK BIGINT AT ASSERT AS THICKARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## eols
@@ -5082,7 +5082,7 @@ program: MODULE UIDENT EOL RECORD UIDENT LCARET LIDENT EOL WHILE
 ##
 ## Ends in an error in state: 86.
 ##
-## rcaret -> eols . RCARET [ WHEN THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET LBRACE INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 FROM EQUAL EOL EOF ELSE DASH COMMA COLON AS ARROW ]
+## rcaret -> eols . RCARET [ WHEN THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET LBRACE INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 FROM EQUAL EOL EOF ELSE DASH COMMA COLON AS THICKARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## eols
@@ -5875,7 +5875,7 @@ program: MODULE UIDENT EOL WASMI64 COLON WHILE
 
 Expected a type to complete the type annotation.
 
-program: MODULE UIDENT EOL WASMI64 COLON FUN LIDENT ARROW EOL WHILE
+program: MODULE UIDENT EOL WASMI64 COLON FUN LIDENT THICKARROW EOL WHILE
 ##
 ## Ends in an error in state: 78.
 ##
@@ -5890,9 +5890,9 @@ program: MODULE UIDENT EOL WASMI64 COLON FUN LIDENT ARROW EOL WHILE
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
 ## In state 5, spurious reduction of production eols -> nonempty_list(eol)
-## In state 77, spurious reduction of production arrow -> ARROW eols
+## In state 77, spurious reduction of production arrow -> THICKARROW eols
 ##
-program: MODULE UIDENT EOL WASMI64 COLON FUN LPAREN RPAREN ARROW EOL WHILE
+program: MODULE UIDENT EOL WASMI64 COLON FUN LPAREN RPAREN THICKARROW EOL WHILE
 ##
 ## Ends in an error in state: 122.
 ##
@@ -5907,7 +5907,22 @@ program: MODULE UIDENT EOL WASMI64 COLON FUN LPAREN RPAREN ARROW EOL WHILE
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
 ## In state 5, spurious reduction of production eols -> nonempty_list(eol)
-## In state 77, spurious reduction of production arrow -> ARROW eols
+## In state 77, spurious reduction of production arrow -> THICKARROW eols
+##
+program: MODULE UIDENT EOL UIDENT COLON FUN UIDENT THICKARROW YIELD
+##
+## Ends in an error in state: 217.
+##
+## typ -> FUN data_typ thickarrow . typ [ WHEN THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 FROM EQUAL EOL EOF ELSE DASH COMMA COLON AS AND ]
+##
+## The known suffix of the stack is as follows:
+## FUN data_typ thickarrow
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 37, spurious reduction of production thickarrow -> THICKARROW
 ##
 
 Expected a type for the result of the function type.
@@ -6095,31 +6110,31 @@ program: MODULE UIDENT EOL WASMI64 COLON LPAREN UIDENT WHEN
 
 Expected `)` for a grouped type or a comma followed by more types for a tuple type.
 
-program: MODULE UIDENT EOL WASMI64 COLON UIDENT ARROW EOL WHILE
+program: MODULE UIDENT EOL UIDENT COLON FUN UIDENT YIELD
 ##
-## Ends in an error in state: 107.
+## Ends in an error in state: 216.
 ##
-## typ -> data_typ arrow . typ [ WHEN THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 FROM EQUAL EOL EOF ELSE DASH COMMA COLON AS ]
+## typ -> FUN data_typ . thickarrow typ [ WHEN THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 FROM EQUAL EOL EOF ELSE DASH COMMA COLON AS AND ]
 ##
 ## The known suffix of the stack is as follows:
-## data_typ arrow
+## FUN data_typ
 ##
 ## WARNING: This example involves spurious reductions.
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
-## In state 5, spurious reduction of production eols -> nonempty_list(eol)
-## In state 77, spurious reduction of production arrow -> ARROW eols
+## In state 106, spurious reduction of production qualified_uid -> lseparated_nonempty_list_inner(dot,type_id_str)
+## In state 167, spurious reduction of production data_typ -> qualified_uid
 ##
 
-Expected a type for the result of the function type.
+# This error can't appear as the FUN token wouldn't have been injected.
+Expected `=>` followed by the function type's result type.
 
 program: MODULE UIDENT EOL WASMI64 COLON UIDENT LCARET EOL WHILE
 ##
 ## Ends in an error in state: 82.
 ##
-## data_typ -> type_id lcaret . typs rcaret [ WHEN THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 FROM EQUAL EOL EOF ELSE DASH COMMA COLON AS ARROW ]
+## data_typ -> type_id lcaret . typs rcaret [ WHEN THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 FROM EQUAL EOL EOF ELSE DASH COMMA COLON AS THICKARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## type_id lcaret
@@ -6139,7 +6154,7 @@ program: MODULE UIDENT EOL WASMI64 COLON UIDENT LCARET UIDENT RPAREN
 ##
 ## Ends in an error in state: 83.
 ##
-## data_typ -> type_id lcaret typs . rcaret [ WHEN THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 FROM EQUAL EOL EOF ELSE DASH COMMA COLON AS ARROW ]
+## data_typ -> type_id lcaret typs . rcaret [ WHEN THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 FROM EQUAL EOL EOF ELSE DASH COMMA COLON AS THICKARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## type_id lcaret typs

--- a/compiler/src/parsing/parser.mly
+++ b/compiler/src/parsing/parser.mly
@@ -20,7 +20,7 @@ module Grain_parsing = struct end
 %token <string> STRING BYTES CHAR
 %token LBRACK LBRACKRCARET RBRACK LPAREN RPAREN LBRACE RBRACE LCARET RCARET
 %token COMMA SEMI AS
-%token THICKARROW ARROW
+%token THICKARROW
 %token EQUAL GETS
 %token UNDERSCORE
 %token COLON QUESTION DOT ELLIPSIS
@@ -98,7 +98,6 @@ module Grain_parsing = struct end
   lcaret
   comma
   eos
-  arrow
   thickarrow
   equal
   const
@@ -188,9 +187,6 @@ comma:
 
 %inline dot:
   | DOT opt_eols {}
-
-arrow:
-  | ARROW opt_eols {}
 
 thickarrow:
   | THICKARROW opt_eols {}
@@ -299,9 +295,9 @@ data_typ:
   | qualified_uid %prec _below_infix { Type.constr ~loc:(to_loc $loc) $1 [] }
 
 typ:
-  | data_typ arrow typ { Type.arrow ~loc:(to_loc $loc) [TypeArgument.mk ~loc:(to_loc $loc($1)) Unlabeled $1] $3 }
-  | FUN LIDENT arrow typ { Type.arrow ~loc:(to_loc $loc) [TypeArgument.mk ~loc:(to_loc $loc($2)) Unlabeled (Type.var $2)] $4 }
-  | FUN lparen arg_typs? rparen arrow typ { Type.arrow ~loc:(to_loc $loc) (Option.value ~default:[] $3) $6 }
+  | FUN data_typ thickarrow typ { Type.arrow ~loc:(to_loc $loc) [TypeArgument.mk ~loc:(to_loc $loc($2)) Unlabeled $2] $4 }
+  | FUN LIDENT thickarrow typ { Type.arrow ~loc:(to_loc $loc) [TypeArgument.mk ~loc:(to_loc $loc($2)) Unlabeled (Type.var $2)] $4 }
+  | FUN lparen arg_typs? rparen thickarrow typ { Type.arrow ~loc:(to_loc $loc) (Option.value ~default:[] $3) $6 }
   | lparen tuple_typs rparen { Type.tuple ~loc:(to_loc $loc) $2 }
   | lparen typ rparen { $2 }
   | LIDENT { Type.var ~loc:(to_loc $loc) $1 }

--- a/compiler/src/parsing/parser.mly
+++ b/compiler/src/parsing/parser.mly
@@ -20,7 +20,7 @@ module Grain_parsing = struct end
 %token <string> STRING BYTES CHAR
 %token LBRACK LBRACKRCARET RBRACK LPAREN RPAREN LBRACE RBRACE LCARET RCARET
 %token COMMA SEMI AS
-%token THICKARROW
+%token THICKARROW ARROW
 %token EQUAL GETS
 %token UNDERSCORE
 %token COLON QUESTION DOT ELLIPSIS
@@ -98,6 +98,7 @@ module Grain_parsing = struct end
   lcaret
   comma
   eos
+  arrow
   thickarrow
   equal
   const
@@ -188,8 +189,15 @@ comma:
 %inline dot:
   | DOT opt_eols {}
 
+arrow:
+  | ARROW opt_eols {}
+
 thickarrow:
   | THICKARROW opt_eols {}
+
+either_arrow:
+  | arrow {}
+  | thickarrow {}
 
 equal:
   | EQUAL opt_eols {}
@@ -295,9 +303,9 @@ data_typ:
   | qualified_uid %prec _below_infix { Type.constr ~loc:(to_loc $loc) $1 [] }
 
 typ:
-  | FUN data_typ thickarrow typ { Type.arrow ~loc:(to_loc $loc) [TypeArgument.mk ~loc:(to_loc $loc($2)) Unlabeled $2] $4 }
-  | FUN LIDENT thickarrow typ { Type.arrow ~loc:(to_loc $loc) [TypeArgument.mk ~loc:(to_loc $loc($2)) Unlabeled (Type.var $2)] $4 }
-  | FUN lparen arg_typs? rparen thickarrow typ { Type.arrow ~loc:(to_loc $loc) (Option.value ~default:[] $3) $6 }
+  | FUN data_typ either_arrow typ { Type.arrow ~loc:(to_loc $loc) [TypeArgument.mk ~loc:(to_loc $loc($2)) Unlabeled $2] $4 }
+  | FUN LIDENT either_arrow typ { Type.arrow ~loc:(to_loc $loc) [TypeArgument.mk ~loc:(to_loc $loc($2)) Unlabeled (Type.var $2)] $4 }
+  | FUN lparen arg_typs? rparen either_arrow typ { Type.arrow ~loc:(to_loc $loc) (Option.value ~default:[] $3) $6 }
   | lparen tuple_typs rparen { Type.tuple ~loc:(to_loc $loc) $2 }
   | lparen typ rparen { $2 }
   | LIDENT { Type.var ~loc:(to_loc $loc) $1 }

--- a/compiler/src/typed/oprint.re
+++ b/compiler/src/typed/oprint.re
@@ -367,7 +367,7 @@ and print_out_type_1 = ppf =>
       if (parens) {
         pp_print_char(ppf, ')');
       };
-      pp_print_string(ppf, " ->");
+      pp_print_string(ppf, " =>");
       pp_print_space(ppf, ());
       print_out_type_1(ppf, ty2);
       pp_close_box(ppf, ());

--- a/compiler/test/graindoc/descriptions.expected.md
+++ b/compiler/test/graindoc/descriptions.expected.md
@@ -49,7 +49,7 @@ Value Doc
 ### DescriptionGrainDoc.**docFunction**
 
 ```grain
-docFunction : (x: Number) -> Number
+docFunction : (x: Number) => Number
 ```
 
 Function Doc

--- a/compiler/test/graindoc/example.expected.md
+++ b/compiler/test/graindoc/example.expected.md
@@ -9,7 +9,7 @@ Functions and constants included in the ExampleDoc module.
 ### ExampleDoc.**singleLineExample**
 
 ```grain
-singleLineExample : (index: a, array: b) -> Number
+singleLineExample : (index: a, array: b) => Number
 ```
 
 SingleLineExample
@@ -23,7 +23,7 @@ singleLineExample(1, [1, 2, 3])
 ### ExampleDoc.**multiLineExample**
 
 ```grain
-multiLineExample : (index: a, array: b) -> Number
+multiLineExample : (index: a, array: b) => Number
 ```
 
 MultiLineExample
@@ -38,7 +38,7 @@ print(x) // 1
 ### ExampleDoc.**multipleSingleLineExamples**
 
 ```grain
-multipleSingleLineExamples : (index: a, array: b) -> Number
+multipleSingleLineExamples : (index: a, array: b) => Number
 ```
 
 SingleLineExample
@@ -60,7 +60,7 @@ print(singleLineExample(1, [1, 2, 3]))
 ### ExampleDoc.**multipleMultiLineExample**
 
 ```grain
-multipleMultiLineExample : (index: a, array: b) -> Number
+multipleMultiLineExample : (index: a, array: b) => Number
 ```
 
 MultiLineExample
@@ -85,7 +85,7 @@ x == 1
 ### ExampleDoc.**mixedLineExample**
 
 ```grain
-mixedLineExample : (index: a, array: b) -> Number
+mixedLineExample : (index: a, array: b) => Number
 ```
 
 MultiLineExample

--- a/compiler/test/graindoc/functionDoc.expected.md
+++ b/compiler/test/graindoc/functionDoc.expected.md
@@ -21,7 +21,7 @@ Functions and constants included in the FunctionGrainDoc module.
 </details>
 
 ```grain
-get : (index: Number, array: Array<a>) -> a
+get : (index: Number, array: Array<a>) => a
 ```
 
 An alias for normal syntactic array access, i.e. `array[n]`.

--- a/compiler/test/graindoc/noDoc.expected.md
+++ b/compiler/test/graindoc/noDoc.expected.md
@@ -41,6 +41,6 @@ docValue : Number
 ### NoGrainDoc.**docFunction**
 
 ```grain
-docFunction : (x: Number) -> Number
+docFunction : (x: Number) => Number
 ```
 

--- a/compiler/test/graindoc/since.expected.md
+++ b/compiler/test/graindoc/since.expected.md
@@ -14,7 +14,7 @@ No other changes yet.
 </details>
 
 ```grain
-sincePrev : (index: a, array: b) -> Number
+sincePrev : (index: a, array: b) => Number
 ```
 
 An alias for normal syntactic array access, i.e. `array[n]`.
@@ -27,7 +27,7 @@ No other changes yet.
 </details>
 
 ```grain
-sinceCurrent : (index: a, array: b) -> Number
+sinceCurrent : (index: a, array: b) => Number
 ```
 
 An alias for normal syntactic array access, i.e. `array[n]`.
@@ -40,7 +40,7 @@ No other changes yet.
 </details>
 
 ```grain
-sinceNext : (index: a, array: b) -> Number
+sinceNext : (index: a, array: b) => Number
 ```
 
 An alias for normal syntactic array access, i.e. `array[n]`.
@@ -53,7 +53,7 @@ No other changes yet.
 </details>
 
 ```grain
-sinceAllNumbers : (index: a, array: b) -> Number
+sinceAllNumbers : (index: a, array: b) => Number
 ```
 
 An alias for normal syntactic array access, i.e. `array[n]`.
@@ -66,7 +66,7 @@ No other changes yet.
 </details>
 
 ```grain
-sinceWithoutV : (index: a, array: b) -> Number
+sinceWithoutV : (index: a, array: b) => Number
 ```
 
 An alias for normal syntactic array access, i.e. `array[n]`.
@@ -79,7 +79,7 @@ No other changes yet.
 </details>
 
 ```grain
-sinceWithoutVNext : (index: a, array: b) -> Number
+sinceWithoutVNext : (index: a, array: b) => Number
 ```
 
 An alias for normal syntactic array access, i.e. `array[n]`.

--- a/compiler/test/grainfmt/function_params.expected.gr
+++ b/compiler/test/grainfmt/function_params.expected.gr
@@ -6,7 +6,7 @@ let unit_arg = () => 3
 
 let two_args = (x, y) => 4
 
-provide let fake_write: (int, int, int, string) -> string =
+provide let fake_write: (int, int, int, string) => string =
   (
     fd,
     iovs,

--- a/compiler/test/grainfmt/function_params.expected.gr
+++ b/compiler/test/grainfmt/function_params.expected.gr
@@ -39,3 +39,5 @@ let stringTailMatcher = (toMatch, len) =>
   ) => {
   true
 }
+
+let f: Number => (Number, Number) => Number = a => (b, c) => a + b + c

--- a/compiler/test/grainfmt/function_params.input.gr
+++ b/compiler/test/grainfmt/function_params.input.gr
@@ -32,3 +32,5 @@ let stringTailMatcher =  (toMatch, len) =>
   ) => {
     true
   }
+
+let f: Number -> (Number, Number) -> Number = a => (b, c) => a + b + c

--- a/compiler/test/grainfmt/function_params.input.gr
+++ b/compiler/test/grainfmt/function_params.input.gr
@@ -6,7 +6,7 @@ let unit_arg = () => 3
 
 let two_args = (x,y) => 4
 
-provide let fake_write: (int, int, int, string) -> string =
+provide let fake_write: (int, int, int, string) => string =
   (
     fd,
     iovs,

--- a/compiler/test/grainfmt/includes.expected.gr
+++ b/compiler/test/grainfmt/includes.expected.gr
@@ -24,7 +24,7 @@ provide foreign wasm storage_read: (
   WasmI64,
   WasmI64,
   WasmI64,
-) -> WasmI64 as storageRead from "env"
+) => WasmI64 as storageRead from "env"
 
 include "runtime/unsafe/wasmi32"
 from WasmI32 use {
@@ -35,4 +35,4 @@ from WasmI32 use {
   // no signed imports, as care should be taken to use signed or unsigned operators
 }
 
-provide foreign wasm promise_results_count: () -> WasmI64 as promiseResultsCount from "env"
+provide foreign wasm promise_results_count: () => WasmI64 as promiseResultsCount from "env"

--- a/compiler/test/grainfmt/includes.input.gr
+++ b/compiler/test/grainfmt/includes.input.gr
@@ -21,7 +21,7 @@ from WasmI32 use {
   shl as (<<)
 }
 
-provide foreign wasm storage_read: (WasmI64, WasmI64, WasmI64) -> WasmI64 as storageRead from "env"
+provide foreign wasm storage_read: (WasmI64, WasmI64, WasmI64) => WasmI64 as storageRead from "env"
 
 
 include "runtime/unsafe/wasmi32"
@@ -33,4 +33,4 @@ from WasmI32 use {
   // no signed imports, as care should be taken to use signed or unsigned operators
 }
 
-provide foreign wasm promise_results_count: () -> WasmI64 as promiseResultsCount from "env"
+provide foreign wasm promise_results_count: () => WasmI64 as promiseResultsCount from "env"

--- a/compiler/test/input/wasiPolyfill.gr
+++ b/compiler/test/input/wasiPolyfill.gr
@@ -5,9 +5,9 @@ foreign wasm fd_write: (
   WasmI32,
   WasmI32,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 
-provide let fd_write: (WasmI32, WasmI32, WasmI32, WasmI32) -> WasmI32 =
+provide let fd_write: (WasmI32, WasmI32, WasmI32, WasmI32) => WasmI32 =
   (
     fd,
     iovs,

--- a/compiler/test/input/wasiPolyfillNoop.gr
+++ b/compiler/test/input/wasiPolyfillNoop.gr
@@ -1,6 +1,6 @@
 module WasiPolyfillNoop
 
-provide let fd_write: (WasmI32, WasmI32, WasmI32, WasmI32) -> WasmI32 =
+provide let fd_write: (WasmI32, WasmI32, WasmI32, WasmI32) => WasmI32 =
   (
     fd,
     iovs,

--- a/compiler/test/suites/foreigns.re
+++ b/compiler/test/suites/foreigns.re
@@ -11,7 +11,7 @@ describe("foreigns", ({test}) => {
       {|
       module Test
       @externalName("env.foo")
-      foreign wasm foo: Number -> Number from "env"
+      foreign wasm foo: Number => Number from "env"
 
       @externalName("__foo%%!")
       provide let bar = () => foo(1)

--- a/compiler/test/suites/functions.re
+++ b/compiler/test/suites/functions.re
@@ -156,11 +156,11 @@ describe("functions", ({test, testSkip}) => {
   );
   assertSnapshot(
     "func_record_associativity1",
-    "record Foo { f: () -> Bool }; let foo = {f: () => false}; !foo.f()",
+    "record Foo { f: () => Bool }; let foo = {f: () => false}; !foo.f()",
   );
   assertSnapshot(
     "func_record_associativity2",
-    "record Foo { g: () -> Bool }; record Bar { f: Foo }; let foo = {f: {g: () => false}}; !foo.f.g()",
+    "record Foo { g: () => Bool }; record Bar { f: Foo }; let foo = {f: {g: () => false}}; !foo.f.g()",
   );
 
   assertSnapshot(
@@ -333,7 +333,7 @@ truc()|},
   assertRun(
     "labeled_args_typecheck1",
     {|
-      let apply = (f: (arg1: Number) -> Number) => f(arg1=5)
+      let apply = (f: (arg1: Number) => Number) => f(arg1=5)
       print(apply(notarg1 => notarg1))
     |},
     "5\n",
@@ -366,7 +366,7 @@ truc()|},
   assertCompileError(
     "labeled_args_err4",
     {|
-      let apply = (f: (?arg1: Number) -> Number) => f(arg1=5)
+      let apply = (f: (?arg1: Number) => Number) => f(arg1=5)
       print(apply(notarg1 => notarg1))
     |},
     "The expected function type contains the argument \\?arg1",
@@ -374,7 +374,7 @@ truc()|},
   assertCompileError(
     "labeled_args_err5",
     {|
-      let apply = (f: (?arg1: Number) -> Number) => f(arg1=5)
+      let apply = (f: (?arg1: Number) => Number) => f(arg1=5)
       print(apply(notarg1 => notarg1))
     |},
     "which has a default value, but the matching argument does not.",

--- a/compiler/test/suites/provides.re
+++ b/compiler/test/suites/provides.re
@@ -163,12 +163,12 @@ describe("provides", ({test, testSkip}) => {
 
   assertHasWasmExport(
     "issue_918_annotated_func_provide",
-    "module Test; provide let foo: () -> Number = () => 5",
+    "module Test; provide let foo: () => Number = () => 5",
     ("foo", Binaryen.Export.external_function),
   );
   assertHasWasmExport(
     "issue_918_annotated_func_provide2",
-    "module Test; provide let rec foo: () -> Number = () => 5",
+    "module Test; provide let rec foo: () => Number = () => 5",
     ("foo", Binaryen.Export.external_function),
   );
 });

--- a/compiler/test/suites/types.re
+++ b/compiler/test/suites/types.re
@@ -202,7 +202,7 @@ describe("aliased types", ({test, testSkip}) => {
   assertRun(
     "regression_annotated_type_func_1",
     {|
-      abstract type AddPrinter = (Number, Number) -> Void
+      abstract type AddPrinter = (Number, Number) => Void
       provide let add: AddPrinter = (x, y) => print(x + y)
       add(4, 4)
     |},
@@ -211,7 +211,7 @@ describe("aliased types", ({test, testSkip}) => {
   assertRun(
     "regression_annotated_type_func_2",
     {|
-      abstract type AddPrinter<a> = (a, a) -> Void
+      abstract type AddPrinter<a> = (a, a) => Void
       provide let add: AddPrinter<Number> = (x, y) => print(x + y)
       add(4, 4)
     |},
@@ -431,5 +431,69 @@ describe("recursive types", ({test, testSkip}) => {
       print({ x: 1 }: T)
     |},
     "{\n  x: 1\n}\n",
+  );
+});
+
+describe("function types", ({test, testSkip}) => {
+  let test_or_skip =
+    Sys.backend_type == Other("js_of_ocaml") ? testSkip : test;
+
+  // let assertCompileError = makeCompileErrorRunner(test);
+  let assertRun = makeRunner(test_or_skip);
+
+  assertRun(
+    "type_fn_1",
+    {|
+      type Foo = Number => String
+      let f: Foo = num => "a"
+      print(f(1))
+    |},
+    "a\n",
+  );
+  assertRun(
+    "type_fn_2",
+    {|
+      type Foo = (Number, Number) => Number
+      let f: Foo = (a, b) => a + b
+      print(f(1, 2))
+    |},
+    "3\n",
+  );
+  assertRun(
+    "type_fn_3",
+    {|
+      type Foo<a> = a => a
+      let f: Foo<Number> = a => a
+      print(f(1))
+    |},
+    "1\n",
+  );
+  assertRun(
+    "type_fn_4",
+    {|
+      include "map"
+      type Foo = Map.Map<List<Number>, Map.Map<Number, Number>> => Map.Map<Number, Number>
+      let f: Foo = a => Map.make()
+      print(f(Map.make()) == Map.make())
+    |},
+    "true\n",
+  );
+  assertRun(
+    "type_fn_5",
+    {|
+      include "map"
+      type Foo = Map.Map<Number, Number> => Map.Map<Number, Number> => Number
+      let f: Foo = a => b => 1
+      print(f(Map.make())(Map.make()))
+    |},
+    "1\n",
+  );
+  assertRun(
+    "type_fn_6",
+    {|
+      let f: List<Number> => List<Number> => Number = a => b => 1
+      print(f([])([]))
+    |},
+    "1\n",
   );
 });

--- a/compiler/test/suites/types.re
+++ b/compiler/test/suites/types.re
@@ -438,7 +438,7 @@ describe("function types", ({test, testSkip}) => {
   let test_or_skip =
     Sys.backend_type == Other("js_of_ocaml") ? testSkip : test;
 
-  // let assertCompileError = makeCompileErrorRunner(test);
+  let assertCompileError = makeCompileErrorRunner(test);
   let assertRun = makeRunner(test_or_skip);
 
   assertRun(
@@ -495,5 +495,36 @@ describe("function types", ({test, testSkip}) => {
       print(f([])([]))
     |},
     "1\n",
+  );
+  assertCompileError(
+    "type_fn_6",
+    {|
+      let badIdentity: x => x
+      print(badIdentity(1))
+    |},
+    "Syntax error after 'x' and before ' '.\nExpected a type annotation or `=`.",
+  );
+  assertCompileError(
+    "type_fn_7",
+    {|
+      let badFn: Number =>
+    |},
+    "Syntax error after ' ' and before ''.\nExpected a type for the result of the function type.",
+  );
+  assertCompileError(
+    "type_fn_8",
+    {|
+      let badFn: Number =>
+      print(badFn(1))
+    |},
+    "Syntax error after 'print' and before '\\('.\nExpected a type annotation or `=`.",
+  );
+  assertCompileError(
+    "type_fn_9",
+    {|
+      let badFn: (Number => )
+      print(badFn(1))
+    |},
+    "Syntax error after '=>' and before '\\)'.\nExpected a type for the result of the function type.",
   );
 });

--- a/compiler/test/test-libs/funcAliasProvide.gr
+++ b/compiler/test/test-libs/funcAliasProvide.gr
@@ -1,5 +1,5 @@
 module FuncAliasProvide
 
-provide type FnType = () -> String
+provide type FnType = () => String
 
 provide let function: FnType = () => "abc"

--- a/compiler/test/test-libs/providedType.gr
+++ b/compiler/test/test-libs/providedType.gr
@@ -2,7 +2,7 @@ module ProvidedType
 
 include "map"
 
-provide let apply = (f: Map.Map<String, String> -> Void) => {
+provide let apply = (f: Map.Map<String, String> => Void) => {
   let map = Map.make()
   Map.set("foo", "bar", map)
   f(map)

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -83,7 +83,7 @@ provide let length = array => {
  * @since v0.1.0
  */
 @unsafe
-provide let make: (Number, a) -> Array<a> = (length: Number, item: a) => {
+provide let make: (Number, a) => Array<a> = (length: Number, item: a) => {
   from WasmI32 use { (+), (*), (<) }
   let lengthArg = length
   checkLength(length)
@@ -117,10 +117,10 @@ provide let make: (Number, a) -> Array<a> = (length: Number, item: a) => {
  * @since v0.1.0
  */
 @unsafe
-provide let init: (Number, Number -> a) -> Array<a> =
+provide let init: (Number, Number => a) => Array<a> =
   (
     length: Number,
-    fn: Number -> a,
+    fn: Number => a,
   ) => {
   from WasmI32 use { (+), (*), (<) }
   checkLength(length)

--- a/stdlib/array.md
+++ b/stdlib/array.md
@@ -35,7 +35,7 @@ No other changes yet.
 </details>
 
 ```grain
-length : (array: Array<a>) -> Number
+length : (array: Array<a>) => Number
 ```
 
 Provides the length of the input array.
@@ -66,7 +66,7 @@ No other changes yet.
 </details>
 
 ```grain
-make : (Number, a) -> Array<a>
+make : (Number, a) => Array<a>
 ```
 
 Creates a new array of the specified length with each element being
@@ -106,7 +106,7 @@ No other changes yet.
 </details>
 
 ```grain
-init : (Number, (Number -> a)) -> Array<a>
+init : (Number, (Number => a)) => Array<a>
 ```
 
 Creates a new array of the specified length where each element is
@@ -118,7 +118,7 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`length`|`Number`|The length of the new array|
-|`fn`|`Number -> a`|The initializer function to call with each index, where the value returned will be used to initialize the element|
+|`fn`|`Number => a`|The initializer function to call with each index, where the value returned will be used to initialize the element|
 
 Returns:
 
@@ -154,7 +154,7 @@ Array.init(5, n => n + 3) // [> 3, 4, 5, 6, 7]
 </details>
 
 ```grain
-get : (index: Number, array: Array<a>) -> a
+get : (index: Number, array: Array<a>) => a
 ```
 
 An alias for normal syntactic array access, i.e. `array[n]`.
@@ -203,7 +203,7 @@ Array.get(1,[> 1, 2, 3, 4, 5]) == 2
 </details>
 
 ```grain
-set : (index: Number, value: a, array: Array<a>) -> Void
+set : (index: Number, value: a, array: Array<a>) => Void
 ```
 
 An alias for normal syntactic array set, i.e. `array[n] = value`.
@@ -240,7 +240,7 @@ No other changes yet.
 </details>
 
 ```grain
-append : (array1: Array<a>, array2: Array<a>) -> Array<a>
+append : (array1: Array<a>, array2: Array<a>) => Array<a>
 ```
 
 Creates a new array with the elements of the first array followed by
@@ -279,7 +279,7 @@ No other changes yet.
 </details>
 
 ```grain
-concat : (arrays: List<Array<a>>) -> Array<a>
+concat : (arrays: List<Array<a>>) => Array<a>
 ```
 
 Creates a single array containing the elements of all arrays in the
@@ -317,7 +317,7 @@ No other changes yet.
 </details>
 
 ```grain
-copy : (array: Array<a>) -> Array<a>
+copy : (array: Array<a>) => Array<a>
 ```
 
 Produces a shallow copy of the input array. The new array contains the
@@ -343,7 +343,7 @@ No other changes yet.
 </details>
 
 ```grain
-cycle : (fn: (a -> Void), n: Number, array: Array<a>) -> Void
+cycle : (fn: (a => Void), n: Number, array: Array<a>) => Void
 ```
 
 Iterates an array a given number of times, calling an iterator function on each element.
@@ -352,7 +352,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Void`|The iterator function to call with each element|
+|`fn`|`a => Void`|The iterator function to call with each element|
 |`n`|`Number`|The number of times to iterate the given array|
 |`array`|`Array<a>`|The array to iterate|
 
@@ -371,7 +371,7 @@ Parameters:
 </details>
 
 ```grain
-forEach : (fn: (a -> Void), array: Array<a>) -> Void
+forEach : (fn: (a => Void), array: Array<a>) => Void
 ```
 
 Iterates an array, calling an iterator function on each element.
@@ -380,7 +380,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Void`|The iterator function to call with each element|
+|`fn`|`a => Void`|The iterator function to call with each element|
 |`array`|`Array<a>`|The array to iterate|
 
 ### Array.**forEachi**
@@ -398,7 +398,7 @@ Parameters:
 </details>
 
 ```grain
-forEachi : (fn: ((a, Number) -> Void), array: Array<a>) -> Void
+forEachi : (fn: ((a, Number) => Void), array: Array<a>) => Void
 ```
 
 Iterates an array, calling an iterator function on each element.
@@ -408,7 +408,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`(a, Number) -> Void`|The iterator function to call with each element|
+|`fn`|`(a, Number) => Void`|The iterator function to call with each element|
 |`array`|`Array<a>`|The array to iterate|
 
 ### Array.**map**
@@ -426,7 +426,7 @@ Parameters:
 </details>
 
 ```grain
-map : (fn: (a -> b), array: Array<a>) -> Array<b>
+map : (fn: (a => b), array: Array<a>) => Array<b>
 ```
 
 Produces a new array initialized with the results of a mapper function
@@ -436,7 +436,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> b`|The mapper function to call on each element, where the value returned will be used to initialize the element in the new array|
+|`fn`|`a => b`|The mapper function to call on each element, where the value returned will be used to initialize the element in the new array|
 |`array`|`Array<a>`|The array to iterate|
 
 Returns:
@@ -453,7 +453,7 @@ No other changes yet.
 </details>
 
 ```grain
-mapi : (fn: ((a, Number) -> b), array: Array<a>) -> Array<b>
+mapi : (fn: ((a, Number) => b), array: Array<a>) => Array<b>
 ```
 
 Produces a new array initialized with the results of a mapper function
@@ -463,7 +463,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`(a, Number) -> b`|The mapper function to call on each element, where the value returned will be used to initialize the element in the new array|
+|`fn`|`(a, Number) => b`|The mapper function to call on each element, where the value returned will be used to initialize the element in the new array|
 |`array`|`Array<a>`|The array to iterate|
 
 Returns:
@@ -480,7 +480,7 @@ No other changes yet.
 </details>
 
 ```grain
-reduce : (fn: ((a, b) -> a), initial: a, array: Array<b>) -> a
+reduce : (fn: ((a, b) => a), initial: a, array: Array<b>) => a
 ```
 
 Combines all elements of an array using a reducer function,
@@ -495,7 +495,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`(a, b) -> a`|The reducer function to call on each element, where the value returned will be the next accumulator value|
+|`fn`|`(a, b) => a`|The reducer function to call on each element, where the value returned will be the next accumulator value|
 |`initial`|`a`|The initial value to use for the accumulator on the first iteration|
 |`array`|`Array<b>`|The array to iterate|
 
@@ -519,7 +519,7 @@ No other changes yet.
 </details>
 
 ```grain
-reduceRight : (fn: ((a, b) -> b), initial: b, array: Array<a>) -> b
+reduceRight : (fn: ((a, b) => b), initial: b, array: Array<a>) => b
 ```
 
 Combines all elements of an array using a reducer function,
@@ -534,7 +534,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`(a, b) -> b`|The reducer function to call on each element, where the value returned will be the next accumulator value|
+|`fn`|`(a, b) => b`|The reducer function to call on each element, where the value returned will be the next accumulator value|
 |`initial`|`b`|The initial value to use for the accumulator on the first iteration|
 |`array`|`Array<a>`|The array to iterate|
 
@@ -558,7 +558,7 @@ No other changes yet.
 </details>
 
 ```grain
-reducei : (fn: ((a, b, Number) -> a), initial: a, array: Array<b>) -> a
+reducei : (fn: ((a, b, Number) => a), initial: a, array: Array<b>) => a
 ```
 
 Combines all elements of an array using a reducer function,
@@ -574,7 +574,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`(a, b, Number) -> a`|The reducer function to call on each element, where the value returned will be the next accumulator value|
+|`fn`|`(a, b, Number) => a`|The reducer function to call on each element, where the value returned will be the next accumulator value|
 |`initial`|`a`|The initial value to use for the accumulator on the first iteration|
 |`array`|`Array<b>`|The array to iterate|
 
@@ -592,7 +592,7 @@ No other changes yet.
 </details>
 
 ```grain
-flatMap : (fn: (b -> Array<a>), array: Array<b>) -> Array<a>
+flatMap : (fn: (b => Array<a>), array: Array<b>) => Array<a>
 ```
 
 Produces a new array by calling a function on each element
@@ -604,7 +604,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`b -> Array<a>`|The function to be called on each element, where the value returned will be an array that gets appended to the new array|
+|`fn`|`b => Array<a>`|The function to be called on each element, where the value returned will be an array that gets appended to the new array|
 |`array`|`Array<b>`|The array to iterate|
 
 Returns:
@@ -627,7 +627,7 @@ No other changes yet.
 </details>
 
 ```grain
-every : (fn: (a -> Bool), array: Array<a>) -> Bool
+every : (fn: (a => Bool), array: Array<a>) => Bool
 ```
 
 Checks that the given condition is satisfied for all
@@ -637,7 +637,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`fn`|`a => Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
 |`array`|`Array<a>`|The array to check|
 
 Returns:
@@ -654,7 +654,7 @@ No other changes yet.
 </details>
 
 ```grain
-some : (fn: (a -> Bool), array: Array<a>) -> Bool
+some : (fn: (a => Bool), array: Array<a>) => Bool
 ```
 
 Checks that the given condition is satisfied **at least
@@ -664,7 +664,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`fn`|`a => Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
 |`array`|`Array<a>`|The array to iterate|
 
 Returns:
@@ -681,7 +681,7 @@ No other changes yet.
 </details>
 
 ```grain
-fill : (value: a, array: Array<a>) -> Void
+fill : (value: a, array: Array<a>) => Void
 ```
 
 Replaces all elements in an array with the new value provided.
@@ -701,7 +701,7 @@ No other changes yet.
 </details>
 
 ```grain
-fillRange : (value: a, start: Number, stop: Number, array: Array<a>) -> Void
+fillRange : (value: a, start: Number, stop: Number, array: Array<a>) => Void
 ```
 
 Replaces all elements in the provided index range in the array
@@ -731,7 +731,7 @@ No other changes yet.
 </details>
 
 ```grain
-reverse : (array: Array<a>) -> Array<a>
+reverse : (array: Array<a>) => Array<a>
 ```
 
 Creates a new array with all elements in reverse order.
@@ -756,7 +756,7 @@ No other changes yet.
 </details>
 
 ```grain
-toList : (array: Array<a>) -> List<a>
+toList : (array: Array<a>) => List<a>
 ```
 
 Converts the input array to a list.
@@ -781,7 +781,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromList : (list: List<a>) -> Array<a>
+fromList : (list: List<a>) => Array<a>
 ```
 
 Converts the input list to an array.
@@ -806,7 +806,7 @@ No other changes yet.
 </details>
 
 ```grain
-contains : (search: a, array: Array<a>) -> Bool
+contains : (search: a, array: Array<a>) => Bool
 ```
 
 Checks if the value is an element of the input array.
@@ -833,7 +833,7 @@ No other changes yet.
 </details>
 
 ```grain
-find : (fn: (a -> Bool), array: Array<a>) -> Option<a>
+find : (fn: (a => Bool), array: Array<a>) => Option<a>
 ```
 
 Finds the first element in an array that satifies the given condition.
@@ -842,7 +842,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`fn`|`a => Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
 |`array`|`Array<a>`|The array to search|
 
 Returns:
@@ -859,7 +859,7 @@ No other changes yet.
 </details>
 
 ```grain
-findIndex : (fn: (a -> Bool), array: Array<a>) -> Option<Number>
+findIndex : (fn: (a => Bool), array: Array<a>) => Option<Number>
 ```
 
 Finds the first index in an array where the element satifies the given condition.
@@ -868,7 +868,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`fn`|`a => Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
 |`array`|`Array<a>`|The array to search|
 
 Returns:
@@ -885,7 +885,7 @@ No other changes yet.
 </details>
 
 ```grain
-product : (array1: Array<a>, array2: Array<b>) -> Array<(a, b)>
+product : (array1: Array<a>, array2: Array<b>) => Array<(a, b)>
 ```
 
 Combines two arrays into a Cartesian product of tuples containing
@@ -918,7 +918,7 @@ No other changes yet.
 </details>
 
 ```grain
-count : (fn: (a -> Bool), array: Array<a>) -> Number
+count : (fn: (a => Bool), array: Array<a>) => Number
 ```
 
 Counts the number of elements in an array that satisfy the given condition.
@@ -927,7 +927,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`fn`|`a => Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
 |`array`|`Array<a>`|The array to iterate|
 
 Returns:
@@ -944,7 +944,7 @@ No other changes yet.
 </details>
 
 ```grain
-counti : (fn: ((a, Number) -> Bool), array: Array<a>) -> Number
+counti : (fn: ((a, Number) => Bool), array: Array<a>) => Number
 ```
 
 Counts the number of elements in an array that satisfy the
@@ -954,7 +954,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`(a, Number) -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`fn`|`(a, Number) => Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
 |`array`|`Array<a>`|The array to iterate|
 
 Returns:
@@ -971,7 +971,7 @@ No other changes yet.
 </details>
 
 ```grain
-filter : (fn: (a -> Bool), array: Array<a>) -> Array<a>
+filter : (fn: (a => Bool), array: Array<a>) => Array<a>
 ```
 
 Produces a new array by calling a function on each element of
@@ -982,7 +982,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`fn`|`a => Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
 |`array`|`Array<a>`|The array to iterate|
 
 Returns:
@@ -999,7 +999,7 @@ No other changes yet.
 </details>
 
 ```grain
-filteri : (fn: ((a, Number) -> Bool), array: Array<a>) -> Array<a>
+filteri : (fn: ((a, Number) => Bool), array: Array<a>) => Array<a>
 ```
 
 Produces a new array by calling a function on each element of
@@ -1010,7 +1010,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`(a, Number) -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`fn`|`(a, Number) => Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
 |`array`|`Array<a>`|The array to iterate|
 
 Returns:
@@ -1027,7 +1027,7 @@ No other changes yet.
 </details>
 
 ```grain
-unique : (array: Array<a>) -> Array<a>
+unique : (array: Array<a>) => Array<a>
 ```
 
 Produces a new array with any duplicates removed.
@@ -1060,7 +1060,7 @@ Returns:
 </details>
 
 ```grain
-zip : (array1: Array<a>, array2: Array<b>) -> Array<(a, b)>
+zip : (array1: Array<a>, array2: Array<b>) => Array<(a, b)>
 ```
 
 Produces a new array filled with tuples of elements from both given arrays.
@@ -1094,7 +1094,7 @@ No other changes yet.
 </details>
 
 ```grain
-zipWith : (fn: ((a, b) -> c), array1: Array<a>, array2: Array<b>) -> Array<c>
+zipWith : (fn: ((a, b) => c), array1: Array<a>, array2: Array<b>) => Array<c>
 ```
 
 Produces a new array filled with elements defined by applying a function on
@@ -1110,7 +1110,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`(a, b) -> c`|The function to apply to pairs of elements|
+|`fn`|`(a, b) => c`|The function to apply to pairs of elements|
 |`array1`|`Array<a>`|The array whose elements will each be passed to the function as the first argument|
 |`array2`|`Array<b>`|The array whose elements will each be passed to the function as the second argument|
 
@@ -1144,7 +1144,7 @@ No other changes yet.
 </details>
 
 ```grain
-unzip : (array: Array<(a, b)>) -> (Array<a>, Array<b>)
+unzip : (array: Array<(a, b)>) => (Array<a>, Array<b>)
 ```
 
 Produces two arrays by splitting apart an array of tuples.
@@ -1169,7 +1169,7 @@ No other changes yet.
 </details>
 
 ```grain
-join : (separator: String, items: Array<String>) -> String
+join : (separator: String, items: Array<String>) => String
 ```
 
 Concatenates an array of strings into a single string, separated by a separator string.
@@ -1202,7 +1202,7 @@ Returns:
 </details>
 
 ```grain
-slice : (start: Number, ?end: Number, array: Array<a>) -> Array<a>
+slice : (start: Number, ?end: Number, array: Array<a>) => Array<a>
 ```
 
 Slices an array given zero-based start and end indexes. The value
@@ -1233,7 +1233,7 @@ No other changes yet.
 </details>
 
 ```grain
-sort : (comp: ((a, a) -> Number), array: Array<a>) -> Void
+sort : (comp: ((a, a) => Number), array: Array<a>) => Void
 ```
 
 Sorts an array in-place.
@@ -1244,7 +1244,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`comp`|`(a, a) -> Number`|The comparator function used to indicate sort order|
+|`comp`|`(a, a) => Number`|The comparator function used to indicate sort order|
 |`array`|`Array<a>`|The array to be sorted|
 
 ### Array.**rotate**
@@ -1262,7 +1262,7 @@ Parameters:
 </details>
 
 ```grain
-rotate : (n: Number, arr: Array<a>) -> Void
+rotate : (n: Number, arr: Array<a>) => Void
 ```
 
 Rotates array elements in place by the specified amount to the left, such
@@ -1296,7 +1296,7 @@ No other changes yet.
 </details>
 
 ```grain
-chunk : (chunkSize: Number, arr: Array<a>) -> Array<Array<a>>
+chunk : (chunkSize: Number, arr: Array<a>) => Array<Array<a>>
 ```
 
 Splits the given array into chunks of the provided size.
@@ -1397,7 +1397,7 @@ An empty array.
 </details>
 
 ```grain
-isEmpty : (array: ImmutableArray<a>) -> Bool
+isEmpty : (array: ImmutableArray<a>) => Bool
 ```
 
 Determines if the array contains no elements.
@@ -1429,7 +1429,7 @@ Returns:
 </details>
 
 ```grain
-length : (array: ImmutableArray<a>) -> Number
+length : (array: ImmutableArray<a>) => Number
 ```
 
 Provides the length of the input array.
@@ -1467,7 +1467,7 @@ length(fromList([1, 2, 3, 4, 5])) == 5
 </details>
 
 ```grain
-get : (index: Number, array: ImmutableArray<a>) -> a
+get : (index: Number, array: ImmutableArray<a>) => a
 ```
 
 Retrieves the element from the array at the specified index.
@@ -1518,7 +1518,7 @@ get(-1, fromList([1, 2, 3, 4])) == 4
 
 ```grain
 set :
-  (index: Number, value: a, array: ImmutableArray<a>) -> ImmutableArray<a>
+  (index: Number, value: a, array: ImmutableArray<a>) => ImmutableArray<a>
 ```
 
 Creates a new array in which the element at the specified index is set to a
@@ -1566,7 +1566,7 @@ set(1, 9, fromList([1, 2, 3, 4, 5])) == fromList([1, 9, 3, 4, 5])
 
 ```grain
 append :
-  (array1: ImmutableArray<a>, array2: ImmutableArray<a>) -> ImmutableArray<a>
+  (array1: ImmutableArray<a>, array2: ImmutableArray<a>) => ImmutableArray<a>
 ```
 
 Creates a new array with the elements of the first array followed by
@@ -1606,7 +1606,7 @@ append(fromList([1, 2]), fromList([3, 4, 5])) == fromList([1, 2, 3, 4, 5])
 </details>
 
 ```grain
-concat : (arrays: List<ImmutableArray<a>>) -> ImmutableArray<a>
+concat : (arrays: List<ImmutableArray<a>>) => ImmutableArray<a>
 ```
 
 Creates a single array containing the elements of all arrays in the
@@ -1645,7 +1645,7 @@ concat([fromList([1, 2]), fromList([3, 4]), fromList([5, 6])]) == fromList([1, 2
 </details>
 
 ```grain
-init : (length: Number, fn: (Number -> a)) -> ImmutableArray<a>
+init : (length: Number, fn: (Number => a)) => ImmutableArray<a>
 ```
 
 Creates a new array of the specified length where each element is
@@ -1657,7 +1657,7 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`length`|`Number`|The length of the new array|
-|`fn`|`Number -> a`|The initializer function to call with each index, where the value returned will be used to initialize the element|
+|`fn`|`Number => a`|The initializer function to call with each index, where the value returned will be used to initialize the element|
 
 Returns:
 
@@ -1686,7 +1686,7 @@ init(5, i => i + 3) == fromList([3, 4, 5, 6, 7])
 </details>
 
 ```grain
-make : (length: Number, value: a) -> ImmutableArray<a>
+make : (length: Number, value: a) => ImmutableArray<a>
 ```
 
 Creates a new array of the specified length with each element being
@@ -1726,7 +1726,7 @@ make(5, "foo") == fromList(["foo", "foo", "foo", "foo", "foo"])
 </details>
 
 ```grain
-forEach : (fn: (a -> Void), array: ImmutableArray<a>) -> Void
+forEach : (fn: (a => Void), array: ImmutableArray<a>) => Void
 ```
 
 Iterates an array, calling an iterator function on each element.
@@ -1735,7 +1735,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Void`|The iterator function to call with each element|
+|`fn`|`a => Void`|The iterator function to call with each element|
 |`array`|`ImmutableArray<a>`|The array to iterate|
 
 #### Array.Immutable.**cycle**
@@ -1753,7 +1753,7 @@ Parameters:
 </details>
 
 ```grain
-cycle : (fn: (a -> Void), n: Number, array: ImmutableArray<a>) -> Void
+cycle : (fn: (a => Void), n: Number, array: ImmutableArray<a>) => Void
 ```
 
 Iterates an array a given number of times, calling an iterator function on each element.
@@ -1762,7 +1762,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Void`|The iterator function to call with each element|
+|`fn`|`a => Void`|The iterator function to call with each element|
 |`n`|`Number`|The number of times to iterate the given array|
 |`array`|`ImmutableArray<a>`|The array to iterate|
 
@@ -1781,7 +1781,7 @@ Parameters:
 </details>
 
 ```grain
-map : (fn: (a -> b), array: ImmutableArray<a>) -> ImmutableArray<b>
+map : (fn: (a => b), array: ImmutableArray<a>) => ImmutableArray<b>
 ```
 
 Produces a new array initialized with the results of a mapper function
@@ -1791,7 +1791,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> b`|The mapper function to call on each element, where the value returned will be used to initialize the element in the new array|
+|`fn`|`a => b`|The mapper function to call on each element, where the value returned will be used to initialize the element in the new array|
 |`array`|`ImmutableArray<a>`|The array to iterate|
 
 Returns:
@@ -1815,7 +1815,7 @@ Returns:
 </details>
 
 ```grain
-reduce : (fn: ((a, b) -> a), initial: a, array: ImmutableArray<b>) -> a
+reduce : (fn: ((a, b) => a), initial: a, array: ImmutableArray<b>) => a
 ```
 
 Combines all elements of an array using a reducer function,
@@ -1830,7 +1830,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`(a, b) -> a`|The reducer function to call on each element, where the value returned will be the next accumulator value|
+|`fn`|`(a, b) => a`|The reducer function to call on each element, where the value returned will be the next accumulator value|
 |`initial`|`a`|The initial value to use for the accumulator on the first iteration|
 |`array`|`ImmutableArray<b>`|The array to iterate|
 
@@ -1861,7 +1861,7 @@ reduce((acc, x) => acc + x, 0, fromList([1, 2, 3])) == 6
 </details>
 
 ```grain
-reduceRight : (fn: ((a, b) -> b), initial: b, array: ImmutableArray<a>) -> b
+reduceRight : (fn: ((a, b) => b), initial: b, array: ImmutableArray<a>) => b
 ```
 
 Combines all elements of an array using a reducer function,
@@ -1876,7 +1876,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`(a, b) -> b`|The reducer function to call on each element, where the value returned will be the next accumulator value|
+|`fn`|`(a, b) => b`|The reducer function to call on each element, where the value returned will be the next accumulator value|
 |`initial`|`b`|The initial value to use for the accumulator on the first iteration|
 |`array`|`ImmutableArray<a>`|The array to iterate|
 
@@ -1908,7 +1908,7 @@ reduceRight((x, acc) => acc ++ x, "", fromList(["baz", "bar", "foo"])) == "fooba
 
 ```grain
 flatMap :
-  (fn: (a -> ImmutableArray<b>), array: ImmutableArray<a>) ->
+  (fn: (a => ImmutableArray<b>), array: ImmutableArray<a>) =>
    ImmutableArray<b>
 ```
 
@@ -1921,7 +1921,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> ImmutableArray<b>`|The function to be called on each element, where the value returned will be an array that gets appended to the new array|
+|`fn`|`a => ImmutableArray<b>`|The function to be called on each element, where the value returned will be an array that gets appended to the new array|
 |`array`|`ImmutableArray<a>`|The array to iterate|
 
 Returns:
@@ -1951,7 +1951,7 @@ flatMap(n => fromList([n, n + 1]), fromList([1, 3, 5])) == fromList([1, 2, 3, 4,
 </details>
 
 ```grain
-fromList : (list: List<a>) -> ImmutableArray<a>
+fromList : (list: List<a>) => ImmutableArray<a>
 ```
 
 Converts the input list to an array.
@@ -1983,7 +1983,7 @@ Returns:
 </details>
 
 ```grain
-toList : (array: ImmutableArray<a>) -> List<a>
+toList : (array: ImmutableArray<a>) => List<a>
 ```
 
 Converts the input array to a list.
@@ -2015,7 +2015,7 @@ Returns:
 </details>
 
 ```grain
-filter : (fn: (a -> Bool), array: ImmutableArray<a>) -> ImmutableArray<a>
+filter : (fn: (a => Bool), array: ImmutableArray<a>) => ImmutableArray<a>
 ```
 
 Produces a new array by calling a function on each element of
@@ -2026,7 +2026,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`fn`|`a => Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
 |`array`|`ImmutableArray<a>`|The array to iterate|
 
 Returns:
@@ -2050,7 +2050,7 @@ Returns:
 </details>
 
 ```grain
-every : (fn: (a -> Bool), array: ImmutableArray<a>) -> Bool
+every : (fn: (a => Bool), array: ImmutableArray<a>) => Bool
 ```
 
 Checks that the given condition is satisfied for all
@@ -2060,7 +2060,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`fn`|`a => Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
 |`array`|`ImmutableArray<a>`|The array to check|
 
 Returns:
@@ -2084,7 +2084,7 @@ Returns:
 </details>
 
 ```grain
-some : (fn: (a -> Bool), array: ImmutableArray<a>) -> Bool
+some : (fn: (a => Bool), array: ImmutableArray<a>) => Bool
 ```
 
 Checks that the given condition is satisfied **at least
@@ -2094,7 +2094,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`fn`|`a => Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
 |`array`|`ImmutableArray<a>`|The array to iterate|
 
 Returns:
@@ -2118,7 +2118,7 @@ Returns:
 </details>
 
 ```grain
-reverse : (array: ImmutableArray<a>) -> ImmutableArray<a>
+reverse : (array: ImmutableArray<a>) => ImmutableArray<a>
 ```
 
 Creates a new array with all elements in reverse order.
@@ -2150,7 +2150,7 @@ Returns:
 </details>
 
 ```grain
-contains : (value: a, array: ImmutableArray<a>) -> Bool
+contains : (value: a, array: ImmutableArray<a>) => Bool
 ```
 
 Checks if the value is an element of the input array.
@@ -2184,7 +2184,7 @@ Returns:
 </details>
 
 ```grain
-find : (fn: (a -> Bool), array: ImmutableArray<a>) -> Option<a>
+find : (fn: (a => Bool), array: ImmutableArray<a>) => Option<a>
 ```
 
 Finds the first element in an array that satifies the given condition.
@@ -2193,7 +2193,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`fn`|`a => Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
 |`array`|`ImmutableArray<a>`|The array to search|
 
 Returns:
@@ -2217,7 +2217,7 @@ Returns:
 </details>
 
 ```grain
-findIndex : (fn: (a -> Bool), array: ImmutableArray<a>) -> Option<Number>
+findIndex : (fn: (a => Bool), array: ImmutableArray<a>) => Option<Number>
 ```
 
 Finds the first index in an array where the element satifies the given condition.
@@ -2226,7 +2226,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`fn`|`a => Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
 |`array`|`ImmutableArray<a>`|The array to search|
 
 Returns:
@@ -2251,7 +2251,7 @@ Returns:
 
 ```grain
 product :
-  (array1: ImmutableArray<a>, array2: ImmutableArray<b>) ->
+  (array1: ImmutableArray<a>, array2: ImmutableArray<b>) =>
    ImmutableArray<(a, b)>
 ```
 
@@ -2286,7 +2286,7 @@ Returns:
 </details>
 
 ```grain
-count : (fn: (a -> Bool), array: ImmutableArray<a>) -> Number
+count : (fn: (a => Bool), array: ImmutableArray<a>) => Number
 ```
 
 Counts the number of elements in an array that satisfy the given condition.
@@ -2295,7 +2295,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`fn`|`a => Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
 |`array`|`ImmutableArray<a>`|The array to iterate|
 
 Returns:
@@ -2319,7 +2319,7 @@ Returns:
 </details>
 
 ```grain
-unique : (array: ImmutableArray<a>) -> ImmutableArray<a>
+unique : (array: ImmutableArray<a>) => ImmutableArray<a>
 ```
 
 Produces a new array with any duplicates removed.
@@ -2353,7 +2353,7 @@ Returns:
 
 ```grain
 zip :
-  (array1: ImmutableArray<a>, array2: ImmutableArray<b>) ->
+  (array1: ImmutableArray<a>, array2: ImmutableArray<b>) =>
    ImmutableArray<(a, b)>
 ```
 
@@ -2393,7 +2393,7 @@ Returns:
 
 ```grain
 zipWith :
-  (fn: ((a, b) -> c), array1: ImmutableArray<a>, array2: ImmutableArray<b>) ->
+  (fn: ((a, b) => c), array1: ImmutableArray<a>, array2: ImmutableArray<b>) =>
    ImmutableArray<c>
 ```
 
@@ -2410,7 +2410,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`(a, b) -> c`|The function to apply to pairs of elements|
+|`fn`|`(a, b) => c`|The function to apply to pairs of elements|
 |`array1`|`ImmutableArray<a>`|The array whose elements will each be passed to the function as the first argument|
 |`array2`|`ImmutableArray<b>`|The array whose elements will each be passed to the function as the second argument|
 
@@ -2446,7 +2446,7 @@ zipWith((a, b) => a * b, fromList([1, 2, 3]), fromList([4, 5])) == fromList([4, 
 
 ```grain
 unzip :
-  (array: ImmutableArray<(a, b)>) -> (ImmutableArray<a>, ImmutableArray<b>)
+  (array: ImmutableArray<(a, b)>) => (ImmutableArray<a>, ImmutableArray<b>)
 ```
 
 Produces two arrays by splitting apart an array of tuples.
@@ -2478,7 +2478,7 @@ Returns:
 </details>
 
 ```grain
-join : (separator: String, array: ImmutableArray<String>) -> String
+join : (separator: String, array: ImmutableArray<String>) => String
 ```
 
 Concatenates an array of strings into a single string, separated by a separator string.
@@ -2513,7 +2513,7 @@ Returns:
 
 ```grain
 slice :
-  (start: Number, ?end: Number, array: ImmutableArray<a>) ->
+  (start: Number, ?end: Number, array: ImmutableArray<a>) =>
    ImmutableArray<a>
 ```
 
@@ -2563,7 +2563,7 @@ slice(1, -1, fromList(['a', 'b', 'c'])) == fromList(['b'])
 
 ```grain
 sort :
-  (comp: ((a, a) -> Number), array: ImmutableArray<a>) -> ImmutableArray<a>
+  (comp: ((a, a) => Number), array: ImmutableArray<a>) => ImmutableArray<a>
 ```
 
 Sorts the given array based on a given comparator function.
@@ -2574,7 +2574,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`comp`|`(a, a) -> Number`|The comparator function used to indicate sort order|
+|`comp`|`(a, a) => Number`|The comparator function used to indicate sort order|
 |`array`|`ImmutableArray<a>`|The array to be sorted|
 
 Returns:
@@ -2598,7 +2598,7 @@ Returns:
 </details>
 
 ```grain
-rotate : (n: Number, array: ImmutableArray<a>) -> ImmutableArray<a>
+rotate : (n: Number, array: ImmutableArray<a>) => ImmutableArray<a>
 ```
 
 Rotates array elements by the specified amount to the left, such that the

--- a/stdlib/bigint.md
+++ b/stdlib/bigint.md
@@ -25,7 +25,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromNumber : (x: Number) -> BigInt
+fromNumber : (x: Number) => BigInt
 ```
 
 Converts a Number to a BigInt.
@@ -50,7 +50,7 @@ No other changes yet.
 </details>
 
 ```grain
-toNumber : (x: BigInt) -> Number
+toNumber : (x: BigInt) => Number
 ```
 
 Converts a BigInt to a Number.
@@ -75,7 +75,7 @@ No other changes yet.
 </details>
 
 ```grain
-incr : (num: BigInt) -> BigInt
+incr : (num: BigInt) => BigInt
 ```
 
 Increments the value by one.
@@ -100,7 +100,7 @@ No other changes yet.
 </details>
 
 ```grain
-decr : (num: BigInt) -> BigInt
+decr : (num: BigInt) => BigInt
 ```
 
 Decrements the value by one.
@@ -125,7 +125,7 @@ No other changes yet.
 </details>
 
 ```grain
-neg : (num: BigInt) -> BigInt
+neg : (num: BigInt) => BigInt
 ```
 
 Negates the given operand.
@@ -150,7 +150,7 @@ No other changes yet.
 </details>
 
 ```grain
-abs : (num: BigInt) -> BigInt
+abs : (num: BigInt) => BigInt
 ```
 
 Returns the absolute value of the given operand.
@@ -182,7 +182,7 @@ Returns:
 </details>
 
 ```grain
-(+) : (num1: BigInt, num2: BigInt) -> BigInt
+(+) : (num1: BigInt, num2: BigInt) => BigInt
 ```
 
 Computes the sum of its operands.
@@ -215,7 +215,7 @@ Returns:
 </details>
 
 ```grain
-(-) : (num1: BigInt, num2: BigInt) -> BigInt
+(-) : (num1: BigInt, num2: BigInt) => BigInt
 ```
 
 Computes the difference of its operands.
@@ -248,7 +248,7 @@ Returns:
 </details>
 
 ```grain
-(*) : (num1: BigInt, num2: BigInt) -> BigInt
+(*) : (num1: BigInt, num2: BigInt) => BigInt
 ```
 
 Computes the product of its operands.
@@ -281,7 +281,7 @@ Returns:
 </details>
 
 ```grain
-(/) : (num1: BigInt, num2: BigInt) -> BigInt
+(/) : (num1: BigInt, num2: BigInt) => BigInt
 ```
 
 Computes the quotient of its operands using signed (truncated) division
@@ -308,7 +308,7 @@ No other changes yet.
 </details>
 
 ```grain
-rem : (num1: BigInt, num2: BigInt) -> BigInt
+rem : (num1: BigInt, num2: BigInt) => BigInt
 ```
 
 Computes the remainder of the division of its operands using signed (truncated) division
@@ -335,7 +335,7 @@ No other changes yet.
 </details>
 
 ```grain
-quotRem : (num1: BigInt, num2: BigInt) -> (BigInt, BigInt)
+quotRem : (num1: BigInt, num2: BigInt) => (BigInt, BigInt)
 ```
 
 Computes the quotient and remainder of its operands using signed (truncated) division.
@@ -361,7 +361,7 @@ No other changes yet.
 </details>
 
 ```grain
-gcd : (num1: BigInt, num2: BigInt) -> BigInt
+gcd : (num1: BigInt, num2: BigInt) => BigInt
 ```
 
 Computes the greatest common divisior of the two operands.
@@ -394,7 +394,7 @@ Returns:
 </details>
 
 ```grain
-(<<) : (num: BigInt, places: Int32) -> BigInt
+(<<) : (num: BigInt, places: Int32) => BigInt
 ```
 
 Shifts the bits of the value left by the given number of bits.
@@ -427,7 +427,7 @@ Returns:
 </details>
 
 ```grain
-(>>) : (num: BigInt, places: Int32) -> BigInt
+(>>) : (num: BigInt, places: Int32) => BigInt
 ```
 
 Shifts the bits of the value right by the given number of bits, preserving the sign bit.
@@ -453,7 +453,7 @@ No other changes yet.
 </details>
 
 ```grain
-eqz : (num: BigInt) -> Bool
+eqz : (num: BigInt) => Bool
 ```
 
 Checks if the given value is equal to zero.
@@ -485,7 +485,7 @@ Returns:
 </details>
 
 ```grain
-(==) : (num1: BigInt, num2: BigInt) -> Bool
+(==) : (num1: BigInt, num2: BigInt) => Bool
 ```
 
 Checks if the first value is equal to the second value.
@@ -518,7 +518,7 @@ Returns:
 </details>
 
 ```grain
-(!=) : (num1: BigInt, num2: BigInt) -> Bool
+(!=) : (num1: BigInt, num2: BigInt) => Bool
 ```
 
 Checks if the first value is not equal to the second value.
@@ -551,7 +551,7 @@ Returns:
 </details>
 
 ```grain
-(<) : (num1: BigInt, num2: BigInt) -> Bool
+(<) : (num1: BigInt, num2: BigInt) => Bool
 ```
 
 Checks if the first value is less than the second value.
@@ -584,7 +584,7 @@ Returns:
 </details>
 
 ```grain
-(<=) : (num1: BigInt, num2: BigInt) -> Bool
+(<=) : (num1: BigInt, num2: BigInt) => Bool
 ```
 
 Checks if the first value is less than or equal to the second value.
@@ -617,7 +617,7 @@ Returns:
 </details>
 
 ```grain
-(>) : (num1: BigInt, num2: BigInt) -> Bool
+(>) : (num1: BigInt, num2: BigInt) => Bool
 ```
 
 Checks if the first value is greater than the second value.
@@ -650,7 +650,7 @@ Returns:
 </details>
 
 ```grain
-(>=) : (num1: BigInt, num2: BigInt) -> Bool
+(>=) : (num1: BigInt, num2: BigInt) => Bool
 ```
 
 Checks if the first value is greater than or equal to the second value.
@@ -676,7 +676,7 @@ No other changes yet.
 </details>
 
 ```grain
-lnot : (num: BigInt) -> BigInt
+lnot : (num: BigInt) => BigInt
 ```
 
 Computes the bitwise NOT of the given value.
@@ -708,7 +708,7 @@ Returns:
 </details>
 
 ```grain
-(&) : (num1: BigInt, num2: BigInt) -> BigInt
+(&) : (num1: BigInt, num2: BigInt) => BigInt
 ```
 
 Computes the bitwise AND (`&`) on the given operands.
@@ -741,7 +741,7 @@ Returns:
 </details>
 
 ```grain
-(|) : (num1: BigInt, num2: BigInt) -> BigInt
+(|) : (num1: BigInt, num2: BigInt) => BigInt
 ```
 
 Computes the bitwise OR (`|`) on the given operands.
@@ -774,7 +774,7 @@ Returns:
 </details>
 
 ```grain
-(^) : (num1: BigInt, num2: BigInt) -> BigInt
+(^) : (num1: BigInt, num2: BigInt) => BigInt
 ```
 
 Computes the bitwise XOR (`^`) on the given operands.
@@ -800,7 +800,7 @@ No other changes yet.
 </details>
 
 ```grain
-clz : (num: BigInt) -> Int32
+clz : (num: BigInt) => Int32
 ```
 
 Counts the number of leading zero bits in the value.
@@ -826,7 +826,7 @@ No other changes yet.
 </details>
 
 ```grain
-ctz : (num: BigInt) -> Int64
+ctz : (num: BigInt) => Int64
 ```
 
 Counts the number of trailing zero bits in the value.
@@ -851,7 +851,7 @@ No other changes yet.
 </details>
 
 ```grain
-popcnt : (num: BigInt) -> Option<Int64>
+popcnt : (num: BigInt) => Option<Int64>
 ```
 
 Counts the number of bits set to `1` in the value, also known as a population count.
@@ -877,7 +877,7 @@ No other changes yet.
 </details>
 
 ```grain
-toString : (num: BigInt) -> String
+toString : (num: BigInt) => String
 ```
 
 Converts the given operand to a string.

--- a/stdlib/buffer.md
+++ b/stdlib/buffer.md
@@ -37,7 +37,7 @@ No other changes yet.
 </details>
 
 ```grain
-make : (initialSize: Number) -> Buffer
+make : (initialSize: Number) => Buffer
 ```
 
 Creates a fresh buffer, initially empty.
@@ -71,7 +71,7 @@ No other changes yet.
 </details>
 
 ```grain
-length : (buffer: Buffer) -> Number
+length : (buffer: Buffer) => Number
 ```
 
 Gets the number of bytes currently contained in a buffer.
@@ -96,7 +96,7 @@ No other changes yet.
 </details>
 
 ```grain
-clear : (buffer: Buffer) -> Void
+clear : (buffer: Buffer) => Void
 ```
 
 Clears data in the buffer and sets its length to zero.
@@ -117,7 +117,7 @@ No other changes yet.
 </details>
 
 ```grain
-reset : (buffer: Buffer) -> Void
+reset : (buffer: Buffer) => Void
 ```
 
 Empty a buffer and deallocate the internal byte sequence holding the buffer contents.
@@ -138,7 +138,7 @@ No other changes yet.
 </details>
 
 ```grain
-truncate : (length: Number, buffer: Buffer) -> Void
+truncate : (length: Number, buffer: Buffer) => Void
 ```
 
 Shortens a buffer to the given length.
@@ -167,7 +167,7 @@ No other changes yet.
 </details>
 
 ```grain
-toBytes : (buffer: Buffer) -> Bytes
+toBytes : (buffer: Buffer) => Bytes
 ```
 
 Returns a copy of the current contents of the buffer as a byte sequence.
@@ -192,7 +192,7 @@ No other changes yet.
 </details>
 
 ```grain
-toBytesSlice : (start: Number, length: Number, buffer: Buffer) -> Bytes
+toBytesSlice : (start: Number, length: Number, buffer: Buffer) => Bytes
 ```
 
 Returns a slice of the current contents of the buffer as a byte sequence.
@@ -227,7 +227,7 @@ No other changes yet.
 </details>
 
 ```grain
-toString : (buffer: Buffer) -> String
+toString : (buffer: Buffer) => String
 ```
 
 Returns a copy of the current contents of the buffer as a string.
@@ -252,7 +252,7 @@ No other changes yet.
 </details>
 
 ```grain
-toStringSlice : (start: Number, length: Number, buffer: Buffer) -> String
+toStringSlice : (start: Number, length: Number, buffer: Buffer) => String
 ```
 
 Returns a copy of a subset of the current contents of the buffer as a string.
@@ -279,7 +279,7 @@ No other changes yet.
 </details>
 
 ```grain
-addBytes : (bytes: Bytes, buffer: Buffer) -> Void
+addBytes : (bytes: Bytes, buffer: Buffer) => Void
 ```
 
 Appends a byte sequence to a buffer.
@@ -299,7 +299,7 @@ No other changes yet.
 </details>
 
 ```grain
-addString : (string: String, buffer: Buffer) -> Void
+addString : (string: String, buffer: Buffer) => Void
 ```
 
 Appends the bytes of a string to a buffer.
@@ -319,7 +319,7 @@ No other changes yet.
 </details>
 
 ```grain
-addChar : (char: Char, buffer: Buffer) -> Void
+addChar : (char: Char, buffer: Buffer) => Void
 ```
 
 Appends the bytes of a char to a buffer.
@@ -347,7 +347,7 @@ Parameters:
 
 ```grain
 addStringSlice :
-  (start: Number, end: Number, string: String, buffer: Buffer) -> Void
+  (start: Number, end: Number, string: String, buffer: Buffer) => Void
 ```
 
 Appends the bytes of a subset of a string to a buffer.
@@ -370,7 +370,7 @@ No other changes yet.
 
 ```grain
 addBytesSlice :
-  (start: Number, length: Number, bytes: Bytes, buffer: Buffer) -> Void
+  (start: Number, length: Number, bytes: Bytes, buffer: Buffer) => Void
 ```
 
 Appends the bytes of a subset of a byte sequence to a buffer.
@@ -401,7 +401,7 @@ No other changes yet.
 </details>
 
 ```grain
-addBuffer : (srcBuffer: Buffer, dstBuffer: Buffer) -> Void
+addBuffer : (srcBuffer: Buffer, dstBuffer: Buffer) => Void
 ```
 
 Appends the bytes of a source buffer to destination buffer.
@@ -424,7 +424,7 @@ No other changes yet.
 
 ```grain
 addBufferSlice :
-  (start: Number, length: Number, srcBuffer: Buffer, dstBuffer: Buffer) ->
+  (start: Number, length: Number, srcBuffer: Buffer, dstBuffer: Buffer) =>
    Void
 ```
 
@@ -456,7 +456,7 @@ Parameters:
 </details>
 
 ```grain
-getInt8 : (index: Number, buffer: Buffer) -> Int8
+getInt8 : (index: Number, buffer: Buffer) => Int8
 ```
 
 Gets a signed 8-bit integer starting at the given byte index.
@@ -497,7 +497,7 @@ Throws:
 </details>
 
 ```grain
-setInt8 : (index: Number, value: Int8, buffer: Buffer) -> Void
+setInt8 : (index: Number, value: Int8, buffer: Buffer) => Void
 ```
 
 Sets a signed 8-bit integer starting at the given byte index.
@@ -533,7 +533,7 @@ Throws:
 </details>
 
 ```grain
-addInt8 : (value: Int8, buffer: Buffer) -> Void
+addInt8 : (value: Int8, buffer: Buffer) => Void
 ```
 
 Appends a signed 8-bit integer to a buffer.
@@ -560,7 +560,7 @@ Parameters:
 </details>
 
 ```grain
-getUint8 : (index: Number, buffer: Buffer) -> Uint8
+getUint8 : (index: Number, buffer: Buffer) => Uint8
 ```
 
 Gets an unsigned 8-bit integer starting at the given byte index.
@@ -594,7 +594,7 @@ No other changes yet.
 </details>
 
 ```grain
-setUint8 : (index: Number, value: Uint8, buffer: Buffer) -> Void
+setUint8 : (index: Number, value: Uint8, buffer: Buffer) => Void
 ```
 
 Sets an unsigned 8-bit integer starting at the given byte index.
@@ -623,7 +623,7 @@ No other changes yet.
 </details>
 
 ```grain
-addUint8 : (value: Uint8, buffer: Buffer) -> Void
+addUint8 : (value: Uint8, buffer: Buffer) => Void
 ```
 
 Appends an unsigned 8-bit integer to a buffer.
@@ -650,7 +650,7 @@ Parameters:
 </details>
 
 ```grain
-getInt16 : (index: Number, buffer: Buffer) -> Int16
+getInt16 : (index: Number, buffer: Buffer) => Int16
 ```
 
 Gets a signed 16-bit integer starting at the given byte index.
@@ -691,7 +691,7 @@ Throws:
 </details>
 
 ```grain
-setInt16 : (index: Number, value: Int16, buffer: Buffer) -> Void
+setInt16 : (index: Number, value: Int16, buffer: Buffer) => Void
 ```
 
 Sets a signed 16-bit integer starting at the given byte index.
@@ -727,7 +727,7 @@ Throws:
 </details>
 
 ```grain
-addInt16 : (value: Int16, buffer: Buffer) -> Void
+addInt16 : (value: Int16, buffer: Buffer) => Void
 ```
 
 Appends a signed 16-bit integer to a buffer.
@@ -754,7 +754,7 @@ Parameters:
 </details>
 
 ```grain
-getUint16 : (index: Number, buffer: Buffer) -> Uint16
+getUint16 : (index: Number, buffer: Buffer) => Uint16
 ```
 
 Gets an unsigned 16-bit integer starting at the given byte index.
@@ -788,7 +788,7 @@ No other changes yet.
 </details>
 
 ```grain
-setUint16 : (index: Number, value: Uint16, buffer: Buffer) -> Void
+setUint16 : (index: Number, value: Uint16, buffer: Buffer) => Void
 ```
 
 Sets an unsigned 16-bit integer starting at the given byte index.
@@ -817,7 +817,7 @@ No other changes yet.
 </details>
 
 ```grain
-addUint16 : (value: Uint16, buffer: Buffer) -> Void
+addUint16 : (value: Uint16, buffer: Buffer) => Void
 ```
 
 Appends an unsigned 16-bit integer to a buffer.
@@ -837,7 +837,7 @@ No other changes yet.
 </details>
 
 ```grain
-getInt32 : (index: Number, buffer: Buffer) -> Int32
+getInt32 : (index: Number, buffer: Buffer) => Int32
 ```
 
 Gets a signed 32-bit integer starting at the given byte index.
@@ -871,7 +871,7 @@ No other changes yet.
 </details>
 
 ```grain
-setInt32 : (index: Number, value: Int32, buffer: Buffer) -> Void
+setInt32 : (index: Number, value: Int32, buffer: Buffer) => Void
 ```
 
 Sets a signed 32-bit integer starting at the given byte index.
@@ -900,7 +900,7 @@ No other changes yet.
 </details>
 
 ```grain
-addInt32 : (value: Int32, buffer: Buffer) -> Void
+addInt32 : (value: Int32, buffer: Buffer) => Void
 ```
 
 Appends a signed 32-bit integer to a buffer.
@@ -920,7 +920,7 @@ No other changes yet.
 </details>
 
 ```grain
-getUint32 : (index: Number, buffer: Buffer) -> Uint32
+getUint32 : (index: Number, buffer: Buffer) => Uint32
 ```
 
 Gets an unsigned 32-bit integer starting at the given byte index.
@@ -954,7 +954,7 @@ No other changes yet.
 </details>
 
 ```grain
-setUint32 : (index: Number, value: Uint32, buffer: Buffer) -> Void
+setUint32 : (index: Number, value: Uint32, buffer: Buffer) => Void
 ```
 
 Sets an unsigned 32-bit integer starting at the given byte index.
@@ -983,7 +983,7 @@ No other changes yet.
 </details>
 
 ```grain
-addUint32 : (value: Uint32, buffer: Buffer) -> Void
+addUint32 : (value: Uint32, buffer: Buffer) => Void
 ```
 
 Appends an unsigned 32-bit integer to a buffer.
@@ -1003,7 +1003,7 @@ No other changes yet.
 </details>
 
 ```grain
-getFloat32 : (index: Number, buffer: Buffer) -> Float32
+getFloat32 : (index: Number, buffer: Buffer) => Float32
 ```
 
 Gets a 32-bit float starting at the given byte index.
@@ -1037,7 +1037,7 @@ No other changes yet.
 </details>
 
 ```grain
-setFloat32 : (index: Number, value: Float32, buffer: Buffer) -> Void
+setFloat32 : (index: Number, value: Float32, buffer: Buffer) => Void
 ```
 
 Sets a 32-bit float starting at the given byte index.
@@ -1066,7 +1066,7 @@ No other changes yet.
 </details>
 
 ```grain
-addFloat32 : (value: Float32, buffer: Buffer) -> Void
+addFloat32 : (value: Float32, buffer: Buffer) => Void
 ```
 
 Appends a 32-bit float to a buffer.
@@ -1086,7 +1086,7 @@ No other changes yet.
 </details>
 
 ```grain
-getInt64 : (index: Number, buffer: Buffer) -> Int64
+getInt64 : (index: Number, buffer: Buffer) => Int64
 ```
 
 Gets a signed 64-bit integer starting at the given byte index.
@@ -1120,7 +1120,7 @@ No other changes yet.
 </details>
 
 ```grain
-setInt64 : (index: Number, value: Int64, buffer: Buffer) -> Void
+setInt64 : (index: Number, value: Int64, buffer: Buffer) => Void
 ```
 
 Sets a signed 64-bit integer starting at the given byte index.
@@ -1149,7 +1149,7 @@ No other changes yet.
 </details>
 
 ```grain
-addInt64 : (value: Int64, buffer: Buffer) -> Void
+addInt64 : (value: Int64, buffer: Buffer) => Void
 ```
 
 Appends a signed 64-bit integer to a buffer.
@@ -1169,7 +1169,7 @@ No other changes yet.
 </details>
 
 ```grain
-getUint64 : (index: Number, buffer: Buffer) -> Uint64
+getUint64 : (index: Number, buffer: Buffer) => Uint64
 ```
 
 Gets an unsigned 64-bit integer starting at the given byte index.
@@ -1203,7 +1203,7 @@ No other changes yet.
 </details>
 
 ```grain
-setUint64 : (index: Number, value: Uint64, buffer: Buffer) -> Void
+setUint64 : (index: Number, value: Uint64, buffer: Buffer) => Void
 ```
 
 Sets an unsigned 64-bit integer starting at the given byte index.
@@ -1232,7 +1232,7 @@ No other changes yet.
 </details>
 
 ```grain
-addUint64 : (value: Uint64, buffer: Buffer) -> Void
+addUint64 : (value: Uint64, buffer: Buffer) => Void
 ```
 
 Appends an unsigned 64-bit integer to a buffer.
@@ -1252,7 +1252,7 @@ No other changes yet.
 </details>
 
 ```grain
-getFloat64 : (index: Number, buffer: Buffer) -> Float64
+getFloat64 : (index: Number, buffer: Buffer) => Float64
 ```
 
 Gets a 64-bit float starting at the given byte index.
@@ -1286,7 +1286,7 @@ No other changes yet.
 </details>
 
 ```grain
-setFloat64 : (index: Number, value: Float64, buffer: Buffer) -> Void
+setFloat64 : (index: Number, value: Float64, buffer: Buffer) => Void
 ```
 
 Sets a 64-bit float starting at the given byte index.
@@ -1315,7 +1315,7 @@ No other changes yet.
 </details>
 
 ```grain
-addFloat64 : (value: Float64, buffer: Buffer) -> Void
+addFloat64 : (value: Float64, buffer: Buffer) => Void
 ```
 
 Appends a 64-bit float to a buffer.

--- a/stdlib/bytes.md
+++ b/stdlib/bytes.md
@@ -25,7 +25,7 @@ No other changes yet.
 </details>
 
 ```grain
-make : (size: Number) -> Bytes
+make : (size: Number) => Bytes
 ```
 
 Creates a new byte sequence of the input size.
@@ -63,7 +63,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromString : (string: String) -> Bytes
+fromString : (string: String) => Bytes
 ```
 
 Creates a new byte sequence from the input string.
@@ -88,7 +88,7 @@ No other changes yet.
 </details>
 
 ```grain
-toString : (bytes: Bytes) -> String
+toString : (bytes: Bytes) => String
 ```
 
 Creates a new string from the input bytes.
@@ -113,7 +113,7 @@ No other changes yet.
 </details>
 
 ```grain
-length : (bytes: Bytes) -> Number
+length : (bytes: Bytes) => Number
 ```
 
 Returns the length of a byte sequence.
@@ -138,7 +138,7 @@ No other changes yet.
 </details>
 
 ```grain
-copy : (b: Bytes) -> Bytes
+copy : (b: Bytes) => Bytes
 ```
 
 Creates a new byte sequence that contains the same bytes as the input byte sequence.
@@ -163,7 +163,7 @@ No other changes yet.
 </details>
 
 ```grain
-slice : (start: Number, length: Number, bytes: Bytes) -> Bytes
+slice : (start: Number, length: Number, bytes: Bytes) => Bytes
 ```
 
 Returns a copy of a subset of the input byte sequence.
@@ -196,7 +196,7 @@ No other changes yet.
 </details>
 
 ```grain
-resize : (left: Number, right: Number, bytes: Bytes) -> Bytes
+resize : (left: Number, right: Number, bytes: Bytes) => Bytes
 ```
 
 Returns a copy of a byte sequence with bytes added or removed from the beginning and/or end.
@@ -232,7 +232,7 @@ No other changes yet.
 
 ```grain
 move :
-  (srcIndex: Number, dstIndex: Number, length: Number, src: Bytes, dst: Bytes) ->
+  (srcIndex: Number, dstIndex: Number, length: Number, src: Bytes, dst: Bytes) =>
    Void
 ```
 
@@ -264,7 +264,7 @@ No other changes yet.
 </details>
 
 ```grain
-concat : (bytes1: Bytes, bytes2: Bytes) -> Bytes
+concat : (bytes1: Bytes, bytes2: Bytes) => Bytes
 ```
 
 Creates a new byte sequence that contains the bytes of both byte sequences.
@@ -297,7 +297,7 @@ Returns:
 </details>
 
 ```grain
-fill : (value: Uint8, bytes: Bytes) -> Void
+fill : (value: Uint8, bytes: Bytes) => Void
 ```
 
 Replaces all bytes in a byte sequnce with the new value provided.
@@ -317,7 +317,7 @@ No other changes yet.
 </details>
 
 ```grain
-clear : (bytes: Bytes) -> Void
+clear : (bytes: Bytes) => Void
 ```
 
 Replaces all bytes in a byte sequence with zeroes.
@@ -343,7 +343,7 @@ Parameters:
 </details>
 
 ```grain
-getInt8 : (index: Number, bytes: Bytes) -> Int8
+getInt8 : (index: Number, bytes: Bytes) => Int8
 ```
 
 Gets a signed 8-bit integer starting at the given byte index.
@@ -383,7 +383,7 @@ Throws:
 </details>
 
 ```grain
-setInt8 : (index: Number, value: Int8, bytes: Bytes) -> Void
+setInt8 : (index: Number, value: Int8, bytes: Bytes) => Void
 ```
 
 Sets a signed 8-bit integer starting at the given byte index.
@@ -418,7 +418,7 @@ Throws:
 </details>
 
 ```grain
-getUint8 : (index: Number, bytes: Bytes) -> Uint8
+getUint8 : (index: Number, bytes: Bytes) => Uint8
 ```
 
 Gets an unsigned 8-bit integer starting at the given byte index.
@@ -451,7 +451,7 @@ No other changes yet.
 </details>
 
 ```grain
-setUint8 : (index: Number, value: Uint8, bytes: Bytes) -> Void
+setUint8 : (index: Number, value: Uint8, bytes: Bytes) => Void
 ```
 
 Sets an unsigned 8-bit integer starting at the given byte index.
@@ -486,7 +486,7 @@ Throws:
 </details>
 
 ```grain
-getInt16 : (index: Number, bytes: Bytes) -> Int16
+getInt16 : (index: Number, bytes: Bytes) => Int16
 ```
 
 Gets a signed 16-bit integer starting at the given byte index.
@@ -526,7 +526,7 @@ Throws:
 </details>
 
 ```grain
-setInt16 : (index: Number, value: Int16, bytes: Bytes) -> Void
+setInt16 : (index: Number, value: Int16, bytes: Bytes) => Void
 ```
 
 Sets a signed 16-bit integer starting at the given byte index.
@@ -561,7 +561,7 @@ Throws:
 </details>
 
 ```grain
-getUint16 : (index: Number, bytes: Bytes) -> Uint16
+getUint16 : (index: Number, bytes: Bytes) => Uint16
 ```
 
 Gets an unsigned 16-bit integer starting at the given byte index.
@@ -594,7 +594,7 @@ No other changes yet.
 </details>
 
 ```grain
-setUint16 : (index: Number, value: Uint16, bytes: Bytes) -> Void
+setUint16 : (index: Number, value: Uint16, bytes: Bytes) => Void
 ```
 
 Sets an unsigned 16-bit integer starting at the given byte index.
@@ -622,7 +622,7 @@ No other changes yet.
 </details>
 
 ```grain
-getInt32 : (index: Number, bytes: Bytes) -> Int32
+getInt32 : (index: Number, bytes: Bytes) => Int32
 ```
 
 Gets a signed 32-bit integer starting at the given byte index.
@@ -655,7 +655,7 @@ No other changes yet.
 </details>
 
 ```grain
-setInt32 : (index: Number, value: Int32, bytes: Bytes) -> Void
+setInt32 : (index: Number, value: Int32, bytes: Bytes) => Void
 ```
 
 Sets a signed 32-bit integer starting at the given byte index.
@@ -683,7 +683,7 @@ No other changes yet.
 </details>
 
 ```grain
-getUint32 : (index: Number, bytes: Bytes) -> Uint32
+getUint32 : (index: Number, bytes: Bytes) => Uint32
 ```
 
 Gets an unsigned 32-bit integer starting at the given byte index.
@@ -716,7 +716,7 @@ No other changes yet.
 </details>
 
 ```grain
-setUint32 : (index: Number, value: Uint32, bytes: Bytes) -> Void
+setUint32 : (index: Number, value: Uint32, bytes: Bytes) => Void
 ```
 
 Sets an unsigned 32-bit integer starting at the given byte index.
@@ -744,7 +744,7 @@ No other changes yet.
 </details>
 
 ```grain
-getFloat32 : (index: Number, bytes: Bytes) -> Float32
+getFloat32 : (index: Number, bytes: Bytes) => Float32
 ```
 
 Gets a 32-bit float starting at the given byte index.
@@ -777,7 +777,7 @@ No other changes yet.
 </details>
 
 ```grain
-setFloat32 : (index: Number, value: Float32, bytes: Bytes) -> Void
+setFloat32 : (index: Number, value: Float32, bytes: Bytes) => Void
 ```
 
 Sets a 32-bit float starting at the given byte index.
@@ -805,7 +805,7 @@ No other changes yet.
 </details>
 
 ```grain
-getInt64 : (index: Number, bytes: Bytes) -> Int64
+getInt64 : (index: Number, bytes: Bytes) => Int64
 ```
 
 Gets a signed 64-bit integer starting at the given byte index.
@@ -838,7 +838,7 @@ No other changes yet.
 </details>
 
 ```grain
-setInt64 : (index: Number, value: Int64, bytes: Bytes) -> Void
+setInt64 : (index: Number, value: Int64, bytes: Bytes) => Void
 ```
 
 Sets a signed 64-bit integer starting at the given byte index.
@@ -866,7 +866,7 @@ No other changes yet.
 </details>
 
 ```grain
-getUint64 : (index: Number, bytes: Bytes) -> Uint64
+getUint64 : (index: Number, bytes: Bytes) => Uint64
 ```
 
 Gets an unsigned 64-bit integer starting at the given byte index.
@@ -899,7 +899,7 @@ No other changes yet.
 </details>
 
 ```grain
-setUint64 : (index: Number, value: Uint64, bytes: Bytes) -> Void
+setUint64 : (index: Number, value: Uint64, bytes: Bytes) => Void
 ```
 
 Sets an unsigned 64-bit integer starting at the given byte index.
@@ -927,7 +927,7 @@ No other changes yet.
 </details>
 
 ```grain
-getFloat64 : (index: Number, bytes: Bytes) -> Float64
+getFloat64 : (index: Number, bytes: Bytes) => Float64
 ```
 
 Gets a 64-bit float starting at the given byte index.
@@ -960,7 +960,7 @@ No other changes yet.
 </details>
 
 ```grain
-setFloat64 : (index: Number, value: Float64, bytes: Bytes) -> Void
+setFloat64 : (index: Number, value: Float64, bytes: Bytes) => Void
 ```
 
 Sets a 64-bit float starting at the given byte index.

--- a/stdlib/char.md
+++ b/stdlib/char.md
@@ -53,7 +53,7 @@ No other changes yet.
 </details>
 
 ```grain
-isValid : (charCode: Number) -> Bool
+isValid : (charCode: Number) => Bool
 ```
 
 Determines whether the given character code is a valid Unicode scalar value.
@@ -78,7 +78,7 @@ No other changes yet.
 </details>
 
 ```grain
-code : (char: Char) -> Number
+code : (char: Char) => Number
 ```
 
 Determines the Unicode scalar value for a character.
@@ -103,7 +103,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromCode : (usv: Number) -> Char
+fromCode : (usv: Number) => Char
 ```
 
 Creates a character from the given Unicode scalar value.
@@ -134,7 +134,7 @@ No other changes yet.
 </details>
 
 ```grain
-succ : (char: Char) -> Char
+succ : (char: Char) => Char
 ```
 
 Returns the next valid character by Unicode scalar value.
@@ -165,7 +165,7 @@ No other changes yet.
 </details>
 
 ```grain
-pred : (char: Char) -> Char
+pred : (char: Char) => Char
 ```
 
 Returns the previous valid character by Unicode scalar value.
@@ -196,7 +196,7 @@ No other changes yet.
 </details>
 
 ```grain
-toString : (char: Char) -> String
+toString : (char: Char) => String
 ```
 
 Converts the given character to a string.
@@ -221,7 +221,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<) : (x: Char, y: Char) -> Bool
+(<) : (x: Char, y: Char) => Bool
 ```
 
 Checks if the first character is less than the second character by Unicode scalar value.
@@ -247,7 +247,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<=) : (x: Char, y: Char) -> Bool
+(<=) : (x: Char, y: Char) => Bool
 ```
 
 Checks if the first character is less than or equal to the second character by Unicode scalar value.
@@ -273,7 +273,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>) : (x: Char, y: Char) -> Bool
+(>) : (x: Char, y: Char) => Bool
 ```
 
 Checks if the first character is greater than the second character by Unicode scalar value.
@@ -299,7 +299,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>=) : (x: Char, y: Char) -> Bool
+(>=) : (x: Char, y: Char) => Bool
 ```
 
 Checks if the first character is greater than or equal to the second character by Unicode scalar value.

--- a/stdlib/exception.gr
+++ b/stdlib/exception.gr
@@ -24,7 +24,7 @@ include "runtime/exception"
  * @since v0.3.0
  */
 @disableGC
-provide let rec registerPrinter = (printer: Exception -> Option<String>) => {
+provide let rec registerPrinter = (printer: Exception => Option<String>) => {
   // This function _must_ be @disableGC because the printer list uses
   // unsafe types. Not really a memory leak as this list is never collected
 

--- a/stdlib/exception.md
+++ b/stdlib/exception.md
@@ -27,7 +27,7 @@ No other changes yet.
 </details>
 
 ```grain
-registerPrinter : (printer: (Exception -> Option<String>)) -> Void
+registerPrinter : (printer: (Exception => Option<String>)) => Void
 ```
 
 Registers an exception printer. When an exception is thrown, all registered
@@ -39,5 +39,5 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`printer`|`Exception -> Option<String>`|The exception printer to register|
+|`printer`|`Exception => Option<String>`|The exception printer to register|
 

--- a/stdlib/float32.md
+++ b/stdlib/float32.md
@@ -90,7 +90,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromNumber : (x: Number) -> Float32
+fromNumber : (x: Number) => Float32
 ```
 
 Converts a Number to a Float32.
@@ -115,7 +115,7 @@ No other changes yet.
 </details>
 
 ```grain
-toNumber : (x: Float32) -> Number
+toNumber : (x: Float32) => Number
 ```
 
 Converts a Float32 to a Number.
@@ -140,7 +140,7 @@ No other changes yet.
 </details>
 
 ```grain
-add : (x: Float32, y: Float32) -> Float32
+add : (x: Float32, y: Float32) => Float32
 ```
 
 Computes the sum of its operands.
@@ -166,7 +166,7 @@ No other changes yet.
 </details>
 
 ```grain
-sub : (x: Float32, y: Float32) -> Float32
+sub : (x: Float32, y: Float32) => Float32
 ```
 
 Computes the difference of its operands.
@@ -192,7 +192,7 @@ No other changes yet.
 </details>
 
 ```grain
-mul : (x: Float32, y: Float32) -> Float32
+mul : (x: Float32, y: Float32) => Float32
 ```
 
 Computes the product of its operands.
@@ -218,7 +218,7 @@ No other changes yet.
 </details>
 
 ```grain
-div : (x: Float32, y: Float32) -> Float32
+div : (x: Float32, y: Float32) => Float32
 ```
 
 Computes the quotient of its operands.
@@ -244,7 +244,7 @@ No other changes yet.
 </details>
 
 ```grain
-lt : (x: Float32, y: Float32) -> Bool
+lt : (x: Float32, y: Float32) => Bool
 ```
 
 Checks if the first value is less than the second value.
@@ -270,7 +270,7 @@ No other changes yet.
 </details>
 
 ```grain
-gt : (x: Float32, y: Float32) -> Bool
+gt : (x: Float32, y: Float32) => Bool
 ```
 
 Checks if the first value is greater than the second value.
@@ -296,7 +296,7 @@ No other changes yet.
 </details>
 
 ```grain
-lte : (x: Float32, y: Float32) -> Bool
+lte : (x: Float32, y: Float32) => Bool
 ```
 
 Checks if the first value is less than or equal to the second value.
@@ -322,7 +322,7 @@ No other changes yet.
 </details>
 
 ```grain
-gte : (x: Float32, y: Float32) -> Bool
+gte : (x: Float32, y: Float32) => Bool
 ```
 
 Checks if the first value is greater than or equal to the second value.

--- a/stdlib/float64.md
+++ b/stdlib/float64.md
@@ -90,7 +90,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromNumber : (x: Number) -> Float64
+fromNumber : (x: Number) => Float64
 ```
 
 Converts a Number to a Float64.
@@ -115,7 +115,7 @@ No other changes yet.
 </details>
 
 ```grain
-toNumber : (x: Float64) -> Number
+toNumber : (x: Float64) => Number
 ```
 
 Converts a Float64 to a Number.
@@ -140,7 +140,7 @@ No other changes yet.
 </details>
 
 ```grain
-add : (x: Float64, y: Float64) -> Float64
+add : (x: Float64, y: Float64) => Float64
 ```
 
 Computes the sum of its operands.
@@ -166,7 +166,7 @@ No other changes yet.
 </details>
 
 ```grain
-sub : (x: Float64, y: Float64) -> Float64
+sub : (x: Float64, y: Float64) => Float64
 ```
 
 Computes the difference of its operands.
@@ -192,7 +192,7 @@ No other changes yet.
 </details>
 
 ```grain
-mul : (x: Float64, y: Float64) -> Float64
+mul : (x: Float64, y: Float64) => Float64
 ```
 
 Computes the product of its operands.
@@ -218,7 +218,7 @@ No other changes yet.
 </details>
 
 ```grain
-div : (x: Float64, y: Float64) -> Float64
+div : (x: Float64, y: Float64) => Float64
 ```
 
 Computes the quotient of its operands.
@@ -244,7 +244,7 @@ No other changes yet.
 </details>
 
 ```grain
-lt : (x: Float64, y: Float64) -> Bool
+lt : (x: Float64, y: Float64) => Bool
 ```
 
 Checks if the first value is less than the second value.
@@ -270,7 +270,7 @@ No other changes yet.
 </details>
 
 ```grain
-gt : (x: Float64, y: Float64) -> Bool
+gt : (x: Float64, y: Float64) => Bool
 ```
 
 Checks if the first value is greater than the second value.
@@ -296,7 +296,7 @@ No other changes yet.
 </details>
 
 ```grain
-lte : (x: Float64, y: Float64) -> Bool
+lte : (x: Float64, y: Float64) => Bool
 ```
 
 Checks if the first value is less than or equal to the second value.
@@ -322,7 +322,7 @@ No other changes yet.
 </details>
 
 ```grain
-gte : (x: Float64, y: Float64) -> Bool
+gte : (x: Float64, y: Float64) => Bool
 ```
 
 Checks if the first value is greater than or equal to the second value.

--- a/stdlib/hash.md
+++ b/stdlib/hash.md
@@ -25,7 +25,7 @@ No other changes yet.
 </details>
 
 ```grain
-hash : (anything: a) -> Number
+hash : (anything: a) => Number
 ```
 
 A generic hash function that produces an integer from any value. If `a == b` then `Hash.hash(a) == Hash.hash(b)`.

--- a/stdlib/int16.md
+++ b/stdlib/int16.md
@@ -25,7 +25,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromNumber : (number: Number) -> Int16
+fromNumber : (number: Number) => Int16
 ```
 
 Converts a Number to an Int16.
@@ -50,7 +50,7 @@ No other changes yet.
 </details>
 
 ```grain
-toNumber : (value: Int16) -> Number
+toNumber : (value: Int16) => Number
 ```
 
 Converts an Int16 to a Number.
@@ -75,7 +75,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromUint16 : (x: Uint16) -> Int16
+fromUint16 : (x: Uint16) => Int16
 ```
 
 Converts a Uint16 to an Int16.
@@ -100,7 +100,7 @@ No other changes yet.
 </details>
 
 ```grain
-incr : (value: Int16) -> Int16
+incr : (value: Int16) => Int16
 ```
 
 Increments the value by one.
@@ -125,7 +125,7 @@ No other changes yet.
 </details>
 
 ```grain
-decr : (value: Int16) -> Int16
+decr : (value: Int16) => Int16
 ```
 
 Decrements the value by one.
@@ -150,7 +150,7 @@ No other changes yet.
 </details>
 
 ```grain
-(+) : (x: Int16, y: Int16) -> Int16
+(+) : (x: Int16, y: Int16) => Int16
 ```
 
 Computes the sum of its operands.
@@ -176,7 +176,7 @@ No other changes yet.
 </details>
 
 ```grain
-(-) : (x: Int16, y: Int16) -> Int16
+(-) : (x: Int16, y: Int16) => Int16
 ```
 
 Computes the difference of its operands.
@@ -202,7 +202,7 @@ No other changes yet.
 </details>
 
 ```grain
-(*) : (x: Int16, y: Int16) -> Int16
+(*) : (x: Int16, y: Int16) => Int16
 ```
 
 Computes the product of its operands.
@@ -228,7 +228,7 @@ No other changes yet.
 </details>
 
 ```grain
-(/) : (x: Int16, y: Int16) -> Int16
+(/) : (x: Int16, y: Int16) => Int16
 ```
 
 Computes the quotient of its operands using signed division.
@@ -254,7 +254,7 @@ No other changes yet.
 </details>
 
 ```grain
-rem : (x: Int16, y: Int16) -> Int16
+rem : (x: Int16, y: Int16) => Int16
 ```
 
 Computes the remainder of the division of its operands using signed division.
@@ -280,7 +280,7 @@ No other changes yet.
 </details>
 
 ```grain
-(%) : (x: Int16, y: Int16) -> Int16
+(%) : (x: Int16, y: Int16) => Int16
 ```
 
 Computes the remainder of the division of the first operand by the second.
@@ -313,7 +313,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<<) : (value: Int16, amount: Int16) -> Int16
+(<<) : (value: Int16, amount: Int16) => Int16
 ```
 
 Shifts the bits of the value left by the given number of bits.
@@ -339,7 +339,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>>) : (value: Int16, amount: Int16) -> Int16
+(>>) : (value: Int16, amount: Int16) => Int16
 ```
 
 Shifts the bits of the value right by the given number of bits, preserving the sign bit.
@@ -365,7 +365,7 @@ No other changes yet.
 </details>
 
 ```grain
-(==) : (x: Int16, y: Int16) -> Bool
+(==) : (x: Int16, y: Int16) => Bool
 ```
 
 Checks if the first value is equal to the second value.
@@ -391,7 +391,7 @@ No other changes yet.
 </details>
 
 ```grain
-(!=) : (x: Int16, y: Int16) -> Bool
+(!=) : (x: Int16, y: Int16) => Bool
 ```
 
 Checks if the first value is not equal to the second value.
@@ -417,7 +417,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<) : (x: Int16, y: Int16) -> Bool
+(<) : (x: Int16, y: Int16) => Bool
 ```
 
 Checks if the first value is less than the second value.
@@ -443,7 +443,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>) : (x: Int16, y: Int16) -> Bool
+(>) : (x: Int16, y: Int16) => Bool
 ```
 
 Checks if the first value is greater than the second value.
@@ -469,7 +469,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<=) : (x: Int16, y: Int16) -> Bool
+(<=) : (x: Int16, y: Int16) => Bool
 ```
 
 Checks if the first value is less than or equal to the second value.
@@ -495,7 +495,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>=) : (x: Int16, y: Int16) -> Bool
+(>=) : (x: Int16, y: Int16) => Bool
 ```
 
 Checks if the first value is greater than or equal to the second value.
@@ -521,7 +521,7 @@ No other changes yet.
 </details>
 
 ```grain
-lnot : (value: Int16) -> Int16
+lnot : (value: Int16) => Int16
 ```
 
 Computes the bitwise NOT of the given value.
@@ -546,7 +546,7 @@ No other changes yet.
 </details>
 
 ```grain
-(&) : (x: Int16, y: Int16) -> Int16
+(&) : (x: Int16, y: Int16) => Int16
 ```
 
 Computes the bitwise AND (`&`) on the given operands.
@@ -572,7 +572,7 @@ No other changes yet.
 </details>
 
 ```grain
-(|) : (x: Int16, y: Int16) -> Int16
+(|) : (x: Int16, y: Int16) => Int16
 ```
 
 Computes the bitwise OR (`|`) on the given operands.
@@ -598,7 +598,7 @@ No other changes yet.
 </details>
 
 ```grain
-(^) : (x: Int16, y: Int16) -> Int16
+(^) : (x: Int16, y: Int16) => Int16
 ```
 
 Computes the bitwise XOR (`^`) on the given operands.

--- a/stdlib/int32.md
+++ b/stdlib/int32.md
@@ -25,7 +25,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromNumber : (x: Number) -> Int32
+fromNumber : (x: Number) => Int32
 ```
 
 Converts a Number to an Int32.
@@ -50,7 +50,7 @@ No other changes yet.
 </details>
 
 ```grain
-toNumber : (x: Int32) -> Number
+toNumber : (x: Int32) => Number
 ```
 
 Converts an Int32 to a Number.
@@ -75,7 +75,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromUint32 : (x: Uint32) -> Int32
+fromUint32 : (x: Uint32) => Int32
 ```
 
 Converts a Uint32 to an Int32.
@@ -100,7 +100,7 @@ No other changes yet.
 </details>
 
 ```grain
-incr : (value: Int32) -> Int32
+incr : (value: Int32) => Int32
 ```
 
 Increments the value by one.
@@ -125,7 +125,7 @@ No other changes yet.
 </details>
 
 ```grain
-decr : (value: Int32) -> Int32
+decr : (value: Int32) => Int32
 ```
 
 Decrements the value by one.
@@ -150,7 +150,7 @@ No other changes yet.
 </details>
 
 ```grain
-add : (x: Int32, y: Int32) -> Int32
+add : (x: Int32, y: Int32) => Int32
 ```
 
 Computes the sum of its operands.
@@ -176,7 +176,7 @@ No other changes yet.
 </details>
 
 ```grain
-sub : (x: Int32, y: Int32) -> Int32
+sub : (x: Int32, y: Int32) => Int32
 ```
 
 Computes the difference of its operands.
@@ -202,7 +202,7 @@ No other changes yet.
 </details>
 
 ```grain
-mul : (x: Int32, y: Int32) -> Int32
+mul : (x: Int32, y: Int32) => Int32
 ```
 
 Computes the product of its operands.
@@ -228,7 +228,7 @@ No other changes yet.
 </details>
 
 ```grain
-div : (x: Int32, y: Int32) -> Int32
+div : (x: Int32, y: Int32) => Int32
 ```
 
 Computes the quotient of its operands using signed division.
@@ -254,7 +254,7 @@ No other changes yet.
 </details>
 
 ```grain
-rem : (x: Int32, y: Int32) -> Int32
+rem : (x: Int32, y: Int32) => Int32
 ```
 
 Computes the remainder of the division of its operands using signed division.
@@ -280,7 +280,7 @@ No other changes yet.
 </details>
 
 ```grain
-mod : (x: Int32, y: Int32) -> Int32
+mod : (x: Int32, y: Int32) => Int32
 ```
 
 Computes the remainder of the division of the first operand by the second.
@@ -313,7 +313,7 @@ No other changes yet.
 </details>
 
 ```grain
-rotl : (value: Int32, amount: Int32) -> Int32
+rotl : (value: Int32, amount: Int32) => Int32
 ```
 
 Rotates the bits of the value left by the given number of bits.
@@ -339,7 +339,7 @@ No other changes yet.
 </details>
 
 ```grain
-rotr : (value: Int32, amount: Int32) -> Int32
+rotr : (value: Int32, amount: Int32) => Int32
 ```
 
 Rotates the bits of the value right by the given number of bits.
@@ -365,7 +365,7 @@ No other changes yet.
 </details>
 
 ```grain
-shl : (value: Int32, amount: Int32) -> Int32
+shl : (value: Int32, amount: Int32) => Int32
 ```
 
 Shifts the bits of the value left by the given number of bits.
@@ -391,7 +391,7 @@ No other changes yet.
 </details>
 
 ```grain
-shr : (value: Int32, amount: Int32) -> Int32
+shr : (value: Int32, amount: Int32) => Int32
 ```
 
 Shifts the bits of the value right by the given number of bits, preserving the sign bit.
@@ -417,7 +417,7 @@ No other changes yet.
 </details>
 
 ```grain
-eq : (x: Int32, y: Int32) -> Bool
+eq : (x: Int32, y: Int32) => Bool
 ```
 
 Checks if the first value is equal to the second value.
@@ -443,7 +443,7 @@ No other changes yet.
 </details>
 
 ```grain
-ne : (x: Int32, y: Int32) -> Bool
+ne : (x: Int32, y: Int32) => Bool
 ```
 
 Checks if the first value is not equal to the second value.
@@ -469,7 +469,7 @@ No other changes yet.
 </details>
 
 ```grain
-eqz : (value: Int32) -> Bool
+eqz : (value: Int32) => Bool
 ```
 
 Checks if the given value is equal to zero.
@@ -494,7 +494,7 @@ No other changes yet.
 </details>
 
 ```grain
-lt : (x: Int32, y: Int32) -> Bool
+lt : (x: Int32, y: Int32) => Bool
 ```
 
 Checks if the first value is less than the second value.
@@ -520,7 +520,7 @@ No other changes yet.
 </details>
 
 ```grain
-gt : (x: Int32, y: Int32) -> Bool
+gt : (x: Int32, y: Int32) => Bool
 ```
 
 Checks if the first value is greater than the second value.
@@ -546,7 +546,7 @@ No other changes yet.
 </details>
 
 ```grain
-lte : (x: Int32, y: Int32) -> Bool
+lte : (x: Int32, y: Int32) => Bool
 ```
 
 Checks if the first value is less than or equal to the second value.
@@ -572,7 +572,7 @@ No other changes yet.
 </details>
 
 ```grain
-gte : (x: Int32, y: Int32) -> Bool
+gte : (x: Int32, y: Int32) => Bool
 ```
 
 Checks if the first value is greater than or equal to the second value.
@@ -598,7 +598,7 @@ No other changes yet.
 </details>
 
 ```grain
-lnot : (value: Int32) -> Int32
+lnot : (value: Int32) => Int32
 ```
 
 Computes the bitwise NOT of the given value.
@@ -623,7 +623,7 @@ No other changes yet.
 </details>
 
 ```grain
-land : (x: Int32, y: Int32) -> Int32
+land : (x: Int32, y: Int32) => Int32
 ```
 
 Computes the bitwise AND (`&`) on the given operands.
@@ -649,7 +649,7 @@ No other changes yet.
 </details>
 
 ```grain
-lor : (x: Int32, y: Int32) -> Int32
+lor : (x: Int32, y: Int32) => Int32
 ```
 
 Computes the bitwise OR (`|`) on the given operands.
@@ -675,7 +675,7 @@ No other changes yet.
 </details>
 
 ```grain
-lxor : (x: Int32, y: Int32) -> Int32
+lxor : (x: Int32, y: Int32) => Int32
 ```
 
 Computes the bitwise XOR (`^`) on the given operands.
@@ -701,7 +701,7 @@ No other changes yet.
 </details>
 
 ```grain
-clz : (value: Int32) -> Int32
+clz : (value: Int32) => Int32
 ```
 
 Counts the number of leading zero bits in the value.
@@ -726,7 +726,7 @@ No other changes yet.
 </details>
 
 ```grain
-ctz : (value: Int32) -> Int32
+ctz : (value: Int32) => Int32
 ```
 
 Counts the number of trailing zero bits in the value.
@@ -751,7 +751,7 @@ No other changes yet.
 </details>
 
 ```grain
-popcnt : (value: Int32) -> Int32
+popcnt : (value: Int32) => Int32
 ```
 
 Counts the number of bits set to `1` in the value, also known as a population count.

--- a/stdlib/int64.md
+++ b/stdlib/int64.md
@@ -25,7 +25,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromNumber : (x: Number) -> Int64
+fromNumber : (x: Number) => Int64
 ```
 
 Converts a Number to an Int64.
@@ -50,7 +50,7 @@ No other changes yet.
 </details>
 
 ```grain
-toNumber : (x: Int64) -> Number
+toNumber : (x: Int64) => Number
 ```
 
 Converts an Int64 to a Number.
@@ -75,7 +75,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromUint64 : (x: Uint64) -> Int64
+fromUint64 : (x: Uint64) => Int64
 ```
 
 Converts a Uint64 to an Int64.
@@ -100,7 +100,7 @@ No other changes yet.
 </details>
 
 ```grain
-incr : (value: Int64) -> Int64
+incr : (value: Int64) => Int64
 ```
 
 Increments the value by one.
@@ -125,7 +125,7 @@ No other changes yet.
 </details>
 
 ```grain
-decr : (value: Int64) -> Int64
+decr : (value: Int64) => Int64
 ```
 
 Decrements the value by one.
@@ -150,7 +150,7 @@ No other changes yet.
 </details>
 
 ```grain
-add : (x: Int64, y: Int64) -> Int64
+add : (x: Int64, y: Int64) => Int64
 ```
 
 Computes the sum of its operands.
@@ -176,7 +176,7 @@ No other changes yet.
 </details>
 
 ```grain
-sub : (x: Int64, y: Int64) -> Int64
+sub : (x: Int64, y: Int64) => Int64
 ```
 
 Computes the difference of its operands.
@@ -202,7 +202,7 @@ No other changes yet.
 </details>
 
 ```grain
-mul : (x: Int64, y: Int64) -> Int64
+mul : (x: Int64, y: Int64) => Int64
 ```
 
 Computes the product of its operands.
@@ -228,7 +228,7 @@ No other changes yet.
 </details>
 
 ```grain
-div : (x: Int64, y: Int64) -> Int64
+div : (x: Int64, y: Int64) => Int64
 ```
 
 Computes the quotient of its operands using signed division.
@@ -254,7 +254,7 @@ No other changes yet.
 </details>
 
 ```grain
-rem : (x: Int64, y: Int64) -> Int64
+rem : (x: Int64, y: Int64) => Int64
 ```
 
 Computes the remainder of the division of its operands using signed division.
@@ -280,7 +280,7 @@ No other changes yet.
 </details>
 
 ```grain
-mod : (x: Int64, y: Int64) -> Int64
+mod : (x: Int64, y: Int64) => Int64
 ```
 
 Computes the remainder of the division of the first operand by the second.
@@ -313,7 +313,7 @@ No other changes yet.
 </details>
 
 ```grain
-rotl : (value: Int64, amount: Int64) -> Int64
+rotl : (value: Int64, amount: Int64) => Int64
 ```
 
 Rotates the bits of the value left by the given number of bits.
@@ -339,7 +339,7 @@ No other changes yet.
 </details>
 
 ```grain
-rotr : (value: Int64, amount: Int64) -> Int64
+rotr : (value: Int64, amount: Int64) => Int64
 ```
 
 Rotates the bits of the value right by the given number of bits.
@@ -365,7 +365,7 @@ No other changes yet.
 </details>
 
 ```grain
-shl : (value: Int64, amount: Int64) -> Int64
+shl : (value: Int64, amount: Int64) => Int64
 ```
 
 Shifts the bits of the value left by the given number of bits.
@@ -391,7 +391,7 @@ No other changes yet.
 </details>
 
 ```grain
-shr : (value: Int64, amount: Int64) -> Int64
+shr : (value: Int64, amount: Int64) => Int64
 ```
 
 Shifts the bits of the value right by the given number of bits, preserving the sign bit.
@@ -417,7 +417,7 @@ No other changes yet.
 </details>
 
 ```grain
-eq : (x: Int64, y: Int64) -> Bool
+eq : (x: Int64, y: Int64) => Bool
 ```
 
 Checks if the first value is equal to the second value.
@@ -443,7 +443,7 @@ No other changes yet.
 </details>
 
 ```grain
-ne : (x: Int64, y: Int64) -> Bool
+ne : (x: Int64, y: Int64) => Bool
 ```
 
 Checks if the first value is not equal to the second value.
@@ -469,7 +469,7 @@ No other changes yet.
 </details>
 
 ```grain
-eqz : (value: Int64) -> Bool
+eqz : (value: Int64) => Bool
 ```
 
 Checks if the given value is equal to zero.
@@ -494,7 +494,7 @@ No other changes yet.
 </details>
 
 ```grain
-lt : (x: Int64, y: Int64) -> Bool
+lt : (x: Int64, y: Int64) => Bool
 ```
 
 Checks if the first value is less than the second value.
@@ -520,7 +520,7 @@ No other changes yet.
 </details>
 
 ```grain
-gt : (x: Int64, y: Int64) -> Bool
+gt : (x: Int64, y: Int64) => Bool
 ```
 
 Checks if the first value is greater than the second value.
@@ -546,7 +546,7 @@ No other changes yet.
 </details>
 
 ```grain
-lte : (x: Int64, y: Int64) -> Bool
+lte : (x: Int64, y: Int64) => Bool
 ```
 
 Checks if the first value is less than or equal to the second value.
@@ -572,7 +572,7 @@ No other changes yet.
 </details>
 
 ```grain
-gte : (x: Int64, y: Int64) -> Bool
+gte : (x: Int64, y: Int64) => Bool
 ```
 
 Checks if the first value is greater than or equal to the second value.
@@ -598,7 +598,7 @@ No other changes yet.
 </details>
 
 ```grain
-lnot : (value: Int64) -> Int64
+lnot : (value: Int64) => Int64
 ```
 
 Computes the bitwise NOT of the given value.
@@ -623,7 +623,7 @@ No other changes yet.
 </details>
 
 ```grain
-land : (x: Int64, y: Int64) -> Int64
+land : (x: Int64, y: Int64) => Int64
 ```
 
 Computes the bitwise AND (`&`) on the given operands.
@@ -649,7 +649,7 @@ No other changes yet.
 </details>
 
 ```grain
-lor : (x: Int64, y: Int64) -> Int64
+lor : (x: Int64, y: Int64) => Int64
 ```
 
 Computes the bitwise OR (`|`) on the given operands.
@@ -675,7 +675,7 @@ No other changes yet.
 </details>
 
 ```grain
-lxor : (x: Int64, y: Int64) -> Int64
+lxor : (x: Int64, y: Int64) => Int64
 ```
 
 Computes the bitwise XOR (`^`) on the given operands.
@@ -701,7 +701,7 @@ No other changes yet.
 </details>
 
 ```grain
-clz : (value: Int64) -> Int64
+clz : (value: Int64) => Int64
 ```
 
 Counts the number of leading zero bits in the value.
@@ -726,7 +726,7 @@ No other changes yet.
 </details>
 
 ```grain
-ctz : (value: Int64) -> Int64
+ctz : (value: Int64) => Int64
 ```
 
 Counts the number of trailing zero bits in the value.
@@ -751,7 +751,7 @@ No other changes yet.
 </details>
 
 ```grain
-popcnt : (value: Int64) -> Int64
+popcnt : (value: Int64) => Int64
 ```
 
 Counts the number of bits set to `1` in the value, also known as a population count.

--- a/stdlib/int8.md
+++ b/stdlib/int8.md
@@ -25,7 +25,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromNumber : (number: Number) -> Int8
+fromNumber : (number: Number) => Int8
 ```
 
 Converts a Number to an Int8.
@@ -50,7 +50,7 @@ No other changes yet.
 </details>
 
 ```grain
-toNumber : (value: Int8) -> Number
+toNumber : (value: Int8) => Number
 ```
 
 Converts an Int8 to a Number.
@@ -75,7 +75,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromUint8 : (x: Uint8) -> Int8
+fromUint8 : (x: Uint8) => Int8
 ```
 
 Converts a Uint8 to an Int8.
@@ -100,7 +100,7 @@ No other changes yet.
 </details>
 
 ```grain
-incr : (value: Int8) -> Int8
+incr : (value: Int8) => Int8
 ```
 
 Increments the value by one.
@@ -125,7 +125,7 @@ No other changes yet.
 </details>
 
 ```grain
-decr : (value: Int8) -> Int8
+decr : (value: Int8) => Int8
 ```
 
 Decrements the value by one.
@@ -150,7 +150,7 @@ No other changes yet.
 </details>
 
 ```grain
-(+) : (x: Int8, y: Int8) -> Int8
+(+) : (x: Int8, y: Int8) => Int8
 ```
 
 Computes the sum of its operands.
@@ -176,7 +176,7 @@ No other changes yet.
 </details>
 
 ```grain
-(-) : (x: Int8, y: Int8) -> Int8
+(-) : (x: Int8, y: Int8) => Int8
 ```
 
 Computes the difference of its operands.
@@ -202,7 +202,7 @@ No other changes yet.
 </details>
 
 ```grain
-(*) : (x: Int8, y: Int8) -> Int8
+(*) : (x: Int8, y: Int8) => Int8
 ```
 
 Computes the product of its operands.
@@ -228,7 +228,7 @@ No other changes yet.
 </details>
 
 ```grain
-(/) : (x: Int8, y: Int8) -> Int8
+(/) : (x: Int8, y: Int8) => Int8
 ```
 
 Computes the quotient of its operands using signed division.
@@ -254,7 +254,7 @@ No other changes yet.
 </details>
 
 ```grain
-rem : (x: Int8, y: Int8) -> Int8
+rem : (x: Int8, y: Int8) => Int8
 ```
 
 Computes the remainder of the division of its operands using signed division.
@@ -280,7 +280,7 @@ No other changes yet.
 </details>
 
 ```grain
-(%) : (x: Int8, y: Int8) -> Int8
+(%) : (x: Int8, y: Int8) => Int8
 ```
 
 Computes the remainder of the division of the first operand by the second.
@@ -313,7 +313,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<<) : (value: Int8, amount: Int8) -> Int8
+(<<) : (value: Int8, amount: Int8) => Int8
 ```
 
 Shifts the bits of the value left by the given number of bits.
@@ -339,7 +339,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>>) : (value: Int8, amount: Int8) -> Int8
+(>>) : (value: Int8, amount: Int8) => Int8
 ```
 
 Shifts the bits of the value right by the given number of bits, preserving the sign bit.
@@ -365,7 +365,7 @@ No other changes yet.
 </details>
 
 ```grain
-(==) : (x: Int8, y: Int8) -> Bool
+(==) : (x: Int8, y: Int8) => Bool
 ```
 
 Checks if the first value is equal to the second value.
@@ -391,7 +391,7 @@ No other changes yet.
 </details>
 
 ```grain
-(!=) : (x: Int8, y: Int8) -> Bool
+(!=) : (x: Int8, y: Int8) => Bool
 ```
 
 Checks if the first value is not equal to the second value.
@@ -417,7 +417,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<) : (x: Int8, y: Int8) -> Bool
+(<) : (x: Int8, y: Int8) => Bool
 ```
 
 Checks if the first value is less than the second value.
@@ -443,7 +443,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>) : (x: Int8, y: Int8) -> Bool
+(>) : (x: Int8, y: Int8) => Bool
 ```
 
 Checks if the first value is greater than the second value.
@@ -469,7 +469,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<=) : (x: Int8, y: Int8) -> Bool
+(<=) : (x: Int8, y: Int8) => Bool
 ```
 
 Checks if the first value is less than or equal to the second value.
@@ -495,7 +495,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>=) : (x: Int8, y: Int8) -> Bool
+(>=) : (x: Int8, y: Int8) => Bool
 ```
 
 Checks if the first value is greater than or equal to the second value.
@@ -521,7 +521,7 @@ No other changes yet.
 </details>
 
 ```grain
-lnot : (value: Int8) -> Int8
+lnot : (value: Int8) => Int8
 ```
 
 Computes the bitwise NOT of the given value.
@@ -546,7 +546,7 @@ No other changes yet.
 </details>
 
 ```grain
-(&) : (x: Int8, y: Int8) -> Int8
+(&) : (x: Int8, y: Int8) => Int8
 ```
 
 Computes the bitwise AND (`&`) on the given operands.
@@ -572,7 +572,7 @@ No other changes yet.
 </details>
 
 ```grain
-(|) : (x: Int8, y: Int8) -> Int8
+(|) : (x: Int8, y: Int8) => Int8
 ```
 
 Computes the bitwise OR (`|`) on the given operands.
@@ -598,7 +598,7 @@ No other changes yet.
 </details>
 
 ```grain
-(^) : (x: Int8, y: Int8) -> Int8
+(^) : (x: Int8, y: Int8) => Int8
 ```
 
 Computes the bitwise XOR (`^`) on the given operands.

--- a/stdlib/list.md
+++ b/stdlib/list.md
@@ -33,7 +33,7 @@ No other changes yet.
 </details>
 
 ```grain
-init : (length: Number, fn: (Number -> a)) -> List<a>
+init : (length: Number, fn: (Number => a)) => List<a>
 ```
 
 Creates a new list of the specified length where each element is
@@ -45,7 +45,7 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`length`|`Number`|The length of the new list|
-|`fn`|`Number -> a`|The initializer function to call with each index, where the value returned will be used to initialize the element|
+|`fn`|`Number => a`|The initializer function to call with each index, where the value returned will be used to initialize the element|
 
 Returns:
 
@@ -74,7 +74,7 @@ List.init(5, n => n + 3) // [3, 4, 5, 6, 7]
 </details>
 
 ```grain
-length : (list: List<a>) -> Number
+length : (list: List<a>) => Number
 ```
 
 Computes the length of the input list.
@@ -99,7 +99,7 @@ No other changes yet.
 </details>
 
 ```grain
-reverse : (list: List<a>) -> List<a>
+reverse : (list: List<a>) => List<a>
 ```
 
 Creates a new list with all elements in reverse order.
@@ -124,7 +124,7 @@ No other changes yet.
 </details>
 
 ```grain
-append : (list1: List<a>, list2: List<a>) -> List<a>
+append : (list1: List<a>, list2: List<a>) => List<a>
 ```
 
 Creates a new list with the elements of the first list followed by
@@ -151,7 +151,7 @@ No other changes yet.
 </details>
 
 ```grain
-contains : (search: a, list: List<a>) -> Bool
+contains : (search: a, list: List<a>) => Bool
 ```
 
 Checks if the value is an element of the input list.
@@ -186,7 +186,7 @@ Returns:
 </details>
 
 ```grain
-reduce : (fn: ((a, b) -> a), initial: a, list: List<b>) -> a
+reduce : (fn: ((a, b) => a), initial: a, list: List<b>) => a
 ```
 
 Combines all elements of a list using a reducer function,
@@ -201,7 +201,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`(a, b) -> a`|The reducer function to call on each element, where the value returned will be the next accumulator value|
+|`fn`|`(a, b) => a`|The reducer function to call on each element, where the value returned will be the next accumulator value|
 |`initial`|`a`|The initial value to use for the accumulator on the first iteration|
 |`list`|`List<b>`|The list to iterate|
 
@@ -233,7 +233,7 @@ List.reduce((a, b) => a + b, 0, [1, 2, 3]) // 6
 </details>
 
 ```grain
-reduceRight : (fn: ((a, b) -> b), initial: b, list: List<a>) -> b
+reduceRight : (fn: ((a, b) => b), initial: b, list: List<a>) => b
 ```
 
 Combines all elements of a list using a reducer function,
@@ -248,7 +248,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`(a, b) -> b`|The reducer function to call on each element, where the value returned will be the next accumulator value|
+|`fn`|`(a, b) => b`|The reducer function to call on each element, where the value returned will be the next accumulator value|
 |`initial`|`b`|The initial value to use for the accumulator on the first iteration|
 |`list`|`List<a>`|The list to iterate|
 
@@ -272,7 +272,7 @@ No other changes yet.
 </details>
 
 ```grain
-map : (fn: (a -> b), list: List<a>) -> List<b>
+map : (fn: (a => b), list: List<a>) => List<b>
 ```
 
 Produces a new list initialized with the results of a mapper function
@@ -282,7 +282,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> b`|The mapper function to call on each element, where the value returned will be used to initialize the element in the new list|
+|`fn`|`a => b`|The mapper function to call on each element, where the value returned will be used to initialize the element in the new list|
 |`list`|`List<a>`|The list to iterate|
 
 Returns:
@@ -299,7 +299,7 @@ No other changes yet.
 </details>
 
 ```grain
-mapi : (fn: ((a, Number) -> b), list: List<a>) -> List<b>
+mapi : (fn: ((a, Number) => b), list: List<a>) => List<b>
 ```
 
 Produces a new list initialized with the results of a mapper function
@@ -309,7 +309,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`(a, Number) -> b`|The mapper function to call on each element, where the value returned will be used to initialize the element in the new list|
+|`fn`|`(a, Number) => b`|The mapper function to call on each element, where the value returned will be used to initialize the element in the new list|
 |`list`|`List<a>`|The list to iterate|
 
 Returns:
@@ -326,7 +326,7 @@ No other changes yet.
 </details>
 
 ```grain
-flatMap : (fn: (a -> List<b>), list: List<a>) -> List<b>
+flatMap : (fn: (a => List<b>), list: List<a>) => List<b>
 ```
 
 Produces a new list by calling a function on each element
@@ -338,7 +338,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> List<b>`|The function to be called on each element, where the value returned will be a list that gets appended to the new list|
+|`fn`|`a => List<b>`|The function to be called on each element, where the value returned will be a list that gets appended to the new list|
 |`list`|`List<a>`|The list to iterate|
 
 Returns:
@@ -355,7 +355,7 @@ No other changes yet.
 </details>
 
 ```grain
-every : (fn: (a -> Bool), list: List<a>) -> Bool
+every : (fn: (a => Bool), list: List<a>) => Bool
 ```
 
 Checks that the given condition is satisfied for all
@@ -365,7 +365,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`fn`|`a => Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
 |`list`|`List<a>`|The list to check|
 
 Returns:
@@ -382,7 +382,7 @@ No other changes yet.
 </details>
 
 ```grain
-some : (fn: (a -> Bool), list: List<a>) -> Bool
+some : (fn: (a => Bool), list: List<a>) => Bool
 ```
 
 Checks that the given condition is satisfied **at least
@@ -392,7 +392,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`fn`|`a => Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
 |`list`|`List<a>`|The list to iterate|
 
 Returns:
@@ -409,7 +409,7 @@ No other changes yet.
 </details>
 
 ```grain
-forEach : (fn: (a -> Void), list: List<a>) -> Void
+forEach : (fn: (a => Void), list: List<a>) => Void
 ```
 
 Iterates a list, calling an iterator function on each element.
@@ -418,7 +418,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Void`|The iterator function to call with each element|
+|`fn`|`a => Void`|The iterator function to call with each element|
 |`list`|`List<a>`|The list to iterate|
 
 ### List.**forEachi**
@@ -429,7 +429,7 @@ No other changes yet.
 </details>
 
 ```grain
-forEachi : (fn: ((a, Number) -> Void), list: List<a>) -> Void
+forEachi : (fn: ((a, Number) => Void), list: List<a>) => Void
 ```
 
 Iterates a list, calling an iterator function on each element.
@@ -439,7 +439,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`(a, Number) -> Void`|The iterator function to call with each element|
+|`fn`|`(a, Number) => Void`|The iterator function to call with each element|
 |`list`|`List<a>`|The list to iterate|
 
 ### List.**filter**
@@ -450,7 +450,7 @@ No other changes yet.
 </details>
 
 ```grain
-filter : (fn: (a -> Bool), list: List<a>) -> List<a>
+filter : (fn: (a => Bool), list: List<a>) => List<a>
 ```
 
 Produces a new list by calling a function on each element of
@@ -461,7 +461,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`fn`|`a => Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
 |`list`|`List<a>`|The list to iterate|
 
 Returns:
@@ -478,7 +478,7 @@ No other changes yet.
 </details>
 
 ```grain
-filteri : (fn: ((a, Number) -> Bool), list: List<a>) -> List<a>
+filteri : (fn: ((a, Number) => Bool), list: List<a>) => List<a>
 ```
 
 Produces a new list by calling a function on each element of
@@ -489,7 +489,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`(a, Number) -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`fn`|`(a, Number) => Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
 |`list`|`List<a>`|The list to iterate|
 
 Returns:
@@ -506,7 +506,7 @@ No other changes yet.
 </details>
 
 ```grain
-reject : (fn: (a -> Bool), list: List<a>) -> List<a>
+reject : (fn: (a => Bool), list: List<a>) => List<a>
 ```
 
 Produces a new list by calling a function on each element of
@@ -517,7 +517,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`fn`|`a => Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
 |`list`|`List<a>`|The list to iterate|
 
 Returns:
@@ -543,7 +543,7 @@ Returns:
 </details>
 
 ```grain
-head : (list: List<a>) -> Option<a>
+head : (list: List<a>) => Option<a>
 ```
 
 Provides `Some(element)` containing the first element, or "head", of
@@ -578,7 +578,7 @@ Returns:
 </details>
 
 ```grain
-tail : (list: List<a>) -> Option<List<a>>
+tail : (list: List<a>) => Option<List<a>>
 ```
 
 Provides `Some(tail)` containing all list items except the first element, or "tail", of
@@ -612,7 +612,7 @@ Returns:
 </details>
 
 ```grain
-nth : (index: Number, list: List<a>) -> Option<a>
+nth : (index: Number, list: List<a>) => Option<a>
 ```
 
 Provides `Some(element)` containing the element in the list at the specified index
@@ -639,7 +639,7 @@ No other changes yet.
 </details>
 
 ```grain
-flatten : (list: List<List<a>>) -> List<a>
+flatten : (list: List<List<a>>) => List<a>
 ```
 
 Flattens nested lists.
@@ -670,7 +670,7 @@ No other changes yet.
 </details>
 
 ```grain
-insert : (value: a, index: Number, list: List<a>) -> List<a>
+insert : (value: a, index: Number, list: List<a>) => List<a>
 ```
 
 Inserts a new value into a list at the specified index.
@@ -711,7 +711,7 @@ Throws:
 </details>
 
 ```grain
-count : (fn: (a -> Bool), list: List<a>) -> Number
+count : (fn: (a => Bool), list: List<a>) => Number
 ```
 
 Counts the number of elements in a list that satisfy the given condition.
@@ -720,7 +720,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`fn`|`a => Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
 |`list`|`List<a>`|The list to iterate|
 
 Returns:
@@ -737,7 +737,7 @@ No other changes yet.
 </details>
 
 ```grain
-part : (count: Number, list: List<a>) -> (List<a>, List<a>)
+part : (count: Number, list: List<a>) => (List<a>, List<a>)
 ```
 
 Split a list into two, with the first list containing the required number of elements.
@@ -777,7 +777,7 @@ Throws:
 </details>
 
 ```grain
-rotate : (count: Number, list: List<a>) -> List<a>
+rotate : (count: Number, list: List<a>) => List<a>
 ```
 
 Rotates list elements by the specified amount to the left, such that `n`th
@@ -823,7 +823,7 @@ List.rotate(-7, [1, 2, 3, 4, 5]) // [4, 5, 1, 2, 3]
 </details>
 
 ```grain
-unique : (list: List<a>) -> List<a>
+unique : (list: List<a>) => List<a>
 ```
 
 Produces a new list with any duplicates removed.
@@ -849,7 +849,7 @@ No other changes yet.
 </details>
 
 ```grain
-zip : (list1: List<a>, list2: List<b>) -> List<(a, b)>
+zip : (list1: List<a>, list2: List<b>) => List<(a, b)>
 ```
 
 Produces a new list filled with tuples of elements from both given lists.
@@ -890,7 +890,7 @@ No other changes yet.
 </details>
 
 ```grain
-zipWith : (fn: ((a, b) -> c), list1: List<a>, list2: List<b>) -> List<c>
+zipWith : (fn: ((a, b) => c), list1: List<a>, list2: List<b>) => List<c>
 ```
 
 Produces a new list filled with elements defined by applying a function on
@@ -906,7 +906,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`(a, b) -> c`|The function to apply to pairs of elements|
+|`fn`|`(a, b) => c`|The function to apply to pairs of elements|
 |`list1`|`List<a>`|The list whose elements will each be passed to the function as the first argument|
 |`list2`|`List<b>`|The list whose elements will each be passed to the function as the second argument|
 
@@ -934,7 +934,7 @@ No other changes yet.
 </details>
 
 ```grain
-unzip : (list: List<(a, b)>) -> (List<a>, List<b>)
+unzip : (list: List<(a, b)>) => (List<a>, List<b>)
 ```
 
 Produces two lists by splitting apart a list of tuples.
@@ -959,7 +959,7 @@ No other changes yet.
 </details>
 
 ```grain
-drop : (count: Number, list: List<a>) -> List<a>
+drop : (count: Number, list: List<a>) => List<a>
 ```
 
 Produces a new list with the specified number of elements removed from
@@ -992,7 +992,7 @@ No other changes yet.
 </details>
 
 ```grain
-dropWhile : (fn: (a -> Bool), list: List<a>) -> List<a>
+dropWhile : (fn: (a => Bool), list: List<a>) => List<a>
 ```
 
 Produces a new list with the elements removed from the beginning
@@ -1003,7 +1003,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`fn`|`a => Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
 |`list`|`List<a>`|The input list|
 
 Returns:
@@ -1020,7 +1020,7 @@ No other changes yet.
 </details>
 
 ```grain
-take : (count: Number, list: List<a>) -> List<a>
+take : (count: Number, list: List<a>) => List<a>
 ```
 
 Produces a new list with–at most—the specified amount elements from
@@ -1053,7 +1053,7 @@ No other changes yet.
 </details>
 
 ```grain
-takeWhile : (fn: (a -> Bool), list: List<a>) -> List<a>
+takeWhile : (fn: (a => Bool), list: List<a>) => List<a>
 ```
 
 Produces a new list with elements from the beginning of the input list
@@ -1064,7 +1064,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`fn`|`a => Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
 |`list`|`List<a>`|The input list|
 
 Returns:
@@ -1089,7 +1089,7 @@ Returns:
 </details>
 
 ```grain
-find : (fn: (a -> Bool), list: List<a>) -> Option<a>
+find : (fn: (a => Bool), list: List<a>) => Option<a>
 ```
 
 Finds the first element in a list that satifies the given condition.
@@ -1098,7 +1098,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`fn`|`a => Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
 |`list`|`List<a>`|The list to search|
 
 Returns:
@@ -1123,7 +1123,7 @@ Returns:
 </details>
 
 ```grain
-findIndex : (fn: (a -> Bool), list: List<a>) -> Option<Number>
+findIndex : (fn: (a => Bool), list: List<a>) => Option<Number>
 ```
 
 Finds the first index in a list where the element satifies the given condition.
@@ -1132,7 +1132,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
+|`fn`|`a => Bool`|The function to call on each element, where the returned value indicates if the element satisfies the condition|
 |`list`|`List<a>`|The list to search|
 
 Returns:
@@ -1149,7 +1149,7 @@ No other changes yet.
 </details>
 
 ```grain
-product : (list1: List<a>, list2: List<b>) -> List<(a, b)>
+product : (list1: List<a>, list2: List<b>) => List<(a, b)>
 ```
 
 Combines two lists into a Cartesian product of tuples containing
@@ -1176,7 +1176,7 @@ No other changes yet.
 </details>
 
 ```grain
-sub : (start: Number, length: Number, list: List<a>) -> List<a>
+sub : (start: Number, length: Number, list: List<a>) => List<a>
 ```
 
 Provides the subset of a list given zero-based start index and amount of elements
@@ -1211,7 +1211,7 @@ No other changes yet.
 </details>
 
 ```grain
-join : (separator: String, list: List<String>) -> String
+join : (separator: String, list: List<String>) => String
 ```
 
 Combine the given list of strings into one string with the specified
@@ -1238,7 +1238,7 @@ No other changes yet.
 </details>
 
 ```grain
-revAppend : (list1: List<a>, list2: List<a>) -> List<a>
+revAppend : (list1: List<a>, list2: List<a>) => List<a>
 ```
 
 Reverses the first list and appends the second list to the end.
@@ -1264,7 +1264,7 @@ No other changes yet.
 </details>
 
 ```grain
-sort : (comp: ((a, a) -> Number), list: List<a>) -> List<a>
+sort : (comp: ((a, a) => Number), list: List<a>) => List<a>
 ```
 
 Sorts the given list based on a given comparator function. The resulting list is sorted in increasing order.
@@ -1275,7 +1275,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`comp`|`(a, a) -> Number`|The comparator function used to indicate sort order|
+|`comp`|`(a, a) => Number`|The comparator function used to indicate sort order|
 |`list`|`List<a>`|The list to be sorted|
 
 Returns:

--- a/stdlib/map.gr
+++ b/stdlib/map.gr
@@ -427,7 +427,7 @@ provide let fromList = list => {
  * @since v0.2.0
  */
 @unsafe
-provide let toArray: Map<a, b> -> Array<(a, b)> = map => {
+provide let toArray: Map<a, b> => Array<(a, b)> = map => {
   from WasmI32 use { (*) }
   let length = untagSimpleNumber(map.size)
   let array = WasmI32.toGrain(allocateArray(length))

--- a/stdlib/map.md
+++ b/stdlib/map.md
@@ -37,7 +37,7 @@ No other changes yet.
 </details>
 
 ```grain
-makeSized : (size: Number) -> Map<a, b>
+makeSized : (size: Number) => Map<a, b>
 ```
 
 Creates a new empty map with an initial storage of the given size. As values are added or removed, the internal storage may grow or shrink. Generally, you won't need to care about the storage size of your map and can use `Map.make()` instead.
@@ -62,7 +62,7 @@ No other changes yet.
 </details>
 
 ```grain
-make : () -> Map<a, b>
+make : () => Map<a, b>
 ```
 
 Creates a new, empty map.
@@ -81,7 +81,7 @@ No other changes yet.
 </details>
 
 ```grain
-set : (key: a, value: b, map: Map<a, b>) -> Void
+set : (key: a, value: b, map: Map<a, b>) => Void
 ```
 
 Adds a new key-value pair to the map. If the key already exists in the map, the value is replaced.
@@ -102,7 +102,7 @@ No other changes yet.
 </details>
 
 ```grain
-get : (key: a, map: Map<a, b>) -> Option<b>
+get : (key: a, map: Map<a, b>) => Option<b>
 ```
 
 Retrieves the value for the given key.
@@ -128,7 +128,7 @@ No other changes yet.
 </details>
 
 ```grain
-contains : (key: a, map: Map<a, b>) -> Bool
+contains : (key: a, map: Map<a, b>) => Bool
 ```
 
 Determines if the map contains the given key. In such a case, it will always contain a value for the given key.
@@ -154,7 +154,7 @@ No other changes yet.
 </details>
 
 ```grain
-remove : (key: a, map: Map<a, b>) -> Void
+remove : (key: a, map: Map<a, b>) => Void
 ```
 
 Removes the given key from the map, which also removes the value. If the key pair doesn't exist, nothing happens.
@@ -174,7 +174,7 @@ No other changes yet.
 </details>
 
 ```grain
-update : (key: a, fn: (Option<b> -> Option<b>), map: Map<a, b>) -> Void
+update : (key: a, fn: (Option<b> => Option<b>), map: Map<a, b>) => Void
 ```
 
 Updates a value in the map by calling an updater function that receives the previously stored value as an `Option` and returns the new value to be stored as an `Option`. If the key didn't exist previously, the value will be `None`. If `None` is returned from the updater function, the key-value pair is removed.
@@ -184,7 +184,7 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`key`|`a`|The unique key in the map|
-|`fn`|`Option<b> -> Option<b>`|The updater function|
+|`fn`|`Option<b> => Option<b>`|The updater function|
 |`map`|`Map<a, b>`|The map to modify|
 
 ### Map.**size**
@@ -195,7 +195,7 @@ No other changes yet.
 </details>
 
 ```grain
-size : (map: Map<a, b>) -> Number
+size : (map: Map<a, b>) => Number
 ```
 
 Provides the count of key-value pairs stored within the map.
@@ -220,7 +220,7 @@ No other changes yet.
 </details>
 
 ```grain
-isEmpty : (map: Map<a, b>) -> Bool
+isEmpty : (map: Map<a, b>) => Bool
 ```
 
 Determines if the map contains no key-value pairs.
@@ -245,7 +245,7 @@ No other changes yet.
 </details>
 
 ```grain
-clear : (map: Map<a, b>) -> Void
+clear : (map: Map<a, b>) => Void
 ```
 
 Resets the map by removing all key-value pairs.
@@ -271,7 +271,7 @@ Parameters:
 </details>
 
 ```grain
-forEach : (fn: ((a, b) -> Void), map: Map<a, b>) -> Void
+forEach : (fn: ((a, b) => Void), map: Map<a, b>) => Void
 ```
 
 Iterates the map, calling an iterator function with each key and value.
@@ -280,7 +280,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`(a, b) -> Void`|The iterator function to call with each key and value|
+|`fn`|`(a, b) => Void`|The iterator function to call with each key and value|
 |`map`|`Map<a, b>`|The map to iterate|
 
 ### Map.**reduce**
@@ -291,7 +291,7 @@ No other changes yet.
 </details>
 
 ```grain
-reduce : (fn: ((a, b, c) -> a), init: a, map: Map<b, c>) -> a
+reduce : (fn: ((a, b, c) => a), init: a, map: Map<b, c>) => a
 ```
 
 Combines all key-value pairs of a map using a reducer function.
@@ -300,7 +300,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`(a, b, c) -> a`|The reducer function to call on each key and value, where the value returned will be the next accumulator value|
+|`fn`|`(a, b, c) => a`|The reducer function to call on each key and value, where the value returned will be the next accumulator value|
 |`init`|`a`|The initial value to use for the accumulator on the first iteration|
 |`map`|`Map<b, c>`|The map to iterate|
 
@@ -318,7 +318,7 @@ No other changes yet.
 </details>
 
 ```grain
-keys : (map: Map<a, b>) -> List<a>
+keys : (map: Map<a, b>) => List<a>
 ```
 
 Enumerates all keys in the given map.
@@ -343,7 +343,7 @@ No other changes yet.
 </details>
 
 ```grain
-values : (map: Map<a, b>) -> List<b>
+values : (map: Map<a, b>) => List<b>
 ```
 
 Enumerates all values in the given map.
@@ -368,7 +368,7 @@ No other changes yet.
 </details>
 
 ```grain
-toList : (map: Map<a, b>) -> List<(a, b)>
+toList : (map: Map<a, b>) => List<(a, b)>
 ```
 
 Enumerates all key-value pairs in the given map.
@@ -393,7 +393,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromList : (list: List<(a, b)>) -> Map<a, b>
+fromList : (list: List<(a, b)>) => Map<a, b>
 ```
 
 Creates a map from a list.
@@ -418,7 +418,7 @@ No other changes yet.
 </details>
 
 ```grain
-toArray : Map<a, b> -> Array<(a, b)>
+toArray : Map<a, b> => Array<(a, b)>
 ```
 
 Converts a map into an array of its key-value pairs.
@@ -443,7 +443,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromArray : (array: Array<(a, b)>) -> Map<a, b>
+fromArray : (array: Array<(a, b)>) => Map<a, b>
 ```
 
 Creates a map from an array.
@@ -468,7 +468,7 @@ No other changes yet.
 </details>
 
 ```grain
-filter : (predicate: ((a, b) -> Bool), map: Map<a, b>) -> Void
+filter : (predicate: ((a, b) => Bool), map: Map<a, b>) => Void
 ```
 
 Removes key-value pairs from a map where a predicate function returns `false`.
@@ -477,7 +477,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`(a, b) -> Bool`|The predicate function to indicate which key-value pairs to remove from the map, where returning `false` indicates the key-value pair should be removed|
+|`fn`|`(a, b) => Bool`|The predicate function to indicate which key-value pairs to remove from the map, where returning `false` indicates the key-value pair should be removed|
 |`map`|`Map<a, b>`|The map to iterate|
 
 ### Map.**reject**
@@ -488,7 +488,7 @@ No other changes yet.
 </details>
 
 ```grain
-reject : (predicate: ((a, b) -> Bool), map: Map<a, b>) -> Void
+reject : (predicate: ((a, b) => Bool), map: Map<a, b>) => Void
 ```
 
 Removes key-value pairs from a map where a predicate function returns `true`.
@@ -497,7 +497,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`(a, b) -> Bool`|The predicate function to indicate which key-value pairs to remove from the map, where returning `true` indicates the key-value pair should be removed|
+|`fn`|`(a, b) => Bool`|The predicate function to indicate which key-value pairs to remove from the map, where returning `true` indicates the key-value pair should be removed|
 |`map`|`Map<a, b>`|The map to iterate|
 
 ### Map.**getInternalStats**
@@ -508,7 +508,7 @@ No other changes yet.
 </details>
 
 ```grain
-getInternalStats : (map: Map<a, b>) -> (Number, Number)
+getInternalStats : (map: Map<a, b>) => (Number, Number)
 ```
 
 Provides data representing the internal state state of the map.
@@ -590,7 +590,7 @@ An empty map
 </details>
 
 ```grain
-size : (map: Map<a, b>) -> Number
+size : (map: Map<a, b>) => Number
 ```
 
 Provides the count of key-value pairs stored within the map.
@@ -622,7 +622,7 @@ Returns:
 </details>
 
 ```grain
-isEmpty : (map: Map<a, b>) -> Bool
+isEmpty : (map: Map<a, b>) => Bool
 ```
 
 Determines if the map contains no key-value pairs.
@@ -654,7 +654,7 @@ Returns:
 </details>
 
 ```grain
-set : (key: a, val: b, map: Map<a, b>) -> Map<a, b>
+set : (key: a, val: b, map: Map<a, b>) => Map<a, b>
 ```
 
 Produces a new map containing a new key-value pair. If the key already exists in the map, the value is replaced.
@@ -688,7 +688,7 @@ Returns:
 </details>
 
 ```grain
-get : (key: a, map: Map<a, b>) -> Option<b>
+get : (key: a, map: Map<a, b>) => Option<b>
 ```
 
 Retrieves the value for the given key.
@@ -721,7 +721,7 @@ Returns:
 </details>
 
 ```grain
-contains : (key: a, map: Map<a, b>) -> Bool
+contains : (key: a, map: Map<a, b>) => Bool
 ```
 
 Determines if the map contains the given key. In such a case, it will always contain a value for the given key.
@@ -754,7 +754,7 @@ Returns:
 </details>
 
 ```grain
-remove : (key: a, map: Map<a, b>) -> Map<a, b>
+remove : (key: a, map: Map<a, b>) => Map<a, b>
 ```
 
 Produces a new map without the key-value pair corresponding to the given
@@ -788,7 +788,7 @@ Returns:
 </details>
 
 ```grain
-update : (key: a, fn: (Option<b> -> Option<b>), map: Map<a, b>) -> Map<a, b>
+update : (key: a, fn: (Option<b> => Option<b>), map: Map<a, b>) => Map<a, b>
 ```
 
 Produces a new map by calling an updater function that receives the
@@ -802,7 +802,7 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`key`|`a`|The unique key in the map|
-|`fn`|`Option<b> -> Option<b>`|The updater function|
+|`fn`|`Option<b> => Option<b>`|The updater function|
 |`map`|`Map<a, b>`|The base map|
 
 Returns:
@@ -826,7 +826,7 @@ Returns:
 </details>
 
 ```grain
-forEach : (fn: ((a, b) -> Void), map: Map<a, b>) -> Void
+forEach : (fn: ((a, b) => Void), map: Map<a, b>) => Void
 ```
 
 Iterates the map, calling an iterator function with each key and value.
@@ -835,7 +835,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`(a, b) -> Void`|The iterator function to call with each key and value|
+|`fn`|`(a, b) => Void`|The iterator function to call with each key and value|
 |`map`|`Map<a, b>`|The map to iterate|
 
 #### Map.Immutable.**reduce**
@@ -853,7 +853,7 @@ Parameters:
 </details>
 
 ```grain
-reduce : (fn: ((a, b, c) -> a), init: a, map: Map<b, c>) -> a
+reduce : (fn: ((a, b, c) => a), init: a, map: Map<b, c>) => a
 ```
 
 Combines all key-value pairs of a map using a reducer function.
@@ -862,7 +862,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`(a, b, c) -> a`|The reducer function to call on each key and value, where the value returned will be the next accumulator value|
+|`fn`|`(a, b, c) => a`|The reducer function to call on each key and value, where the value returned will be the next accumulator value|
 |`init`|`a`|The initial value to use for the accumulator on the first iteration|
 |`map`|`Map<b, c>`|The map to iterate|
 
@@ -887,7 +887,7 @@ Returns:
 </details>
 
 ```grain
-keys : (map: Map<a, b>) -> List<a>
+keys : (map: Map<a, b>) => List<a>
 ```
 
 Enumerates all keys in the given map.
@@ -919,7 +919,7 @@ Returns:
 </details>
 
 ```grain
-values : (map: Map<a, b>) -> List<b>
+values : (map: Map<a, b>) => List<b>
 ```
 
 Enumerates all values in the given map.
@@ -951,7 +951,7 @@ Returns:
 </details>
 
 ```grain
-filter : (fn: ((a, b) -> Bool), map: Map<a, b>) -> Map<a, b>
+filter : (fn: ((a, b) => Bool), map: Map<a, b>) => Map<a, b>
 ```
 
 Produces a new map excluding the key-value pairs where a predicate function returns `false`.
@@ -960,7 +960,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`(a, b) -> Bool`|The predicate function to indicate which key-value pairs to exclude from the map, where returning `false` indicates the key-value pair should be excluded|
+|`fn`|`(a, b) => Bool`|The predicate function to indicate which key-value pairs to exclude from the map, where returning `false` indicates the key-value pair should be excluded|
 |`map`|`Map<a, b>`|The map to iterate|
 
 Returns:
@@ -984,7 +984,7 @@ Returns:
 </details>
 
 ```grain
-reject : (fn: ((a, b) -> Bool), map: Map<a, b>) -> Map<a, b>
+reject : (fn: ((a, b) => Bool), map: Map<a, b>) => Map<a, b>
 ```
 
 Produces a new map excluding the key-value pairs where a predicate function returns `true`.
@@ -993,7 +993,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`(a, b) -> Bool`|The predicate function to indicate which key-value pairs to exclude from the map, where returning `true` indicates the key-value pair should be excluded|
+|`fn`|`(a, b) => Bool`|The predicate function to indicate which key-value pairs to exclude from the map, where returning `true` indicates the key-value pair should be excluded|
 |`map`|`Map<a, b>`|The map to iterate|
 
 Returns:
@@ -1017,7 +1017,7 @@ Returns:
 </details>
 
 ```grain
-fromList : (list: List<(a, b)>) -> Map<a, b>
+fromList : (list: List<(a, b)>) => Map<a, b>
 ```
 
 Creates a map from a list.
@@ -1049,7 +1049,7 @@ Returns:
 </details>
 
 ```grain
-toList : (map: Map<a, b>) -> List<(a, b)>
+toList : (map: Map<a, b>) => List<(a, b)>
 ```
 
 Enumerates all key-value pairs in the given map.
@@ -1081,7 +1081,7 @@ Returns:
 </details>
 
 ```grain
-fromArray : (array: Array<(a, b)>) -> Map<a, b>
+fromArray : (array: Array<(a, b)>) => Map<a, b>
 ```
 
 Creates a map from an array.
@@ -1113,7 +1113,7 @@ Returns:
 </details>
 
 ```grain
-toArray : (map: Map<a, b>) -> Array<(a, b)>
+toArray : (map: Map<a, b>) => Array<(a, b)>
 ```
 
 Converts a map into an array of its key-value pairs.

--- a/stdlib/marshal.md
+++ b/stdlib/marshal.md
@@ -25,7 +25,7 @@ No other changes yet.
 </details>
 
 ```grain
-marshal : (value: a) -> Bytes
+marshal : (value: a) => Bytes
 ```
 
 Serialize a value into a byte-based representation suitable for transmission
@@ -52,7 +52,7 @@ No other changes yet.
 </details>
 
 ```grain
-unmarshal : (bytes: Bytes) -> Result<a, String>
+unmarshal : (bytes: Bytes) => Result<a, String>
 ```
 
 Deserialize the byte-based representation of a value back into an in-memory

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -71,7 +71,7 @@ Euler's number represented as a Number value.
 </details>
 
 ```grain
-(+) : (x: Number, y: Number) -> Number
+(+) : (x: Number, y: Number) => Number
 ```
 
 Computes the sum of its operands.
@@ -104,7 +104,7 @@ Returns:
 </details>
 
 ```grain
-(-) : (x: Number, y: Number) -> Number
+(-) : (x: Number, y: Number) => Number
 ```
 
 Computes the difference of its operands.
@@ -137,7 +137,7 @@ Returns:
 </details>
 
 ```grain
-(*) : (x: Number, y: Number) -> Number
+(*) : (x: Number, y: Number) => Number
 ```
 
 Computes the product of its operands.
@@ -170,7 +170,7 @@ Returns:
 </details>
 
 ```grain
-(/) : (x: Number, y: Number) -> Number
+(/) : (x: Number, y: Number) => Number
 ```
 
 Computes the quotient of its operands.
@@ -203,7 +203,7 @@ Returns:
 </details>
 
 ```grain
-(**) : (base: Number, power: Number) -> Number
+(**) : (base: Number, power: Number) => Number
 ```
 
 Computes the exponentiation of the given base and power.
@@ -229,7 +229,7 @@ No other changes yet.
 </details>
 
 ```grain
-exp : (power: Number) -> Number
+exp : (power: Number) => Number
 ```
 
 Computes the exponentiation of Euler's number to the given power.
@@ -254,7 +254,7 @@ No other changes yet.
 </details>
 
 ```grain
-sqrt : (x: Number) -> Number
+sqrt : (x: Number) => Number
 ```
 
 Computes the square root of its operand.
@@ -274,7 +274,7 @@ Returns:
 ### Number.**sign**
 
 ```grain
-sign : (x: Number) -> Number
+sign : (x: Number) => Number
 ```
 
 Determine the positivity or negativity of a Number.
@@ -320,7 +320,7 @@ Number.sign(0) == 0
 </details>
 
 ```grain
-min : (x: Number, y: Number) -> Number
+min : (x: Number, y: Number) => Number
 ```
 
 Returns the smaller of its operands.
@@ -353,7 +353,7 @@ Returns:
 </details>
 
 ```grain
-max : (x: Number, y: Number) -> Number
+max : (x: Number, y: Number) => Number
 ```
 
 Returns the larger of its operands.
@@ -386,7 +386,7 @@ Returns:
 </details>
 
 ```grain
-ceil : (x: Number) -> Number
+ceil : (x: Number) => Number
 ```
 
 Rounds its operand up to the next largest integer.
@@ -418,7 +418,7 @@ Returns:
 </details>
 
 ```grain
-floor : (x: Number) -> Number
+floor : (x: Number) => Number
 ```
 
 Rounds its operand down to the largest integer less than the operand.
@@ -450,7 +450,7 @@ Returns:
 </details>
 
 ```grain
-trunc : (x: Number) -> Number
+trunc : (x: Number) => Number
 ```
 
 Returns the integer part of its operand, removing any fractional value.
@@ -482,7 +482,7 @@ Returns:
 </details>
 
 ```grain
-round : (x: Number) -> Number
+round : (x: Number) => Number
 ```
 
 Returns its operand rounded to its nearest integer.
@@ -507,7 +507,7 @@ No other changes yet.
 </details>
 
 ```grain
-abs : (x: Number) -> Number
+abs : (x: Number) => Number
 ```
 
 Returns the absolute value of a number. That is, it returns `x` if `x` is positive or zero and the negation of `x` if `x` is negative.
@@ -532,7 +532,7 @@ No other changes yet.
 </details>
 
 ```grain
-neg : (x: Number) -> Number
+neg : (x: Number) => Number
 ```
 
 Returns the negation of its operand.
@@ -557,7 +557,7 @@ No other changes yet.
 </details>
 
 ```grain
-isFloat : (x: Number) -> Bool
+isFloat : (x: Number) => Bool
 ```
 
 Checks if a number is a floating point value.
@@ -582,7 +582,7 @@ No other changes yet.
 </details>
 
 ```grain
-isInteger : (x: Number) -> Bool
+isInteger : (x: Number) => Bool
 ```
 
 Checks if a number is an integer.
@@ -607,7 +607,7 @@ No other changes yet.
 </details>
 
 ```grain
-isRational : (x: Number) -> Bool
+isRational : (x: Number) => Bool
 ```
 
 Checks if a number is a non-integer rational value.
@@ -632,7 +632,7 @@ No other changes yet.
 </details>
 
 ```grain
-isFinite : (x: Number) -> Bool
+isFinite : (x: Number) => Bool
 ```
 
 Checks if a number is finite.
@@ -658,7 +658,7 @@ No other changes yet.
 </details>
 
 ```grain
-isNaN : (x: Number) -> Bool
+isNaN : (x: Number) => Bool
 ```
 
 Checks if a number is the float NaN value (Not A Number).
@@ -683,7 +683,7 @@ No other changes yet.
 </details>
 
 ```grain
-isInfinite : (x: Number) -> Bool
+isInfinite : (x: Number) => Bool
 ```
 
 Checks if a number is infinite, that is either of floating point positive or negative infinity.
@@ -709,7 +709,7 @@ No other changes yet.
 </details>
 
 ```grain
-parseInt : (string: String, radix: Number) -> Result<Number, String>
+parseInt : (string: String, radix: Number) => Result<Number, String>
 ```
 
 Parses a string representation of an integer into a `Number` using the
@@ -741,7 +741,7 @@ No other changes yet.
 </details>
 
 ```grain
-parseFloat : (string: String) -> Result<Number, String>
+parseFloat : (string: String) => Result<Number, String>
 ```
 
 Parses a string representation of a float into a `Number`. Underscores that appear
@@ -767,7 +767,7 @@ No other changes yet.
 </details>
 
 ```grain
-parse : (input: String) -> Result<Number, String>
+parse : (input: String) => Result<Number, String>
 ```
 
 Parses a string representation of an integer, float, or rational into a `Number`.
@@ -800,7 +800,7 @@ Returns:
 </details>
 
 ```grain
-sin : (radians: Number) -> Number
+sin : (radians: Number) => Number
 ```
 
 Computes the sine of a number (in radians) using Chebyshev polynomials.
@@ -832,7 +832,7 @@ Returns:
 </details>
 
 ```grain
-cos : (radians: Number) -> Number
+cos : (radians: Number) => Number
 ```
 
 Computes the cosine of a number (in radians) using Chebyshev polynomials.
@@ -857,7 +857,7 @@ No other changes yet.
 </details>
 
 ```grain
-tan : (radians: Number) -> Number
+tan : (radians: Number) => Number
 ```
 
 Computes the tangent of a number (in radians) using Chebyshev polynomials.
@@ -882,7 +882,7 @@ No other changes yet.
 </details>
 
 ```grain
-gamma : (z: Number) -> Number
+gamma : (z: Number) => Number
 ```
 
 Computes the gamma function of a value using Lanczos approximation.
@@ -913,7 +913,7 @@ No other changes yet.
 </details>
 
 ```grain
-factorial : (n: Number) -> Number
+factorial : (n: Number) => Number
 ```
 
 Computes the product of consecutive integers for an integer input and computes the gamma function for non-integer inputs.
@@ -944,7 +944,7 @@ No other changes yet.
 </details>
 
 ```grain
-toRadians : (degrees: Number) -> Number
+toRadians : (degrees: Number) => Number
 ```
 
 Converts degrees to radians.
@@ -969,7 +969,7 @@ No other changes yet.
 </details>
 
 ```grain
-toDegrees : (radians: Number) -> Number
+toDegrees : (radians: Number) => Number
 ```
 
 Converts radians to degrees.
@@ -994,7 +994,7 @@ No other changes yet.
 </details>
 
 ```grain
-clamp : (range: Range<Number>, input: Number) -> Number
+clamp : (range: Range<Number>, input: Number) => Number
 ```
 
 Constrains a number within the given inclusive range.
@@ -1020,7 +1020,7 @@ No other changes yet.
 </details>
 
 ```grain
-linearInterpolate : (range: Range<Number>, weight: Number) -> Number
+linearInterpolate : (range: Range<Number>, weight: Number) => Number
 ```
 
 Maps a weight between 0 and 1 within the given inclusive range.
@@ -1055,7 +1055,7 @@ No other changes yet.
 
 ```grain
 linearMap :
-  (inputRange: Range<Number>, outputRange: Range<Number>, current: Number) ->
+  (inputRange: Range<Number>, outputRange: Range<Number>, current: Number) =>
    Number
 ```
 

--- a/stdlib/option.md
+++ b/stdlib/option.md
@@ -35,7 +35,7 @@ No other changes yet.
 </details>
 
 ```grain
-isSome : (option: Option<a>) -> Bool
+isSome : (option: Option<a>) => Bool
 ```
 
 Checks if the Option is the `Some` variant.
@@ -60,7 +60,7 @@ No other changes yet.
 </details>
 
 ```grain
-isNone : (option: Option<a>) -> Bool
+isNone : (option: Option<a>) => Bool
 ```
 
 Checks if the Option is the `None` variant.
@@ -85,7 +85,7 @@ No other changes yet.
 </details>
 
 ```grain
-contains : (value: a, option: Option<a>) -> Bool
+contains : (value: a, option: Option<a>) => Bool
 ```
 
 Checks if the Option is the `Some` variant and contains the given value. Uses the generic `==` equality operator.
@@ -111,7 +111,7 @@ No other changes yet.
 </details>
 
 ```grain
-expect : (msg: String, option: Option<a>) -> a
+expect : (msg: String, option: Option<a>) => a
 ```
 
 Extracts the value inside a `Some` option, otherwise throws an
@@ -144,7 +144,7 @@ No other changes yet.
 </details>
 
 ```grain
-unwrap : (option: Option<a>) -> a
+unwrap : (option: Option<a>) => a
 ```
 
 Extracts the value inside a `Some` option, otherwise
@@ -176,7 +176,7 @@ No other changes yet.
 </details>
 
 ```grain
-unwrapWithDefault : (default: a, option: Option<a>) -> a
+unwrapWithDefault : (default: a, option: Option<a>) => a
 ```
 
 Extracts the value inside a `Some` option or provide the default value if `None`.
@@ -202,7 +202,7 @@ No other changes yet.
 </details>
 
 ```grain
-map : (fn: (a -> b), option: Option<a>) -> Option<b>
+map : (fn: (a => b), option: Option<a>) => Option<b>
 ```
 
 If the Option is `Some(value)`, applies the given function to the `value` and wraps the new value in a `Some` variant.
@@ -211,7 +211,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> b`|The function to call on the value of a `Some` variant|
+|`fn`|`a => b`|The function to call on the value of a `Some` variant|
 |`option`|`Option<a>`|The option to map|
 
 Returns:
@@ -228,7 +228,7 @@ No other changes yet.
 </details>
 
 ```grain
-mapWithDefault : (fn: (a -> b), default: b, option: Option<a>) -> b
+mapWithDefault : (fn: (a => b), default: b, option: Option<a>) => b
 ```
 
 If the Option is `Some(value)`, applies the given function to the `value` to produce a new value, otherwise uses the default value.
@@ -238,7 +238,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> b`|The function to call on the value of a `Some` variant|
+|`fn`|`a => b`|The function to call on the value of a `Some` variant|
 |`default`|`b`|A fallback value for a `None` variant|
 |`option`|`Option<a>`|The option to map|
 
@@ -257,7 +257,7 @@ No other changes yet.
 
 ```grain
 mapWithDefaultFn :
-  (fn: (a -> b), defaultFn: (() -> b), option: Option<a>) -> b
+  (fn: (a => b), defaultFn: (() => b), option: Option<a>) => b
 ```
 
 If the Option is `Some(value)`, applies the `fn` function to the `value` to produce a new value.
@@ -268,8 +268,8 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> b`|The function to call on the value of a `Some` variant|
-|`defaultFn`|`() -> b`|The default function|
+|`fn`|`a => b`|The function to call on the value of a `Some` variant|
+|`defaultFn`|`() => b`|The default function|
 |`option`|`Option<a>`|The option to map|
 
 Returns:
@@ -286,7 +286,7 @@ No other changes yet.
 </details>
 
 ```grain
-flatMap : (fn: (a -> Option<b>), option: Option<a>) -> Option<b>
+flatMap : (fn: (a => Option<b>), option: Option<a>) => Option<b>
 ```
 
 If the Option is `Some(value)`, applies the given function to the `value` to produce a new Option.
@@ -295,7 +295,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Option<b>`|The function to call on the value of a `Some` variant|
+|`fn`|`a => Option<b>`|The function to call on the value of a `Some` variant|
 |`option`|`Option<a>`|The option to map|
 
 Returns:
@@ -312,7 +312,7 @@ No other changes yet.
 </details>
 
 ```grain
-filter : (fn: (a -> Bool), option: Option<a>) -> Option<a>
+filter : (fn: (a => Bool), option: Option<a>) => Option<a>
 ```
 
 Converts `Some(value)` variants to `None` variants where the predicate function returns `false`.
@@ -322,7 +322,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Bool`|The predicate function to indicate if the option should remain `Some`|
+|`fn`|`a => Bool`|The predicate function to indicate if the option should remain `Some`|
 |`option`|`Option<a>`|The option to inspect|
 
 Returns:
@@ -339,7 +339,7 @@ No other changes yet.
 </details>
 
 ```grain
-zip : (optionA: Option<a>, optionB: Option<b>) -> Option<(a, b)>
+zip : (optionA: Option<a>, optionB: Option<b>) => Option<(a, b)>
 ```
 
 Combine two Options into a single Option containing a tuple of their values.
@@ -366,7 +366,7 @@ No other changes yet.
 
 ```grain
 zipWith :
-  (fn: ((a, b) -> c), optionA: Option<a>, optionB: Option<b>) -> Option<c>
+  (fn: ((a, b) => c), optionA: Option<a>, optionB: Option<b>) => Option<c>
 ```
 
 Combine two Options into a single Option. The new value is produced by applying the given function to both values.
@@ -375,7 +375,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`(a, b) -> c`|The function to generate a new value|
+|`fn`|`(a, b) => c`|The function to generate a new value|
 |`optionA`|`Option<a>`|The first option to combine|
 |`optionB`|`Option<b>`|The second option to combine|
 
@@ -393,7 +393,7 @@ No other changes yet.
 </details>
 
 ```grain
-flatten : (option: Option<Option<a>>) -> Option<a>
+flatten : (option: Option<Option<a>>) => Option<a>
 ```
 
 Flattens nested Options.
@@ -424,7 +424,7 @@ No other changes yet.
 </details>
 
 ```grain
-toList : (option: Option<a>) -> List<a>
+toList : (option: Option<a>) => List<a>
 ```
 
 Converts an Option to a list with either zero or one item.
@@ -449,7 +449,7 @@ No other changes yet.
 </details>
 
 ```grain
-toArray : (option: Option<a>) -> Array<a>
+toArray : (option: Option<a>) => Array<a>
 ```
 
 Converts an Option to an array with either zero or one item.
@@ -474,7 +474,7 @@ No other changes yet.
 </details>
 
 ```grain
-toResult : (err: a, option: Option<b>) -> Result<b, a>
+toResult : (err: a, option: Option<b>) => Result<b, a>
 ```
 
 Converts the Option to a Result, using the provided error in case of the `None` variant.
@@ -500,7 +500,7 @@ No other changes yet.
 </details>
 
 ```grain
-sideEffect : (fn: (a -> Void), option: Option<a>) -> Void
+sideEffect : (fn: (a => Void), option: Option<a>) => Void
 ```
 
 If the Option is `Some(value)`, applies the `fn` function to the `value` without producing a new value.
@@ -509,7 +509,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Void`|The function to call on the value of a `Some` variant|
+|`fn`|`a => Void`|The function to call on the value of a `Some` variant|
 |`option`|`Option<a>`|The option to inspect|
 
 ### Option.**peek**
@@ -520,7 +520,7 @@ No other changes yet.
 </details>
 
 ```grain
-peek : (fn: (a -> Void), option: Option<a>) -> Option<a>
+peek : (fn: (a => Void), option: Option<a>) => Option<a>
 ```
 
 If the Option is `Some(value)`, applies the `fn` function to the `value` without producing a new value.
@@ -530,7 +530,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Void`|The function to call on the value of a `Some` variant|
+|`fn`|`a => Void`|The function to call on the value of a `Some` variant|
 |`option`|`Option<a>`|The option to inspect|
 
 Returns:
@@ -554,7 +554,7 @@ Returns:
 </details>
 
 ```grain
-(||) : (optionA: Option<a>, optionB: Option<a>) -> Option<a>
+(||) : (optionA: Option<a>, optionB: Option<a>) => Option<a>
 ```
 
 Behaves like a logical OR (`||`) where the first Option is only returned if it is the `Some` variant and falling back to the second Option in all other cases.
@@ -587,7 +587,7 @@ Returns:
 </details>
 
 ```grain
-(&&) : (optionA: Option<a>, optionB: Option<a>) -> Option<a>
+(&&) : (optionA: Option<a>, optionB: Option<a>) => Option<a>
 ```
 
 Behaves like a logical AND (`&&`) where the first Option is only returned if it is the `None` variant and falling back to the second Option Result in all other cases.

--- a/stdlib/path.md
+++ b/stdlib/path.md
@@ -177,7 +177,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromString : (pathStr: String) -> Path
+fromString : (pathStr: String) => Path
 ```
 
 Parses a path string into a `Path`. Paths will be parsed as file paths
@@ -217,7 +217,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromPlatformString : (pathStr: String, platform: Platform) -> Path
+fromPlatformString : (pathStr: String, platform: Platform) => Path
 ```
 
 Parses a path string into a `Path` using the path separators appropriate to
@@ -256,7 +256,7 @@ No other changes yet.
 </details>
 
 ```grain
-toString : (path: Path) -> String
+toString : (path: Path) => String
 ```
 
 Converts the given `Path` into a string, using the `/` path separator.
@@ -292,7 +292,7 @@ No other changes yet.
 </details>
 
 ```grain
-toPlatformString : (path: Path, platform: Platform) -> String
+toPlatformString : (path: Path, platform: Platform) => String
 ```
 
 Converts the given `Path` into a string, using the canonical path separator
@@ -330,7 +330,7 @@ No other changes yet.
 </details>
 
 ```grain
-isDirectory : (path: Path) -> Bool
+isDirectory : (path: Path) => Bool
 ```
 
 Determines whether the path is a directory path.
@@ -360,7 +360,7 @@ isDirectory(fromString("/bin/")) == true
 ### Path.**isAbsolute**
 
 ```grain
-isAbsolute : (path: Path) -> Bool
+isAbsolute : (path: Path) => Bool
 ```
 
 Determines whether the path is an absolute path.
@@ -395,7 +395,7 @@ No other changes yet.
 </details>
 
 ```grain
-append : (path: Path, toAppend: Path) -> Result<Path, AppendError>
+append : (path: Path, toAppend: Path) => Result<Path, AppendError>
 ```
 
 Creates a new path by appending a relative path segment to a directory path.
@@ -435,7 +435,7 @@ No other changes yet.
 </details>
 
 ```grain
-relativeTo : (source: Path, dest: Path) -> Result<Path, RelativizationError>
+relativeTo : (source: Path, dest: Path) => Result<Path, RelativizationError>
 ```
 
 Attempts to construct a new relative path which will lead to the destination
@@ -495,7 +495,7 @@ No other changes yet.
 
 ```grain
 ancestry :
-  (path1: Path, path2: Path) -> Result<AncestryStatus, IncompatibilityError>
+  (path1: Path, path2: Path) => Result<AncestryStatus, IncompatibilityError>
 ```
 
 Determines the relative ancestry betwen two paths.
@@ -539,7 +539,7 @@ No other changes yet.
 </details>
 
 ```grain
-parent : (path: Path) -> Path
+parent : (path: Path) => Path
 ```
 
 Retrieves the path corresponding to the parent directory of the given path.
@@ -574,7 +574,7 @@ No other changes yet.
 </details>
 
 ```grain
-basename : (path: Path) -> Option<String>
+basename : (path: Path) => Option<String>
 ```
 
 Retrieves the basename (named final segment) of a path.
@@ -609,7 +609,7 @@ No other changes yet.
 </details>
 
 ```grain
-stem : (path: Path) -> Result<String, PathOperationError>
+stem : (path: Path) => Result<String, PathOperationError>
 ```
 
 Retrieves the basename of a file path without the extension.
@@ -652,7 +652,7 @@ No other changes yet.
 </details>
 
 ```grain
-extension : (path: Path) -> Result<String, PathOperationError>
+extension : (path: Path) => Result<String, PathOperationError>
 ```
 
 Retrieves the extension on the basename of a file path.
@@ -695,7 +695,7 @@ No other changes yet.
 </details>
 
 ```grain
-root : (path: Path) -> Result<AbsoluteRoot, PathOperationError>
+root : (path: Path) => Result<AbsoluteRoot, PathOperationError>
 ```
 
 Retrieves the root of the absolute path.

--- a/stdlib/pervasives.gr
+++ b/stdlib/pervasives.gr
@@ -98,7 +98,7 @@ provide { (==) }
  *
  * @since v0.2.0
  */
-provide let (!=): (a, a) -> Bool = (x, y) => !(x == y)
+provide let (!=): (a, a) => Bool = (x, y) => !(x == y)
 
 /**
  * Checks that two values are physically equal.
@@ -122,7 +122,7 @@ provide primitive (is) = "@is"
  *
  * @since v0.2.0
  */
-provide let (isnt): (a, a) -> Bool = (x, y) => !(x is y)
+provide let (isnt): (a, a) => Bool = (x, y) => !(x is y)
 
 provide {
   (<),
@@ -151,8 +151,8 @@ provide {
 // Number coercions & conversions
 
 // TODO(#311): Commented until we nail down semantics
-// foreign wasm convertExactToInexact : Number -> Number as inexact from "stdlib-external/runtime"
-// foreign wasm convertInexactToExact : Number -> Number as exact from "stdlib-external/runtime"
+// foreign wasm convertExactToInexact : Number => Number as inexact from "stdlib-external/runtime"
+// foreign wasm convertInexactToExact : Number => Number as exact from "stdlib-external/runtime"
 
 provide { toString, print }
 
@@ -200,7 +200,7 @@ provide primitive throw = "@throw"
  * @param message: The reason for the failure
  * @returns Anything and nothing—your program won't continue past a fail expression
  */
-provide let fail: String -> a = msg => throw Failure(msg)
+provide let fail: String => a = msg => throw Failure(msg)
 
 /**
  * Provides the operand untouched.

--- a/stdlib/pervasives.md
+++ b/stdlib/pervasives.md
@@ -25,7 +25,7 @@ No other changes yet.
 </details>
 
 ```grain
-(!) : Bool -> Bool
+(!) : Bool => Bool
 ```
 
 Computes the logical NOT (`!`) of the given operand.
@@ -61,7 +61,7 @@ No other changes yet.
 </details>
 
 ```grain
-(&&) : (Bool, Bool) -> Bool
+(&&) : (Bool, Bool) => Bool
 ```
 
 Computes the logical AND (`&&`) of the given operands.
@@ -90,7 +90,7 @@ No other changes yet.
 </details>
 
 ```grain
-(||) : (Bool, Bool) -> Bool
+(||) : (Bool, Bool) => Bool
 ```
 
 Computes the logical OR `||` of the given operands.
@@ -119,7 +119,7 @@ No other changes yet.
 </details>
 
 ```grain
-(==) : (x: a, y: a) -> Bool
+(==) : (x: a, y: a) => Bool
 ```
 
 Check that two values are equal. This checks for structural equality,
@@ -146,7 +146,7 @@ No other changes yet.
 </details>
 
 ```grain
-(!=) : (a, a) -> Bool
+(!=) : (a, a) => Bool
 ```
 
 Check that two values are **not** equal. This checks for structural equality,
@@ -173,7 +173,7 @@ No other changes yet.
 </details>
 
 ```grain
-is : (a, a) -> Bool
+is : (a, a) => Bool
 ```
 
 Checks that two values are physically equal.
@@ -200,7 +200,7 @@ No other changes yet.
 </details>
 
 ```grain
-isnt : (a, a) -> Bool
+isnt : (a, a) => Bool
 ```
 
 Checks that two values are **not** physically equal.
@@ -227,7 +227,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<) : (x: Number, y: Number) -> Bool
+(<) : (x: Number, y: Number) => Bool
 ```
 
 Checks if the first operand is less than the second operand.
@@ -253,7 +253,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>) : (x: Number, y: Number) -> Bool
+(>) : (x: Number, y: Number) => Bool
 ```
 
 Checks if the first operand is greater than the second operand.
@@ -279,7 +279,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<=) : (x: Number, y: Number) -> Bool
+(<=) : (x: Number, y: Number) => Bool
 ```
 
 Checks if the first operand is less than or equal to the second operand.
@@ -305,7 +305,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>=) : (x: Number, y: Number) -> Bool
+(>=) : (x: Number, y: Number) => Bool
 ```
 
 Checks if the first operand is greater than or equal to the second operand.
@@ -331,7 +331,7 @@ No other changes yet.
 </details>
 
 ```grain
-compare : (x: a, y: a) -> Number
+compare : (x: a, y: a) => Number
 ```
 
 Compares the first argument to the second argument and produces an integer result.
@@ -359,7 +359,7 @@ No other changes yet.
 </details>
 
 ```grain
-(+) : (x: Number, y: Number) -> Number
+(+) : (x: Number, y: Number) => Number
 ```
 
 Computes the sum of its operands.
@@ -385,7 +385,7 @@ No other changes yet.
 </details>
 
 ```grain
-(-) : (x: Number, y: Number) -> Number
+(-) : (x: Number, y: Number) => Number
 ```
 
 Computes the difference of its operands.
@@ -411,7 +411,7 @@ No other changes yet.
 </details>
 
 ```grain
-(*) : (x: Number, y: Number) -> Number
+(*) : (x: Number, y: Number) => Number
 ```
 
 Computes the product of its operands.
@@ -437,7 +437,7 @@ No other changes yet.
 </details>
 
 ```grain
-(/) : (x: Number, y: Number) -> Number
+(/) : (x: Number, y: Number) => Number
 ```
 
 Computes the quotient of its operands.
@@ -463,7 +463,7 @@ No other changes yet.
 </details>
 
 ```grain
-(%) : (x: Number, y: Number) -> Number
+(%) : (x: Number, y: Number) => Number
 ```
 
 Computes the remainder of the division of the first operand by the second.
@@ -497,7 +497,7 @@ Returns:
 </details>
 
 ```grain
-(**) : (base: Number, power: Number) -> Number
+(**) : (base: Number, power: Number) => Number
 ```
 
 Computes the exponentiation of the given base and power.
@@ -523,7 +523,7 @@ No other changes yet.
 </details>
 
 ```grain
-incr : (x: Number) -> Number
+incr : (x: Number) => Number
 ```
 
 Increments the value by one.
@@ -548,7 +548,7 @@ No other changes yet.
 </details>
 
 ```grain
-decr : (x: Number) -> Number
+decr : (x: Number) => Number
 ```
 
 Decrements the value by one.
@@ -573,7 +573,7 @@ No other changes yet.
 </details>
 
 ```grain
-(++) : (s1: String, s2: String) -> String
+(++) : (s1: String, s2: String) => String
 ```
 
 Concatenate two strings.
@@ -605,7 +605,7 @@ No other changes yet.
 </details>
 
 ```grain
-lnot : (x: Number) -> Number
+lnot : (x: Number) => Number
 ```
 
 Computes the bitwise NOT of the operand.
@@ -638,7 +638,7 @@ Returns:
 </details>
 
 ```grain
-(&) : (x: Number, y: Number) -> Number
+(&) : (x: Number, y: Number) => Number
 ```
 
 Computes the bitwise AND (`&`) on the given operands.
@@ -672,7 +672,7 @@ Returns:
 </details>
 
 ```grain
-(|) : (x: Number, y: Number) -> Number
+(|) : (x: Number, y: Number) => Number
 ```
 
 Computes the bitwise OR (`|`) on the given operands.
@@ -707,7 +707,7 @@ Returns:
 </details>
 
 ```grain
-(^) : (x: Number, y: Number) -> Number
+(^) : (x: Number, y: Number) => Number
 ```
 
 Computes the bitwise XOR (`^`) on the given operands.
@@ -741,7 +741,7 @@ Returns:
 </details>
 
 ```grain
-(<<) : (x: Number, y: Number) -> Number
+(<<) : (x: Number, y: Number) => Number
 ```
 
 Shifts the bits of the value left by the given number of bits.
@@ -775,7 +775,7 @@ Returns:
 </details>
 
 ```grain
-(>>>) : (x: Number, y: Number) -> Number
+(>>>) : (x: Number, y: Number) => Number
 ```
 
 Shifts the bits of the value right by the given number of bits, preserving the sign bit.
@@ -809,7 +809,7 @@ Returns:
 </details>
 
 ```grain
-(>>) : (x: Number, y: Number) -> Number
+(>>) : (x: Number, y: Number) => Number
 ```
 
 Shifts the bits of the value right by the given number of bits.
@@ -835,7 +835,7 @@ No other changes yet.
 </details>
 
 ```grain
-toString : (value: a) -> String
+toString : (value: a) => String
 ```
 
 Converts the given operand to a string.
@@ -861,7 +861,7 @@ No other changes yet.
 </details>
 
 ```grain
-print : (value: a) -> Void
+print : (value: a) => Void
 ```
 
 Prints the given operand to the console. Works for any type. Internally, calls `toString`
@@ -882,7 +882,7 @@ No other changes yet.
 </details>
 
 ```grain
-ignore : a -> Void
+ignore : a => Void
 ```
 
 Accepts any value and always returns `void`.
@@ -901,7 +901,7 @@ No other changes yet.
 </details>
 
 ```grain
-assert : Bool -> Void
+assert : Bool => Void
 ```
 
 Assert that the given Boolean condition is `true`.
@@ -936,7 +936,7 @@ No other changes yet.
 </details>
 
 ```grain
-throw : Exception -> a
+throw : Exception => a
 ```
 
 Throw an exception. Currently, exceptions cannot be caught and will crash your program.
@@ -956,7 +956,7 @@ Returns:
 ### Pervasives.**fail**
 
 ```grain
-fail : String -> a
+fail : String => a
 ```
 
 Unconditionally throw a `Failure` exception with a message.
@@ -982,7 +982,7 @@ No other changes yet.
 </details>
 
 ```grain
-identity : (x: a) -> a
+identity : (x: a) => a
 ```
 
 Provides the operand untouched.
@@ -1007,7 +1007,7 @@ No other changes yet.
 </details>
 
 ```grain
-box : a -> Box<a>
+box : a => Box<a>
 ```
 
 Creates a box containing the given initial value.
@@ -1034,7 +1034,7 @@ No other changes yet.
 </details>
 
 ```grain
-unbox : Box<a> -> a
+unbox : Box<a> => a
 ```
 
 Retrieves the current value from a box.

--- a/stdlib/priorityqueue.gr
+++ b/stdlib/priorityqueue.gr
@@ -21,7 +21,7 @@ include "option"
 abstract record PriorityQueue<a> {
   mut size: Number,
   mut array: Array<Option<a>>,
-  comp: (a, a) -> Number,
+  comp: (a, a) => Number,
 }
 
 let swap = (i1, i2, array) => {
@@ -283,7 +283,7 @@ provide module Immutable {
    */
 
   abstract record PriorityQueue<a> {
-    comp: (a, a) -> Number,
+    comp: (a, a) => Number,
     size: Number,
     root: Option<PQRoot<a>>,
   }

--- a/stdlib/priorityqueue.md
+++ b/stdlib/priorityqueue.md
@@ -39,7 +39,7 @@ No other changes yet.
 </details>
 
 ```grain
-makeSized : (size: Number, comp: ((a, a) -> Number)) -> PriorityQueue<a>
+makeSized : (size: Number, comp: ((a, a) => Number)) => PriorityQueue<a>
 ```
 
 Creates a new priority queue with a given internal storage size and a
@@ -56,7 +56,7 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`size`|`Number`|The initial storage size of the priority queue|
-|`comp`|`(a, a) -> Number`|The comparator function used to indicate priority order|
+|`comp`|`(a, a) => Number`|The comparator function used to indicate priority order|
 
 Returns:
 
@@ -72,7 +72,7 @@ No other changes yet.
 </details>
 
 ```grain
-make : (comp: ((a, a) -> Number)) -> PriorityQueue<a>
+make : (comp: ((a, a) => Number)) => PriorityQueue<a>
 ```
 
 Creates a new priority queue with a comparator function, which is used to
@@ -84,7 +84,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`comp`|`(a, a) -> Number`|The comparator function used to indicate priority order|
+|`comp`|`(a, a) => Number`|The comparator function used to indicate priority order|
 
 Returns:
 
@@ -110,7 +110,7 @@ No other changes yet.
 </details>
 
 ```grain
-size : (pq: PriorityQueue<a>) -> Number
+size : (pq: PriorityQueue<a>) => Number
 ```
 
 Gets the number of elements in a priority queue.
@@ -135,7 +135,7 @@ No other changes yet.
 </details>
 
 ```grain
-isEmpty : (pq: PriorityQueue<a>) -> Bool
+isEmpty : (pq: PriorityQueue<a>) => Bool
 ```
 
 Determines if the priority queue contains no elements.
@@ -160,7 +160,7 @@ No other changes yet.
 </details>
 
 ```grain
-push : (val: a, pq: PriorityQueue<a>) -> Void
+push : (val: a, pq: PriorityQueue<a>) => Void
 ```
 
 Adds a new element to the priority queue.
@@ -180,7 +180,7 @@ No other changes yet.
 </details>
 
 ```grain
-peek : (pq: PriorityQueue<a>) -> Option<a>
+peek : (pq: PriorityQueue<a>) => Option<a>
 ```
 
 Retrieves the highest priority element in the priority queue. It is not
@@ -206,7 +206,7 @@ No other changes yet.
 </details>
 
 ```grain
-pop : (pq: PriorityQueue<a>) -> Option<a>
+pop : (pq: PriorityQueue<a>) => Option<a>
 ```
 
 Removes and retrieves the highest priority element in the priority queue.
@@ -231,7 +231,7 @@ No other changes yet.
 </details>
 
 ```grain
-drain : (pq: PriorityQueue<a>) -> List<a>
+drain : (pq: PriorityQueue<a>) => List<a>
 ```
 
 Clears the priority queue and produces a list of all of the elements in the priority
@@ -257,7 +257,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromArray : (array: Array<a>, comp: ((a, a) -> Number)) -> PriorityQueue<a>
+fromArray : (array: Array<a>, comp: ((a, a) => Number)) => PriorityQueue<a>
 ```
 
 Constructs a new priority queue initialized with the elements in the array
@@ -271,7 +271,7 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`array`|`Array<a>`|An array of values used to initialize the priority queue|
-|`comp`|`(a, a) -> Number`|A comparator function used to assign priority to elements|
+|`comp`|`(a, a) => Number`|A comparator function used to assign priority to elements|
 
 Returns:
 
@@ -287,7 +287,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromList : (list: List<a>, comp: ((a, a) -> Number)) -> PriorityQueue<a>
+fromList : (list: List<a>, comp: ((a, a) => Number)) => PriorityQueue<a>
 ```
 
 Constructs a new priority queue initialized with the elements in the list
@@ -301,7 +301,7 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`list`|`List<a>`|A list of values used to initialize the priority queue|
-|`comp`|`(a, a) -> Number`|A comparator function used to assign priority to elements|
+|`comp`|`(a, a) => Number`|A comparator function used to assign priority to elements|
 
 Returns:
 
@@ -376,7 +376,7 @@ An empty priority queue with the default `compare` comparator.
 </details>
 
 ```grain
-make : (comp: ((a, a) -> Number)) -> PriorityQueue<a>
+make : (comp: ((a, a) => Number)) => PriorityQueue<a>
 ```
 
 Creates a new priority queue with a comparator function, which is used to
@@ -388,7 +388,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`comp`|`(a, a) -> Number`|The comparator function used to indicate priority order|
+|`comp`|`(a, a) => Number`|The comparator function used to indicate priority order|
 
 Returns:
 
@@ -421,7 +421,7 @@ PriorityQueue.Immutable.make((a, b) => String.length(b) - String.length(a)) // c
 </details>
 
 ```grain
-size : PriorityQueue<a> -> Number
+size : PriorityQueue<a> => Number
 ```
 
 Gets the number of elements in a priority queue.
@@ -453,7 +453,7 @@ Returns:
 </details>
 
 ```grain
-isEmpty : PriorityQueue<a> -> Bool
+isEmpty : PriorityQueue<a> => Bool
 ```
 
 Determines if the priority queue contains no elements.
@@ -485,7 +485,7 @@ Returns:
 </details>
 
 ```grain
-push : (val: a, pq: PriorityQueue<a>) -> PriorityQueue<a>
+push : (val: a, pq: PriorityQueue<a>) => PriorityQueue<a>
 ```
 
 Produces a new priority queue by inserting the given element into the given priority queue.
@@ -518,7 +518,7 @@ Returns:
 </details>
 
 ```grain
-peek : (pq: PriorityQueue<a>) -> Option<a>
+peek : (pq: PriorityQueue<a>) => Option<a>
 ```
 
 Retrieves the highest priority element in the priority queue. It is not
@@ -551,7 +551,7 @@ Returns:
 </details>
 
 ```grain
-pop : (pq: PriorityQueue<a>) -> PriorityQueue<a>
+pop : (pq: PriorityQueue<a>) => PriorityQueue<a>
 ```
 
 Produces a new priority queue without the highest priority element in the
@@ -585,7 +585,7 @@ Returns:
 </details>
 
 ```grain
-drain : (pq: PriorityQueue<a>) -> List<a>
+drain : (pq: PriorityQueue<a>) => List<a>
 ```
 
 Produces a list of all elements in the priority queue in priority order.
@@ -617,7 +617,7 @@ Returns:
 </details>
 
 ```grain
-fromList : (list: List<a>, comp: ((a, a) -> Number)) -> PriorityQueue<a>
+fromList : (list: List<a>, comp: ((a, a) => Number)) => PriorityQueue<a>
 ```
 
 Constructs a new priority queue initialized with the elements in the list
@@ -631,7 +631,7 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`list`|`List<a>`|A list of values used to initialize the priority queue|
-|`comp`|`(a, a) -> Number`|A comparator function used to assign priority to elements|
+|`comp`|`(a, a) => Number`|A comparator function used to assign priority to elements|
 
 Returns:
 
@@ -654,7 +654,7 @@ Returns:
 </details>
 
 ```grain
-fromArray : (array: Array<a>, comp: ((a, a) -> Number)) -> PriorityQueue<a>
+fromArray : (array: Array<a>, comp: ((a, a) => Number)) => PriorityQueue<a>
 ```
 
 Constructs a new priority queue initialized with the elements in the array
@@ -668,7 +668,7 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`array`|`Array<a>`|An array of values used to initialize the priority queue|
-|`comp`|`(a, a) -> Number`|A comparator function used to assign priority to elements|
+|`comp`|`(a, a) => Number`|A comparator function used to assign priority to elements|
 
 Returns:
 

--- a/stdlib/queue.md
+++ b/stdlib/queue.md
@@ -41,7 +41,7 @@ No other changes yet.
 </details>
 
 ```grain
-makeSized : (size: Number) -> Queue<a>
+makeSized : (size: Number) => Queue<a>
 ```
 
 Creates a new queue with an initial storage of the given size. As values are
@@ -69,7 +69,7 @@ No other changes yet.
 </details>
 
 ```grain
-make : () -> Queue<a>
+make : () => Queue<a>
 ```
 
 Creates a new queue.
@@ -88,7 +88,7 @@ No other changes yet.
 </details>
 
 ```grain
-isEmpty : (queue: Queue<a>) -> Bool
+isEmpty : (queue: Queue<a>) => Bool
 ```
 
 Checks if the given queue contains no items.
@@ -113,7 +113,7 @@ No other changes yet.
 </details>
 
 ```grain
-size : (queue: Queue<a>) -> Number
+size : (queue: Queue<a>) => Number
 ```
 
 Computes the size of the input queue.
@@ -138,7 +138,7 @@ No other changes yet.
 </details>
 
 ```grain
-peek : (queue: Queue<a>) -> Option<a>
+peek : (queue: Queue<a>) => Option<a>
 ```
 
 Provides the value at the beginning of the queue, if it exists.
@@ -163,7 +163,7 @@ No other changes yet.
 </details>
 
 ```grain
-push : (value: a, queue: Queue<a>) -> Void
+push : (value: a, queue: Queue<a>) => Void
 ```
 
 Adds a new item to the end of the queue.
@@ -183,7 +183,7 @@ No other changes yet.
 </details>
 
 ```grain
-pop : (queue: Queue<a>) -> Option<a>
+pop : (queue: Queue<a>) => Option<a>
 ```
 
 Removes the item at the beginning of the queue.
@@ -208,7 +208,7 @@ No other changes yet.
 </details>
 
 ```grain
-clear : (queue: Queue<a>) -> Void
+clear : (queue: Queue<a>) => Void
 ```
 
 Clears the queue by removing all of its elements
@@ -227,7 +227,7 @@ No other changes yet.
 </details>
 
 ```grain
-copy : (queue: Queue<a>) -> Queue<a>
+copy : (queue: Queue<a>) => Queue<a>
 ```
 
 Produces a shallow copy of the input queue.
@@ -299,7 +299,7 @@ An empty queue.
 </details>
 
 ```grain
-isEmpty : (queue: ImmutableQueue<a>) -> Bool
+isEmpty : (queue: ImmutableQueue<a>) => Bool
 ```
 
 Checks if the given queue contains any values.
@@ -334,7 +334,7 @@ Returns:
 </details>
 
 ```grain
-peek : (queue: ImmutableQueue<a>) -> Option<a>
+peek : (queue: ImmutableQueue<a>) => Option<a>
 ```
 
 Returns the value at the beginning of the queue. It is not removed from the queue.
@@ -369,7 +369,7 @@ Returns:
 </details>
 
 ```grain
-push : (value: a, queue: ImmutableQueue<a>) -> ImmutableQueue<a>
+push : (value: a, queue: ImmutableQueue<a>) => ImmutableQueue<a>
 ```
 
 Adds a value to the end of the queue.
@@ -405,7 +405,7 @@ Returns:
 </details>
 
 ```grain
-pop : (queue: ImmutableQueue<a>) -> ImmutableQueue<a>
+pop : (queue: ImmutableQueue<a>) => ImmutableQueue<a>
 ```
 
 Dequeues the next value in the queue.
@@ -437,7 +437,7 @@ Returns:
 </details>
 
 ```grain
-size : (queue: ImmutableQueue<a>) -> Number
+size : (queue: ImmutableQueue<a>) => Number
 ```
 
 Get the number of values in a queue.

--- a/stdlib/random.md
+++ b/stdlib/random.md
@@ -35,7 +35,7 @@ No other changes yet.
 </details>
 
 ```grain
-make : (seed: Uint64) -> Random
+make : (seed: Uint64) => Random
 ```
 
 Creates a new pseudo-random number generator with the given seed.
@@ -60,7 +60,7 @@ No other changes yet.
 </details>
 
 ```grain
-makeUnseeded : () -> Result<Random, Exception>
+makeUnseeded : () => Result<Random, Exception>
 ```
 
 Creates a new pseudo-random number generator with a random seed.
@@ -86,7 +86,7 @@ Returns:
 </details>
 
 ```grain
-nextUint32 : (random: Random) -> Uint32
+nextUint32 : (random: Random) => Uint32
 ```
 
 Generates a random 32-bit integer from the given pseudo-random number generator.
@@ -118,7 +118,7 @@ Returns:
 </details>
 
 ```grain
-nextUint64 : (random: Random) -> Uint64
+nextUint64 : (random: Random) => Uint64
 ```
 
 Generates a random 64-bit integer from the given pseudo-random number generator.
@@ -150,7 +150,7 @@ Returns:
 </details>
 
 ```grain
-nextUint32InRange : (random: Random, low: Uint32, high: Uint32) -> Uint32
+nextUint32InRange : (random: Random, low: Uint32, high: Uint32) => Uint32
 ```
 
 Generates a random 32-bit integer from the given pseudo-random number generator
@@ -185,7 +185,7 @@ Returns:
 </details>
 
 ```grain
-nextUint64InRange : (random: Random, low: Uint64, high: Uint64) -> Uint64
+nextUint64InRange : (random: Random, low: Uint64, high: Uint64) => Uint64
 ```
 
 Generates a random 64-bit integer from the given pseudo-random number generator

--- a/stdlib/range.gr
+++ b/stdlib/range.gr
@@ -56,7 +56,7 @@ provide let inRange = (value, range) => {
  * @since v0.3.0
  * @history v0.6.0: Treats all ranges as exclusive
  */
-provide let forEach = (fn: Number -> Void, range) => {
+provide let forEach = (fn: Number => Void, range) => {
   match (range) {
     { rangeStart: lower, rangeEnd: upper } when lower <= upper => {
       let mut idx = lower
@@ -157,7 +157,7 @@ provide module Inclusive {
    * @history v0.3.0: Root APIs originally handled Inclusive & Exclusive variants
    */
 
-  provide let forEach = (fn: Number -> Void, range) => {
+  provide let forEach = (fn: Number => Void, range) => {
     match (range) {
       { rangeStart: lower, rangeEnd: upper } when lower <= upper => {
         let mut idx = lower

--- a/stdlib/range.md
+++ b/stdlib/range.md
@@ -44,7 +44,7 @@ Functions and constants included in the Range module.
 </details>
 
 ```grain
-inRange : (value: Number, range: Range<Number>) -> Bool
+inRange : (value: Number, range: Range<Number>) => Bool
 ```
 
 Checks if the given number is within the range.
@@ -87,7 +87,7 @@ Range.inRange(10, { rangeStart: 0, rangeEnd: 2 }) == false
 </details>
 
 ```grain
-forEach : (fn: (Number -> Void), range: Range<Number>) -> Void
+forEach : (fn: (Number => Void), range: Range<Number>) => Void
 ```
 
 Calls the given function with each number in the range.
@@ -100,7 +100,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`Number -> Void`|The function to be executed on each number in the range|
+|`fn`|`Number => Void`|The function to be executed on each number in the range|
 |`range`|`Range<Number>`|The range to iterate|
 
 Examples:
@@ -124,7 +124,7 @@ Range.forEach(val => print(val), { rangeStart: 0, rangeEnd: 2 })
 </details>
 
 ```grain
-map : (fn: (Number -> a), range: Range<Number>) -> List<a>
+map : (fn: (Number => a), range: Range<Number>) => List<a>
 ```
 
 Produces a list by calling the given function on each number included in the range.
@@ -137,7 +137,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`Number -> a`|The function called on each number in the range that returns the value for the output list|
+|`fn`|`Number => a`|The function called on each number in the range that returns the value for the output list|
 |`range`|`Range<Number>`|The range to iterate|
 
 Returns:
@@ -173,7 +173,7 @@ Functions and constants included in the Range.Inclusive module.
 </details>
 
 ```grain
-inRange : (value: Number, range: Range<Number>) -> Bool
+inRange : (value: Number, range: Range<Number>) => Bool
 ```
 
 Checks if the given number is within the range.
@@ -216,7 +216,7 @@ Range.Inclusive.inRange(10, { rangeStart: 0, rangeEnd: 2 }) == false
 </details>
 
 ```grain
-forEach : (fn: (Number -> Void), range: Range<Number>) -> Void
+forEach : (fn: (Number => Void), range: Range<Number>) => Void
 ```
 
 Calls the given function with each number in the range.
@@ -229,7 +229,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`Number -> Void`|The function to be executed on each number in the range|
+|`fn`|`Number => Void`|The function to be executed on each number in the range|
 |`range`|`Range<Number>`|The range to iterate|
 
 Examples:
@@ -253,7 +253,7 @@ Range.Inclusive.forEach(val => print(val), { rangeStart: 0, rangeEnd: 2 })
 </details>
 
 ```grain
-map : (fn: (Number -> a), range: Range<Number>) -> List<a>
+map : (fn: (Number => a), range: Range<Number>) => List<a>
 ```
 
 Produces a list by calling the given function on each number included in the range.
@@ -266,7 +266,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`Number -> a`|The function called on each number in the range that returns the value for the output list|
+|`fn`|`Number => a`|The function called on each number in the range that returns the value for the output list|
 |`range`|`Range<Number>`|The range to iterate|
 
 Returns:

--- a/stdlib/rational.md
+++ b/stdlib/rational.md
@@ -25,7 +25,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromNumber : (x: Number) -> Rational
+fromNumber : (x: Number) => Rational
 ```
 
 Converts a Number to a Rational.
@@ -50,7 +50,7 @@ No other changes yet.
 </details>
 
 ```grain
-toNumber : (x: Rational) -> Number
+toNumber : (x: Rational) => Number
 ```
 
 Converts a Rational to a Number.
@@ -75,7 +75,7 @@ No other changes yet.
 </details>
 
 ```grain
-numerator : (x: Rational) -> Number
+numerator : (x: Rational) => Number
 ```
 
 Finds the numerator of the rational number.
@@ -100,7 +100,7 @@ No other changes yet.
 </details>
 
 ```grain
-denominator : (x: Rational) -> Number
+denominator : (x: Rational) => Number
 ```
 
 Finds the denominator of the rational number.
@@ -125,7 +125,7 @@ No other changes yet.
 </details>
 
 ```grain
-toIntegerRatio : (x: Rational) -> (Number, Number)
+toIntegerRatio : (x: Rational) => (Number, Number)
 ```
 
 Gets the numerator and denominator of the rational.
@@ -150,7 +150,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromIntegerRatio : (numerator: Number, denominator: Number) -> Rational
+fromIntegerRatio : (numerator: Number, denominator: Number) => Rational
 ```
 
 Creates a rational from a numerator and denominator.
@@ -183,7 +183,7 @@ No other changes yet.
 </details>
 
 ```grain
-(+) : (x: Rational, y: Rational) -> Rational
+(+) : (x: Rational, y: Rational) => Rational
 ```
 
 Computes the sum of its operands.
@@ -209,7 +209,7 @@ No other changes yet.
 </details>
 
 ```grain
-(-) : (x: Rational, y: Rational) -> Rational
+(-) : (x: Rational, y: Rational) => Rational
 ```
 
 Computes the difference of its operands.
@@ -235,7 +235,7 @@ No other changes yet.
 </details>
 
 ```grain
-(*) : (x: Rational, y: Rational) -> Rational
+(*) : (x: Rational, y: Rational) => Rational
 ```
 
 Computes the product of its operands.
@@ -261,7 +261,7 @@ No other changes yet.
 </details>
 
 ```grain
-(/) : (x: Rational, y: Rational) -> Rational
+(/) : (x: Rational, y: Rational) => Rational
 ```
 
 Computes the quotient of its operands.
@@ -287,7 +287,7 @@ No other changes yet.
 </details>
 
 ```grain
-(==) : (x: Rational, y: Rational) -> Bool
+(==) : (x: Rational, y: Rational) => Bool
 ```
 
 Checks if the first value is equal to the second value.
@@ -313,7 +313,7 @@ No other changes yet.
 </details>
 
 ```grain
-(!=) : (x: Rational, y: Rational) -> Bool
+(!=) : (x: Rational, y: Rational) => Bool
 ```
 
 Checks if the first value is not equal to the second value.
@@ -339,7 +339,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<) : (x: Rational, y: Rational) -> Bool
+(<) : (x: Rational, y: Rational) => Bool
 ```
 
 Checks if the first value is less than the second value.
@@ -365,7 +365,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>) : (x: Rational, y: Rational) -> Bool
+(>) : (x: Rational, y: Rational) => Bool
 ```
 
 Checks if the first value is greater than the second value.
@@ -391,7 +391,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<=) : (x: Rational, y: Rational) -> Bool
+(<=) : (x: Rational, y: Rational) => Bool
 ```
 
 Checks if the first value is less than or equal to the second value.
@@ -417,7 +417,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>=) : (x: Rational, y: Rational) -> Bool
+(>=) : (x: Rational, y: Rational) => Bool
 ```
 
 Checks if the first value is greater than or equal to the second value.

--- a/stdlib/regex.gr
+++ b/stdlib/regex.gr
@@ -2246,7 +2246,7 @@ let matchBufChar = (buf: MatchBuf, pos: Number) => {
 }
 
 enum StackElt {
-  SEPositionProducer(Number -> Option<Number>),
+  SEPositionProducer(Number => Option<Number>),
   SESavedGroup(Number, Option<(Number, Number)>),
 }
 
@@ -3328,7 +3328,7 @@ abstract record RegularExpression {
     Number,
     Array<Option<(Number, Number)>>,
     List<StackElt>,
-  ) -> Option<Number>,
+  ) => Option<Number>,
   reMustString: Option<String>,
   reIsAnchored: Bool,
   reStartRange: Option<RERange>,
@@ -3586,14 +3586,14 @@ let searchMatch =
  * the following accessors:
  *
  * ```grain
- * group : Number -> Option<String>
+ * group : Number => Option<String>
  * ```
  *
  * Returns the contents of the given group. Note that group 0 contains
  * the entire matched substring, and group 1 contains the first parenthesized group.
  *
  * ```grain
- * groupPosition : Number -> Option<(Number, Number)>
+ * groupPosition : Number => Option<(Number, Number)>
  * ```
  *
  * Returns the position of the given group.
@@ -3605,13 +3605,13 @@ let searchMatch =
  * The number of defined groups in this match object (including group 0).
  *
  * ```grain
- * allGroups : () -> Array<Option<String>>
+ * allGroups : () => Array<Option<String>>
  * ```
  *
  * Returns the contents of all groups matched in this match object.
  *
  * ```grain
- * allGroupPositions : () -> Array<Option<(Number, Number)>>
+ * allGroupPositions : () => Array<Option<(Number, Number)>>
  * ```
  *
  * Returns the positions of all groups matched in this match object.
@@ -3622,11 +3622,11 @@ provide record MatchResult {
   /**
    * Returns the contents of the given group
    */
-  group: Number -> Option<String>,
+  group: Number => Option<String>,
   /**
    * Returns the position of the given group
    */
-  groupPosition: Number -> Option<(Number, Number)>,
+  groupPosition: Number => Option<(Number, Number)>,
   /**
    * Returns the number of defined groups in this match object (includes group 0)
    */
@@ -3634,11 +3634,11 @@ provide record MatchResult {
   /**
    * Returns the contents of all groups matched in this match object
    */
-  allGroups: () -> Array<Option<String>>,
+  allGroups: () => Array<Option<String>>,
   /**
    * Returns the positions of all groups matched in this match object
    */
-  allGroupPositions: () -> Array<Option<(Number, Number)>>,
+  allGroupPositions: () => Array<Option<(Number, Number)>>,
 }
 
 let makeMatchResult = (origString, start, end, state) => {

--- a/stdlib/regex.md
+++ b/stdlib/regex.md
@@ -32,11 +32,11 @@ No other changes yet.
 
 ```grain
 record MatchResult {
-  group: Number -> Option<String>,
-  groupPosition: Number -> Option<(Number, Number)>,
+  group: Number => Option<String>,
+  groupPosition: Number => Option<(Number, Number)>,
   numGroups: Number,
-  allGroups: () -> Array<Option<String>>,
-  allGroupPositions: () -> Array<Option<(Number, Number)>>,
+  allGroups: () => Array<Option<String>>,
+  allGroupPositions: () => Array<Option<(Number, Number)>>,
 }
 ```
 
@@ -45,14 +45,14 @@ of a regular expression match. The results can be obtained using
 the following accessors:
 
 ```grain
-group : Number -> Option<String>
+group : Number => Option<String>
 ```
 
 Returns the contents of the given group. Note that group 0 contains
 the entire matched substring, and group 1 contains the first parenthesized group.
 
 ```grain
-groupPosition : Number -> Option<(Number, Number)>
+groupPosition : Number => Option<(Number, Number)>
 ```
 
 Returns the position of the given group.
@@ -64,13 +64,13 @@ numGroups : Number
 The number of defined groups in this match object (including group 0).
 
 ```grain
-allGroups : () -> Array<Option<String>>
+allGroups : () => Array<Option<String>>
 ```
 
 Returns the contents of all groups matched in this match object.
 
 ```grain
-allGroupPositions : () -> Array<Option<(Number, Number)>>
+allGroupPositions : () => Array<Option<(Number, Number)>>
 ```
 
 Returns the positions of all groups matched in this match object.
@@ -87,7 +87,7 @@ No other changes yet.
 </details>
 
 ```grain
-make : (regexString: String) -> Result<RegularExpression, String>
+make : (regexString: String) => Result<RegularExpression, String>
 ```
 
 Compiles the given pattern string into a regular expression object.
@@ -200,7 +200,7 @@ No other changes yet.
 </details>
 
 ```grain
-isMatch : (rx: RegularExpression, string: String) -> Bool
+isMatch : (rx: RegularExpression, string: String) => Bool
 ```
 
 Determines if the given regular expression has a match in the given string.
@@ -233,7 +233,7 @@ No other changes yet.
 
 ```grain
 isMatchRange :
-  (rx: RegularExpression, string: String, start: Number, end: Number) -> Bool
+  (rx: RegularExpression, string: String, start: Number, end: Number) => Bool
 ```
 
 Determines if the given regular expression has a match in the given string between the given start/end offsets.
@@ -271,7 +271,7 @@ No other changes yet.
 </details>
 
 ```grain
-find : (rx: RegularExpression, string: String) -> Option<MatchResult>
+find : (rx: RegularExpression, string: String) => Option<MatchResult>
 ```
 
 Returns the first match for the given regular expression contained within the given string.
@@ -304,7 +304,7 @@ No other changes yet.
 
 ```grain
 findRange :
-  (rx: RegularExpression, string: String, start: Number, end: Number) ->
+  (rx: RegularExpression, string: String, start: Number, end: Number) =>
    Option<MatchResult>
 ```
 
@@ -335,7 +335,7 @@ Regex.findRange(Result.unwrap(Regex.make("ca+[at]")), "caaat", 0, 5)
 ### Regex.**findAll**
 
 ```grain
-findAll : (rx: RegularExpression, string: String) -> List<MatchResult>
+findAll : (rx: RegularExpression, string: String) => List<MatchResult>
 ```
 
 Returns all matches for the given regular expression contained within the given string.
@@ -362,7 +362,7 @@ No other changes yet.
 
 ```grain
 findAllRange :
-  (rx: RegularExpression, string: String, start: Number, end: Number) ->
+  (rx: RegularExpression, string: String, start: Number, end: Number) =>
    List<MatchResult>
 ```
 
@@ -399,7 +399,7 @@ No other changes yet.
 
 ```grain
 replace :
-  (rx: RegularExpression, toSearch: String, replacement: String) -> String
+  (rx: RegularExpression, toSearch: String, replacement: String) => String
 ```
 
 Replaces the first match for the given regular expression contained within the given string with the specified replacement.
@@ -441,7 +441,7 @@ No other changes yet.
 
 ```grain
 replaceAll :
-  (rx: RegularExpression, toSearch: String, replacement: String) -> String
+  (rx: RegularExpression, toSearch: String, replacement: String) => String
 ```
 
 Replaces all matches for the given regular expression contained within the given string with the specified replacement.
@@ -475,7 +475,7 @@ No other changes yet.
 </details>
 
 ```grain
-split : (rx: RegularExpression, str: String) -> List<String>
+split : (rx: RegularExpression, str: String) => List<String>
 ```
 
 Splits the given string at the first match for the given regular expression.
@@ -510,7 +510,7 @@ No other changes yet.
 </details>
 
 ```grain
-splitAll : (rx: RegularExpression, str: String) -> List<String>
+splitAll : (rx: RegularExpression, str: String) => List<String>
 ```
 
 Splits the given string at every match for the given regular expression.

--- a/stdlib/result.md
+++ b/stdlib/result.md
@@ -36,7 +36,7 @@ No other changes yet.
 </details>
 
 ```grain
-isOk : (result: Result<a, b>) -> Bool
+isOk : (result: Result<a, b>) => Bool
 ```
 
 Checks if the Result is the `Ok` variant.
@@ -61,7 +61,7 @@ No other changes yet.
 </details>
 
 ```grain
-isErr : (result: Result<a, b>) -> Bool
+isErr : (result: Result<a, b>) => Bool
 ```
 
 Checks if the Result is the `Err` variant.
@@ -86,7 +86,7 @@ No other changes yet.
 </details>
 
 ```grain
-toOption : (result: Result<a, b>) -> Option<a>
+toOption : (result: Result<a, b>) => Option<a>
 ```
 
 Converts the Result to an Option. An error value is discarded and replaced with `None`.
@@ -111,7 +111,7 @@ No other changes yet.
 </details>
 
 ```grain
-flatMap : (fn: (a -> Result<b, c>), result: Result<a, c>) -> Result<b, c>
+flatMap : (fn: (a => Result<b, c>), result: Result<a, c>) => Result<b, c>
 ```
 
 If the Result is `Ok(value)`, applies the given function to the `value` to produce a new Result.
@@ -120,7 +120,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Result<b, c>`|The function to call on the value of an `Ok` variant|
+|`fn`|`a => Result<b, c>`|The function to call on the value of an `Ok` variant|
 |`result`|`Result<a, c>`|The result to map|
 
 Returns:
@@ -137,7 +137,7 @@ No other changes yet.
 </details>
 
 ```grain
-flatMapErr : (fn: (a -> Result<b, c>), result: Result<b, a>) -> Result<b, c>
+flatMapErr : (fn: (a => Result<b, c>), result: Result<b, a>) => Result<b, c>
 ```
 
 If the Result is an `Err(value)`, applies the given function to the `value` to produce a new Result.
@@ -146,7 +146,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Result<b, c>`|The function to call on the value of an `Err` variant|
+|`fn`|`a => Result<b, c>`|The function to call on the value of an `Err` variant|
 |`result`|`Result<b, a>`|The result to map|
 
 Returns:
@@ -163,7 +163,7 @@ No other changes yet.
 </details>
 
 ```grain
-map : (fn: (a -> b), result: Result<a, c>) -> Result<b, c>
+map : (fn: (a => b), result: Result<a, c>) => Result<b, c>
 ```
 
 If the Result is `Ok(value)`, applies the given function to the `value` and wraps the new value in an `Ok` variant.
@@ -172,7 +172,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> b`|The function to call on the value of an `Ok` variant|
+|`fn`|`a => b`|The function to call on the value of an `Ok` variant|
 |`result`|`Result<a, c>`|The result to map|
 
 Returns:
@@ -189,7 +189,7 @@ No other changes yet.
 </details>
 
 ```grain
-mapErr : (fn: (a -> b), result: Result<c, a>) -> Result<c, b>
+mapErr : (fn: (a => b), result: Result<c, a>) => Result<c, b>
 ```
 
 If the Result is `Err(value)`, applies the given function to the `value` and wraps the new value in an `Err` variant.
@@ -198,7 +198,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> b`|The function to call on the value of an `Err` variant|
+|`fn`|`a => b`|The function to call on the value of an `Err` variant|
 |`result`|`Result<c, a>`|The result to map|
 
 Returns:
@@ -215,7 +215,7 @@ No other changes yet.
 </details>
 
 ```grain
-mapWithDefault : (fn: (a -> b), def: b, result: Result<a, c>) -> b
+mapWithDefault : (fn: (a => b), def: b, result: Result<a, c>) => b
 ```
 
 If the Result is `Ok(value)`, applies the given function to the `value` to produce a new value, otherwise uses the default value.
@@ -225,7 +225,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> b`|The function to call on the value of an `Ok` variant|
+|`fn`|`a => b`|The function to call on the value of an `Ok` variant|
 |`def`|`b`|A fallback value for an `Err` variant|
 |`result`|`Result<a, c>`|The result to map|
 
@@ -244,7 +244,7 @@ No other changes yet.
 
 ```grain
 mapWithDefaultFn :
-  (fnOk: (a -> b), fnErr: (c -> b), result: Result<a, c>) -> b
+  (fnOk: (a => b), fnErr: (c => b), result: Result<a, c>) => b
 ```
 
 If the Result is `Ok(value)`, applies the `fnOk` function to the `value` to produce a new value.
@@ -255,8 +255,8 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fnOk`|`a -> b`|The function to call on the value of an `Ok` variant|
-|`fnErr`|`c -> b`|The function to call on the value of an `Err` variant|
+|`fnOk`|`a => b`|The function to call on the value of an `Ok` variant|
+|`fnErr`|`c => b`|The function to call on the value of an `Err` variant|
 |`result`|`Result<a, c>`|The result to map|
 
 Returns:
@@ -280,7 +280,7 @@ Returns:
 </details>
 
 ```grain
-(||) : (result1: Result<a, b>, result2: Result<a, b>) -> Result<a, b>
+(||) : (result1: Result<a, b>, result2: Result<a, b>) => Result<a, b>
 ```
 
 Behaves like a logical OR (`||`) where the first Result is only returned if it is the `Ok` variant and falling back to the second Result in all other cases.
@@ -313,7 +313,7 @@ Returns:
 </details>
 
 ```grain
-(&&) : (result1: Result<a, b>, result2: Result<a, b>) -> Result<a, b>
+(&&) : (result1: Result<a, b>, result2: Result<a, b>) => Result<a, b>
 ```
 
 Behaves like a logical AND (`&&`) where the first Result is only returned if it is the `Err` variant and falling back to the second Result in all other cases.
@@ -339,7 +339,7 @@ No other changes yet.
 </details>
 
 ```grain
-peek : (fnOk: (a -> b), fnErr: (c -> d), result: Result<a, c>) -> Void
+peek : (fnOk: (a => b), fnErr: (c => d), result: Result<a, c>) => Void
 ```
 
 If the Result is `Ok(value)`, applies the `fnOk` function to the `value` without producing a new value.
@@ -350,8 +350,8 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fnOk`|`a -> b`|The function to call on the value of an `Ok` variant|
-|`fnErr`|`c -> d`|The function to call on the value of an `Err` variant|
+|`fnOk`|`a => b`|The function to call on the value of an `Ok` variant|
+|`fnErr`|`c => d`|The function to call on the value of an `Err` variant|
 |`result`|`Result<a, c>`|The result to inspect|
 
 ### Result.**peekOk**
@@ -362,7 +362,7 @@ No other changes yet.
 </details>
 
 ```grain
-peekOk : (fn: (a -> b), result: Result<a, c>) -> Void
+peekOk : (fn: (a => b), result: Result<a, c>) => Void
 ```
 
 If the Result is `Ok(value)`, applies the given function to the `value` without producing a new value.
@@ -371,7 +371,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> b`|The function to call on the value of an `Ok` variant|
+|`fn`|`a => b`|The function to call on the value of an `Ok` variant|
 |`result`|`Result<a, c>`|The result to inspect|
 
 ### Result.**peekErr**
@@ -382,7 +382,7 @@ No other changes yet.
 </details>
 
 ```grain
-peekErr : (fn: (a -> b), result: Result<c, a>) -> Void
+peekErr : (fn: (a => b), result: Result<c, a>) => Void
 ```
 
 If the Result is `Err(value)`, applies the given function to the `value` without producing a new value.
@@ -391,7 +391,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> b`|The function to call on the value of an `Err` variant|
+|`fn`|`a => b`|The function to call on the value of an `Err` variant|
 |`result`|`Result<c, a>`|The result to inspect|
 
 ### Result.**expect**
@@ -402,7 +402,7 @@ No other changes yet.
 </details>
 
 ```grain
-expect : (msg: String, result: Result<a, b>) -> a
+expect : (msg: String, result: Result<a, b>) => a
 ```
 
 Extracts the value inside an `Ok` result, otherwise throw an
@@ -441,7 +441,7 @@ No other changes yet.
 </details>
 
 ```grain
-unwrap : (result: Result<a, b>) -> a
+unwrap : (result: Result<a, b>) => a
 ```
 
 Extracts the value inside an `Ok` result, otherwise throw an

--- a/stdlib/runtime/atof/common.md
+++ b/stdlib/runtime/atof/common.md
@@ -196,60 +196,60 @@ _CHAR_CODE_y : WasmI32
 ### Common.**fpZero**
 
 ```grain
-fpZero : () -> BiasedFp
+fpZero : () => BiasedFp
 ```
 
 ### Common.**fpInf**
 
 ```grain
-fpInf : () -> BiasedFp
+fpInf : () => BiasedFp
 ```
 
 ### Common.**fpErr**
 
 ```grain
-fpErr : () -> BiasedFp
+fpErr : () => BiasedFp
 ```
 
 ### Common.**fpNan**
 
 ```grain
-fpNan : () -> BiasedFp
+fpNan : () => BiasedFp
 ```
 
 ### Common.**getPowers10**
 
 ```grain
-getPowers10 : (i: WasmI32) -> WasmI32
+getPowers10 : (i: WasmI32) => WasmI32
 ```
 
 ### Common.**getPowers10FastPath**
 
 ```grain
-getPowers10FastPath : (i: WasmI32) -> WasmF64
+getPowers10FastPath : (i: WasmI32) => WasmF64
 ```
 
 ### Common.**is8Digits**
 
 ```grain
-is8Digits : (value: WasmI64) -> Bool
+is8Digits : (value: WasmI64) => Bool
 ```
 
 ### Common.**power**
 
 ```grain
-power : (q: WasmI32) -> WasmI32
+power : (q: WasmI32) => WasmI32
 ```
 
 ### Common.**fullMultiplication**
 
 ```grain
-fullMultiplication : (a: WasmI64, b: WasmI64) -> (Int64, Int64)
+fullMultiplication : (a: WasmI64, b: WasmI64) => (Int64, Int64)
 ```
 
 ### Common.**biasedFpToNumber**
 
 ```grain
-biasedFpToNumber : (fp: BiasedFp, negative: Bool) -> Number
+biasedFpToNumber : (fp: BiasedFp, negative: Bool) => Number
 ```
 

--- a/stdlib/runtime/atof/decimal.md
+++ b/stdlib/runtime/atof/decimal.md
@@ -30,42 +30,42 @@ _DECIMAL_POINT_RANGE : WasmI32
 ### Decimal.**tryAddDigit**
 
 ```grain
-tryAddDigit : (d: Decimal, digit: WasmI32) -> Void
+tryAddDigit : (d: Decimal, digit: WasmI32) => Void
 ```
 
 ### Decimal.**round**
 
 ```grain
-round : (d: Decimal) -> WasmI64
+round : (d: Decimal) => WasmI64
 ```
 
 ### Decimal.**get_TABLE**
 
 ```grain
-get_TABLE : () -> WasmI32
+get_TABLE : () => WasmI32
 ```
 
 ### Decimal.**get_TABLE_POW5**
 
 ```grain
-get_TABLE_POW5 : () -> WasmI32
+get_TABLE_POW5 : () => WasmI32
 ```
 
 ### Decimal.**leftShift**
 
 ```grain
-leftShift : (d: Decimal, shift: WasmI32) -> Void
+leftShift : (d: Decimal, shift: WasmI32) => Void
 ```
 
 ### Decimal.**rightShift**
 
 ```grain
-rightShift : (d: Decimal, shift: WasmI32) -> Void
+rightShift : (d: Decimal, shift: WasmI32) => Void
 ```
 
 ### Decimal.**parseDecimal**
 
 ```grain
-parseDecimal : (s: String) -> Decimal
+parseDecimal : (s: String) => Decimal
 ```
 

--- a/stdlib/runtime/atof/lemire.md
+++ b/stdlib/runtime/atof/lemire.md
@@ -9,6 +9,6 @@ Functions and constants included in the Lemire module.
 ### Lemire.**computeFloat**
 
 ```grain
-computeFloat : (exponent: WasmI64, mantissa: WasmI64) -> Common.BiasedFp
+computeFloat : (exponent: WasmI64, mantissa: WasmI64) => Common.BiasedFp
 ```
 

--- a/stdlib/runtime/atof/parse.md
+++ b/stdlib/runtime/atof/parse.md
@@ -10,13 +10,13 @@ Functions and constants included in the Parse module.
 
 ```grain
 isFastPath :
-  (exponent: WasmI32, mantissa: WasmI64, negative: Bool, manyDigits: Bool) ->
+  (exponent: WasmI32, mantissa: WasmI64, negative: Bool, manyDigits: Bool) =>
    Bool
 ```
 
 ### Parse.**parseFloat**
 
 ```grain
-parseFloat : (string: String) -> Result<Number, String>
+parseFloat : (string: String) => Result<Number, String>
 ```
 

--- a/stdlib/runtime/atof/slow.md
+++ b/stdlib/runtime/atof/slow.md
@@ -9,6 +9,6 @@ Functions and constants included in the Slow module.
 ### Slow.**parseLongMantissa**
 
 ```grain
-parseLongMantissa : (s: String) -> Common.BiasedFp
+parseLongMantissa : (s: String) => Common.BiasedFp
 ```
 

--- a/stdlib/runtime/atof/table.md
+++ b/stdlib/runtime/atof/table.md
@@ -9,12 +9,12 @@ Functions and constants included in the Table module.
 ### Table.**get_F64_POWERS10_FAST_PATH**
 
 ```grain
-get_F64_POWERS10_FAST_PATH : () -> WasmI32
+get_F64_POWERS10_FAST_PATH : () => WasmI32
 ```
 
 ### Table.**get_POWERS5**
 
 ```grain
-get_POWERS5 : () -> WasmI32
+get_POWERS5 : () => WasmI32
 ```
 

--- a/stdlib/runtime/atoi/parse.md
+++ b/stdlib/runtime/atoi/parse.md
@@ -9,6 +9,6 @@ Functions and constants included in the Parse module.
 ### Parse.**parseInt**
 
 ```grain
-parseInt : (string: String, radix: Number) -> Result<Number, String>
+parseInt : (string: String, radix: Number) => Result<Number, String>
 ```
 

--- a/stdlib/runtime/bigint.md
+++ b/stdlib/runtime/bigint.md
@@ -9,61 +9,61 @@ Functions and constants included in the Bigint module.
 ### Bigint.**debugDumpNumber**
 
 ```grain
-debugDumpNumber : (num: WasmI32) -> Void
+debugDumpNumber : (num: WasmI32) => Void
 ```
 
 ### Bigint.**getSize**
 
 ```grain
-getSize : (ptr: WasmI32) -> WasmI32
+getSize : (ptr: WasmI32) => WasmI32
 ```
 
 ### Bigint.**getFlags**
 
 ```grain
-getFlags : (ptr: WasmI32) -> WasmI32
+getFlags : (ptr: WasmI32) => WasmI32
 ```
 
 ### Bigint.**getLimb**
 
 ```grain
-getLimb : (ptr: WasmI32, i: WasmI32) -> WasmI64
+getLimb : (ptr: WasmI32, i: WasmI32) => WasmI64
 ```
 
 ### Bigint.**makeWrappedInt32**
 
 ```grain
-makeWrappedInt32 : (value: WasmI32) -> WasmI32
+makeWrappedInt32 : (value: WasmI32) => WasmI32
 ```
 
 ### Bigint.**makeWrappedUint32**
 
 ```grain
-makeWrappedUint32 : (value: WasmI32) -> WasmI32
+makeWrappedUint32 : (value: WasmI32) => WasmI32
 ```
 
 ### Bigint.**makeWrappedInt64**
 
 ```grain
-makeWrappedInt64 : (value: WasmI64) -> WasmI32
+makeWrappedInt64 : (value: WasmI64) => WasmI32
 ```
 
 ### Bigint.**makeWrappedUint64**
 
 ```grain
-makeWrappedUint64 : (value: WasmI64) -> WasmI32
+makeWrappedUint64 : (value: WasmI64) => WasmI32
 ```
 
 ### Bigint.**isNegative**
 
 ```grain
-isNegative : (num: WasmI32) -> Bool
+isNegative : (num: WasmI32) => Bool
 ```
 
 ### Bigint.**eqz**
 
 ```grain
-eqz : (num: WasmI32) -> Bool
+eqz : (num: WasmI32) => Bool
 ```
 
 Returns true if the given bigint is equal to zero
@@ -71,270 +71,270 @@ Returns true if the given bigint is equal to zero
 ### Bigint.**negate**
 
 ```grain
-negate : (num: WasmI32) -> WasmI32
+negate : (num: WasmI32) => WasmI32
 ```
 
 ### Bigint.**abs**
 
 ```grain
-abs : (num: WasmI32) -> WasmI32
+abs : (num: WasmI32) => WasmI32
 ```
 
 ### Bigint.**canConvertToInt32**
 
 ```grain
-canConvertToInt32 : (num: WasmI32) -> Bool
+canConvertToInt32 : (num: WasmI32) => Bool
 ```
 
 ### Bigint.**toInt32**
 
 ```grain
-toInt32 : (num: WasmI32) -> WasmI32
+toInt32 : (num: WasmI32) => WasmI32
 ```
 
 ### Bigint.**canConvertToInt64**
 
 ```grain
-canConvertToInt64 : (num: WasmI32) -> Bool
+canConvertToInt64 : (num: WasmI32) => Bool
 ```
 
 ### Bigint.**toInt64**
 
 ```grain
-toInt64 : (num: WasmI32) -> WasmI64
+toInt64 : (num: WasmI32) => WasmI64
 ```
 
 ### Bigint.**toUnsignedInt64**
 
 ```grain
-toUnsignedInt64 : (num: WasmI32) -> WasmI64
+toUnsignedInt64 : (num: WasmI32) => WasmI64
 ```
 
 ### Bigint.**toFloat64**
 
 ```grain
-toFloat64 : (num: WasmI32) -> WasmF64
+toFloat64 : (num: WasmI32) => WasmF64
 ```
 
 ### Bigint.**toFloat32**
 
 ```grain
-toFloat32 : (num: WasmI32) -> WasmF32
+toFloat32 : (num: WasmI32) => WasmF32
 ```
 
 ### Bigint.**cmpI64**
 
 ```grain
-cmpI64 : (num1: WasmI32, num2: WasmI64) -> WasmI32
+cmpI64 : (num1: WasmI32, num2: WasmI64) => WasmI32
 ```
 
 ### Bigint.**cmpU64**
 
 ```grain
-cmpU64 : (num1: WasmI32, num2: WasmI64) -> WasmI32
+cmpU64 : (num1: WasmI32, num2: WasmI64) => WasmI32
 ```
 
 ### Bigint.**cmpF64**
 
 ```grain
-cmpF64 : (num1: WasmI32, num2: WasmF64) -> WasmI32
+cmpF64 : (num1: WasmI32, num2: WasmF64) => WasmI32
 ```
 
 ### Bigint.**cmpF32**
 
 ```grain
-cmpF32 : (num1: WasmI32, num2: WasmF32) -> WasmI32
+cmpF32 : (num1: WasmI32, num2: WasmF32) => WasmI32
 ```
 
 ### Bigint.**cmp**
 
 ```grain
-cmp : (num1: WasmI32, num2: WasmI32) -> WasmI32
+cmp : (num1: WasmI32, num2: WasmI32) => WasmI32
 ```
 
 ### Bigint.**eq**
 
 ```grain
-eq : (num1: WasmI32, num2: WasmI32) -> Bool
+eq : (num1: WasmI32, num2: WasmI32) => Bool
 ```
 
 ### Bigint.**ne**
 
 ```grain
-ne : (num1: WasmI32, num2: WasmI32) -> Bool
+ne : (num1: WasmI32, num2: WasmI32) => Bool
 ```
 
 ### Bigint.**lt**
 
 ```grain
-lt : (num1: WasmI32, num2: WasmI32) -> Bool
+lt : (num1: WasmI32, num2: WasmI32) => Bool
 ```
 
 ### Bigint.**lte**
 
 ```grain
-lte : (num1: WasmI32, num2: WasmI32) -> Bool
+lte : (num1: WasmI32, num2: WasmI32) => Bool
 ```
 
 ### Bigint.**gt**
 
 ```grain
-gt : (num1: WasmI32, num2: WasmI32) -> Bool
+gt : (num1: WasmI32, num2: WasmI32) => Bool
 ```
 
 ### Bigint.**gte**
 
 ```grain
-gte : (num1: WasmI32, num2: WasmI32) -> Bool
+gte : (num1: WasmI32, num2: WasmI32) => Bool
 ```
 
 ### Bigint.**bigIntToString**
 
 ```grain
-bigIntToString : (num: WasmI32, base: WasmI32) -> String
+bigIntToString : (num: WasmI32, base: WasmI32) => String
 ```
 
 ### Bigint.**bigIntToString10**
 
 ```grain
-bigIntToString10 : (num: WasmI32) -> String
+bigIntToString10 : (num: WasmI32) => String
 ```
 
 ### Bigint.**add**
 
 ```grain
-add : (num1: WasmI32, num2: WasmI32) -> WasmI32
+add : (num1: WasmI32, num2: WasmI32) => WasmI32
 ```
 
 ### Bigint.**addInt**
 
 ```grain
-addInt : (num1: WasmI32, int: WasmI64) -> WasmI32
+addInt : (num1: WasmI32, int: WasmI64) => WasmI32
 ```
 
 ### Bigint.**sub**
 
 ```grain
-sub : (num1: WasmI32, num2: WasmI32) -> WasmI32
+sub : (num1: WasmI32, num2: WasmI32) => WasmI32
 ```
 
 ### Bigint.**subInt**
 
 ```grain
-subInt : (num1: WasmI32, int: WasmI64) -> WasmI32
+subInt : (num1: WasmI32, int: WasmI64) => WasmI32
 ```
 
 ### Bigint.**incr**
 
 ```grain
-incr : (num: WasmI32) -> WasmI32
+incr : (num: WasmI32) => WasmI32
 ```
 
 ### Bigint.**decr**
 
 ```grain
-decr : (num: WasmI32) -> WasmI32
+decr : (num: WasmI32) => WasmI32
 ```
 
 ### Bigint.**mul**
 
 ```grain
-mul : (num1: WasmI32, num2: WasmI32) -> WasmI32
+mul : (num1: WasmI32, num2: WasmI32) => WasmI32
 ```
 
 ### Bigint.**shl**
 
 ```grain
-shl : (num: WasmI32, places: WasmI32) -> WasmI32
+shl : (num: WasmI32, places: WasmI32) => WasmI32
 ```
 
 ### Bigint.**shrS**
 
 ```grain
-shrS : (num: WasmI32, places: WasmI32) -> WasmI32
+shrS : (num: WasmI32, places: WasmI32) => WasmI32
 ```
 
 ### Bigint.**bitwiseNot**
 
 ```grain
-bitwiseNot : (num: WasmI32) -> WasmI32
+bitwiseNot : (num: WasmI32) => WasmI32
 ```
 
 ### Bigint.**bitwiseAnd**
 
 ```grain
-bitwiseAnd : (num1: WasmI32, num2: WasmI32) -> WasmI32
+bitwiseAnd : (num1: WasmI32, num2: WasmI32) => WasmI32
 ```
 
 ### Bigint.**bitwiseOr**
 
 ```grain
-bitwiseOr : (num1: WasmI32, num2: WasmI32) -> WasmI32
+bitwiseOr : (num1: WasmI32, num2: WasmI32) => WasmI32
 ```
 
 ### Bigint.**bitwiseXor**
 
 ```grain
-bitwiseXor : (num1: WasmI32, num2: WasmI32) -> WasmI32
+bitwiseXor : (num1: WasmI32, num2: WasmI32) => WasmI32
 ```
 
 ### Bigint.**countLeadingZeros**
 
 ```grain
-countLeadingZeros : (num: WasmI32) -> WasmI32
+countLeadingZeros : (num: WasmI32) => WasmI32
 ```
 
 ### Bigint.**countTrailingZeros**
 
 ```grain
-countTrailingZeros : (num: WasmI32) -> WasmI64
+countTrailingZeros : (num: WasmI32) => WasmI64
 ```
 
 ### Bigint.**popcnt**
 
 ```grain
-popcnt : (num: WasmI32, flagDest: WasmI32) -> WasmI64
+popcnt : (num: WasmI32, flagDest: WasmI32) => WasmI64
 ```
 
 ### Bigint.**gcd**
 
 ```grain
-gcd : (num1: WasmI32, num2: WasmI32) -> WasmI32
+gcd : (num1: WasmI32, num2: WasmI32) => WasmI32
 ```
 
 ### Bigint.**quotRem**
 
 ```grain
-quotRem : (num1: WasmI32, num2: WasmI32, dest: WasmI32) -> Void
+quotRem : (num1: WasmI32, num2: WasmI32, dest: WasmI32) => Void
 ```
 
 ### Bigint.**divMod**
 
 ```grain
-divMod : (num1: WasmI32, num2: WasmI32, dest: WasmI32) -> Void
+divMod : (num1: WasmI32, num2: WasmI32, dest: WasmI32) => Void
 ```
 
 ### Bigint.**quot**
 
 ```grain
-quot : (num1: WasmI32, num2: WasmI32) -> WasmI32
+quot : (num1: WasmI32, num2: WasmI32) => WasmI32
 ```
 
 ### Bigint.**div**
 
 ```grain
-div : (num1: WasmI32, num2: WasmI32) -> WasmI32
+div : (num1: WasmI32, num2: WasmI32) => WasmI32
 ```
 
 ### Bigint.**rem**
 
 ```grain
-rem : (num1: WasmI32, num2: WasmI32) -> WasmI32
+rem : (num1: WasmI32, num2: WasmI32) => WasmI32
 ```
 
 ### Bigint.**mod**
 
 ```grain
-mod : (num1: WasmI32, num2: WasmI32) -> WasmI32
+mod : (num1: WasmI32, num2: WasmI32) => WasmI32
 ```
 

--- a/stdlib/runtime/compare.md
+++ b/stdlib/runtime/compare.md
@@ -14,7 +14,7 @@ No other changes yet.
 </details>
 
 ```grain
-compare : (x: a, y: a) -> Number
+compare : (x: a, y: a) => Number
 ```
 
 Compares the first argument to the second argument and produces an integer result.

--- a/stdlib/runtime/dataStructures.md
+++ b/stdlib/runtime/dataStructures.md
@@ -9,7 +9,7 @@ Functions and constants included in the DataStructures module.
 ### DataStructures.**allocateArray**
 
 ```grain
-allocateArray : WasmI32 -> WasmI32
+allocateArray : WasmI32 => WasmI32
 ```
 
 Allocates a new Grain array.
@@ -29,7 +29,7 @@ Returns:
 ### DataStructures.**allocateTuple**
 
 ```grain
-allocateTuple : WasmI32 -> WasmI32
+allocateTuple : WasmI32 => WasmI32
 ```
 
 Allocates a new Grain tuple.
@@ -49,7 +49,7 @@ Returns:
 ### DataStructures.**allocateBytes**
 
 ```grain
-allocateBytes : WasmI32 -> WasmI32
+allocateBytes : WasmI32 => WasmI32
 ```
 
 Allocates a new Grain bytes.
@@ -69,7 +69,7 @@ Returns:
 ### DataStructures.**allocateString**
 
 ```grain
-allocateString : WasmI32 -> WasmI32
+allocateString : WasmI32 => WasmI32
 ```
 
 Allocates a new Grain string.
@@ -89,7 +89,7 @@ Returns:
 ### DataStructures.**allocateInt32**
 
 ```grain
-allocateInt32 : () -> WasmI32
+allocateInt32 : () => WasmI32
 ```
 
 Allocates a new Int32.
@@ -103,7 +103,7 @@ Returns:
 ### DataStructures.**newInt32**
 
 ```grain
-newInt32 : WasmI32 -> WasmI32
+newInt32 : WasmI32 => WasmI32
 ```
 
 Allocates a new Int32 with a prepopulated value
@@ -123,7 +123,7 @@ Returns:
 ### DataStructures.**allocateUint32**
 
 ```grain
-allocateUint32 : () -> WasmI32
+allocateUint32 : () => WasmI32
 ```
 
 Allocates a new Uint32.
@@ -137,7 +137,7 @@ Returns:
 ### DataStructures.**newUint32**
 
 ```grain
-newUint32 : WasmI32 -> WasmI32
+newUint32 : WasmI32 => WasmI32
 ```
 
 Allocates a new Uint32 with a prepopulated value
@@ -157,7 +157,7 @@ Returns:
 ### DataStructures.**allocateInt64**
 
 ```grain
-allocateInt64 : () -> WasmI32
+allocateInt64 : () => WasmI32
 ```
 
 Allocates a new Int64.
@@ -171,7 +171,7 @@ Returns:
 ### DataStructures.**newInt64**
 
 ```grain
-newInt64 : WasmI64 -> WasmI32
+newInt64 : WasmI64 => WasmI32
 ```
 
 Allocates a new Int64 with a prepopulated value
@@ -191,7 +191,7 @@ Returns:
 ### DataStructures.**allocateUint64**
 
 ```grain
-allocateUint64 : () -> WasmI32
+allocateUint64 : () => WasmI32
 ```
 
 Allocates a new Uint64.
@@ -205,7 +205,7 @@ Returns:
 ### DataStructures.**newUint64**
 
 ```grain
-newUint64 : WasmI64 -> WasmI32
+newUint64 : WasmI64 => WasmI32
 ```
 
 Allocates a new Uint64 with a prepopulated value
@@ -225,7 +225,7 @@ Returns:
 ### DataStructures.**allocateFloat32**
 
 ```grain
-allocateFloat32 : () -> WasmI32
+allocateFloat32 : () => WasmI32
 ```
 
 Allocates a new Float32.
@@ -239,7 +239,7 @@ Returns:
 ### DataStructures.**newFloat32**
 
 ```grain
-newFloat32 : WasmF32 -> WasmI32
+newFloat32 : WasmF32 => WasmI32
 ```
 
 Allocates a new Float32 with a prepopulated value
@@ -259,7 +259,7 @@ Returns:
 ### DataStructures.**allocateFloat64**
 
 ```grain
-allocateFloat64 : () -> WasmI32
+allocateFloat64 : () => WasmI32
 ```
 
 Allocates a new Float64.
@@ -273,7 +273,7 @@ Returns:
 ### DataStructures.**newFloat64**
 
 ```grain
-newFloat64 : WasmF64 -> WasmI32
+newFloat64 : WasmF64 => WasmI32
 ```
 
 Allocates a new Float64 with a prepopulated value
@@ -293,7 +293,7 @@ Returns:
 ### DataStructures.**allocateRational**
 
 ```grain
-allocateRational : () -> WasmI32
+allocateRational : () => WasmI32
 ```
 
 Allocates a new Rational.
@@ -307,7 +307,7 @@ Returns:
 ### DataStructures.**newRational**
 
 ```grain
-newRational : (WasmI32, WasmI32) -> WasmI32
+newRational : (WasmI32, WasmI32) => WasmI32
 ```
 
 Allocates a new Rational with a prepopulated value
@@ -328,7 +328,7 @@ Returns:
 ### DataStructures.**loadAdtVariant**
 
 ```grain
-loadAdtVariant : WasmI32 -> WasmI32
+loadAdtVariant : WasmI32 => WasmI32
 ```
 
 Load the (tagged) variant of an ADT.
@@ -348,7 +348,7 @@ Returns:
 ### DataStructures.**stringSize**
 
 ```grain
-stringSize : WasmI32 -> WasmI32
+stringSize : WasmI32 => WasmI32
 ```
 
 Load an untagged string's size.
@@ -368,7 +368,7 @@ Returns:
 ### DataStructures.**bytesSize**
 
 ```grain
-bytesSize : WasmI32 -> WasmI32
+bytesSize : WasmI32 => WasmI32
 ```
 
 Load an untagged Bytes' size.
@@ -388,7 +388,7 @@ Returns:
 ### DataStructures.**tagSimpleNumber**
 
 ```grain
-tagSimpleNumber : WasmI32 -> Number
+tagSimpleNumber : WasmI32 => Number
 ```
 
 Tag a simple number.
@@ -408,7 +408,7 @@ Returns:
 ### DataStructures.**untagSimpleNumber**
 
 ```grain
-untagSimpleNumber : Number -> WasmI32
+untagSimpleNumber : Number => WasmI32
 ```
 
 Untag a simple number.
@@ -428,7 +428,7 @@ Returns:
 ### DataStructures.**tagChar**
 
 ```grain
-tagChar : WasmI32 -> Char
+tagChar : WasmI32 => Char
 ```
 
 Tag a char.
@@ -448,7 +448,7 @@ Returns:
 ### DataStructures.**untagChar**
 
 ```grain
-untagChar : Char -> WasmI32
+untagChar : Char => WasmI32
 ```
 
 Untag a char.
@@ -468,7 +468,7 @@ Returns:
 ### DataStructures.**tagInt8**
 
 ```grain
-tagInt8 : WasmI32 -> Int8
+tagInt8 : WasmI32 => Int8
 ```
 
 Tag an int8.
@@ -488,7 +488,7 @@ Returns:
 ### DataStructures.**untagInt8**
 
 ```grain
-untagInt8 : Int8 -> WasmI32
+untagInt8 : Int8 => WasmI32
 ```
 
 Untag an int8.
@@ -508,7 +508,7 @@ Returns:
 ### DataStructures.**tagInt16**
 
 ```grain
-tagInt16 : WasmI32 -> Int16
+tagInt16 : WasmI32 => Int16
 ```
 
 Tag an int16.
@@ -528,7 +528,7 @@ Returns:
 ### DataStructures.**untagInt16**
 
 ```grain
-untagInt16 : Int16 -> WasmI32
+untagInt16 : Int16 => WasmI32
 ```
 
 Untag an int16.
@@ -548,7 +548,7 @@ Returns:
 ### DataStructures.**tagUint8**
 
 ```grain
-tagUint8 : WasmI32 -> Uint8
+tagUint8 : WasmI32 => Uint8
 ```
 
 Tag a uint8.
@@ -568,7 +568,7 @@ Returns:
 ### DataStructures.**untagUint8**
 
 ```grain
-untagUint8 : Uint8 -> WasmI32
+untagUint8 : Uint8 => WasmI32
 ```
 
 Untag a uint8.
@@ -588,7 +588,7 @@ Returns:
 ### DataStructures.**tagUint16**
 
 ```grain
-tagUint16 : WasmI32 -> Uint16
+tagUint16 : WasmI32 => Uint16
 ```
 
 Tag a uint16.
@@ -608,7 +608,7 @@ Returns:
 ### DataStructures.**untagUint16**
 
 ```grain
-untagUint16 : Uint16 -> WasmI32
+untagUint16 : Uint16 => WasmI32
 ```
 
 Untag a uint16.

--- a/stdlib/runtime/debug.gr
+++ b/stdlib/runtime/debug.gr
@@ -1,4 +1,4 @@
 /* grainc-flags --compilation-mode=runtime */
 module Debug
 
-provide foreign wasm debug: a -> Void from "console"
+provide foreign wasm debug: a => Void from "console"

--- a/stdlib/runtime/debug.md
+++ b/stdlib/runtime/debug.md
@@ -9,6 +9,6 @@ Functions and constants included in the Debug module.
 ### Debug.**debug**
 
 ```grain
-debug : a -> Void
+debug : a => Void
 ```
 

--- a/stdlib/runtime/debugPrint.gr
+++ b/stdlib/runtime/debugPrint.gr
@@ -11,7 +11,7 @@ foreign wasm fd_write: (
   WasmI32,
   WasmI32,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 
 @unsafe
 provide let print = (s: String) => {

--- a/stdlib/runtime/debugPrint.md
+++ b/stdlib/runtime/debugPrint.md
@@ -9,30 +9,30 @@ Functions and constants included in the DebugPrint module.
 ### DebugPrint.**print**
 
 ```grain
-print : (s: String) -> Void
+print : (s: String) => Void
 ```
 
 ### DebugPrint.**printI32**
 
 ```grain
-printI32 : (val: WasmI32) -> Void
+printI32 : (val: WasmI32) => Void
 ```
 
 ### DebugPrint.**printI64**
 
 ```grain
-printI64 : (val: WasmI64) -> Void
+printI64 : (val: WasmI64) => Void
 ```
 
 ### DebugPrint.**printF32**
 
 ```grain
-printF32 : (val: WasmF32) -> Void
+printF32 : (val: WasmF32) => Void
 ```
 
 ### DebugPrint.**printF64**
 
 ```grain
-printF64 : (val: WasmF64) -> Void
+printF64 : (val: WasmF64) => Void
 ```
 

--- a/stdlib/runtime/equal.md
+++ b/stdlib/runtime/equal.md
@@ -14,7 +14,7 @@ No other changes yet.
 </details>
 
 ```grain
-equal : (x: a, y: a) -> Bool
+equal : (x: a, y: a) => Bool
 ```
 
 Check that two values are equal. This checks for structural equality,

--- a/stdlib/runtime/exception.gr
+++ b/stdlib/runtime/exception.gr
@@ -9,7 +9,7 @@ foreign wasm fd_write: (
   WasmI32,
   WasmI32,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 
 primitive unreachable = "@unreachable"
 
@@ -24,7 +24,7 @@ provide let dangerouslyRegisterBasePrinter = f => {
   while (true) {
     // There will be at least one printer registered by the time this is called
     let (_, next) = WasmI32.toGrain(current): (
-      Exception -> Option<String>,
+      Exception => Option<String>,
       WasmI32
     )
     if (next == 0n) {
@@ -63,7 +63,7 @@ let exceptionToString = (e: Exception) => {
   while (true) {
     if (current == 0n) return result
     let (printer, next) = WasmI32.toGrain(current): (
-      Exception -> Option<String>,
+      Exception => Option<String>,
       WasmI32
     )
     // as GC is not available, manually increment the references

--- a/stdlib/runtime/exception.md
+++ b/stdlib/runtime/exception.md
@@ -15,24 +15,24 @@ printers : WasmI32
 ### Exception.**dangerouslyRegisterBasePrinter**
 
 ```grain
-dangerouslyRegisterBasePrinter : (f: a) -> Void
+dangerouslyRegisterBasePrinter : (f: a) => Void
 ```
 
 ### Exception.**dangerouslyRegisterPrinter**
 
 ```grain
-dangerouslyRegisterPrinter : (f: a) -> Void
+dangerouslyRegisterPrinter : (f: a) => Void
 ```
 
 ### Exception.**panic**
 
 ```grain
-panic : (msg: String) -> a
+panic : (msg: String) => a
 ```
 
 ### Exception.**panicWithException**
 
 ```grain
-panicWithException : (e: Exception) -> a
+panicWithException : (e: Exception) => a
 ```
 

--- a/stdlib/runtime/gc.gr
+++ b/stdlib/runtime/gc.gr
@@ -30,7 +30,7 @@ foreign wasm fd_write: (
   WasmI32,
   WasmI32,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 
 primitive (&&) = "@and"
 primitive (||) = "@or"

--- a/stdlib/runtime/gc.md
+++ b/stdlib/runtime/gc.md
@@ -9,24 +9,24 @@ Functions and constants included in the GC module.
 ### GC.**malloc**
 
 ```grain
-malloc : (size: WasmI32) -> WasmI32
+malloc : (size: WasmI32) => WasmI32
 ```
 
 ### GC.**free**
 
 ```grain
-free : (userPtr: WasmI32) -> Void
+free : (userPtr: WasmI32) => Void
 ```
 
 ### GC.**incRef**
 
 ```grain
-incRef : (userPtr: WasmI32) -> WasmI32
+incRef : (userPtr: WasmI32) => WasmI32
 ```
 
 ### GC.**decRef**
 
 ```grain
-decRef : (userPtr: WasmI32) -> WasmI32
+decRef : (userPtr: WasmI32) => WasmI32
 ```
 

--- a/stdlib/runtime/malloc.md
+++ b/stdlib/runtime/malloc.md
@@ -15,7 +15,7 @@ _RESERVED_RUNTIME_SPACE : WasmI32
 ### Malloc.**free**
 
 ```grain
-free : (ap: WasmI32) -> Void
+free : (ap: WasmI32) => Void
 ```
 
 Frees the given allocated pointer.
@@ -29,7 +29,7 @@ Parameters:
 ### Malloc.**malloc**
 
 ```grain
-malloc : (nb: WasmI32) -> WasmI32
+malloc : (nb: WasmI32) => WasmI32
 ```
 
 Allocates the requested number of bytes, returning a pointer.
@@ -49,7 +49,7 @@ Returns:
 ### Malloc.**getFreePtr**
 
 ```grain
-getFreePtr : () -> WasmI32
+getFreePtr : () => WasmI32
 ```
 
 Returns the current free list pointer.

--- a/stdlib/runtime/numberUtils.md
+++ b/stdlib/runtime/numberUtils.md
@@ -15,54 +15,54 @@ _MAX_DOUBLE_LENGTH : WasmI32
 ### NumberUtils.**get_POWERS10**
 
 ```grain
-get_POWERS10 : () -> WasmI32
+get_POWERS10 : () => WasmI32
 ```
 
 ### NumberUtils.**get_HEX_DIGITS**
 
 ```grain
-get_HEX_DIGITS : () -> WasmI32
+get_HEX_DIGITS : () => WasmI32
 ```
 
 ### NumberUtils.**decimalCount32**
 
 ```grain
-decimalCount32 : (value: WasmI32) -> WasmI32
+decimalCount32 : (value: WasmI32) => WasmI32
 ```
 
 ### NumberUtils.**utoa32Buffered**
 
 ```grain
-utoa32Buffered : (buf: WasmI32, value: WasmI32, radix: WasmI32) -> Void
+utoa32Buffered : (buf: WasmI32, value: WasmI32, radix: WasmI32) => Void
 ```
 
 ### NumberUtils.**utoa32**
 
 ```grain
-utoa32 : (value: WasmI32, radix: WasmI32) -> String
+utoa32 : (value: WasmI32, radix: WasmI32) => String
 ```
 
 ### NumberUtils.**itoa32**
 
 ```grain
-itoa32 : (value: WasmI32, radix: WasmI32) -> String
+itoa32 : (value: WasmI32, radix: WasmI32) => String
 ```
 
 ### NumberUtils.**utoa64**
 
 ```grain
-utoa64 : (value: WasmI64, radix: WasmI32) -> String
+utoa64 : (value: WasmI64, radix: WasmI32) => String
 ```
 
 ### NumberUtils.**itoa64**
 
 ```grain
-itoa64 : (value: WasmI64, radix: WasmI32) -> String
+itoa64 : (value: WasmI64, radix: WasmI32) => String
 ```
 
 ### NumberUtils.**dtoa**
 
 ```grain
-dtoa : (value: WasmF64) -> String
+dtoa : (value: WasmF64) => String
 ```
 

--- a/stdlib/runtime/numbers.md
+++ b/stdlib/runtime/numbers.md
@@ -9,153 +9,153 @@ Functions and constants included in the Numbers module.
 ### Numbers.**tagSimple**
 
 ```grain
-tagSimple : (x: WasmI32) -> WasmI32
+tagSimple : (x: WasmI32) => WasmI32
 ```
 
 ### Numbers.**isBoxedNumber**
 
 ```grain
-isBoxedNumber : (x: WasmI32) -> Bool
+isBoxedNumber : (x: WasmI32) => Bool
 ```
 
 ### Numbers.**isFloat**
 
 ```grain
-isFloat : (x: WasmI32) -> Bool
+isFloat : (x: WasmI32) => Bool
 ```
 
 ### Numbers.**isInteger**
 
 ```grain
-isInteger : (x: WasmI32) -> Bool
+isInteger : (x: WasmI32) => Bool
 ```
 
 ### Numbers.**isRational**
 
 ```grain
-isRational : (x: WasmI32) -> Bool
+isRational : (x: WasmI32) => Bool
 ```
 
 ### Numbers.**isNaN**
 
 ```grain
-isNaN : (x: WasmI32) -> Bool
+isNaN : (x: WasmI32) => Bool
 ```
 
 ### Numbers.**isNumber**
 
 ```grain
-isNumber : (x: WasmI32) -> Bool
+isNumber : (x: WasmI32) => Bool
 ```
 
 ### Numbers.**reducedInteger**
 
 ```grain
-reducedInteger : (x: WasmI64) -> WasmI32
+reducedInteger : (x: WasmI64) => WasmI32
 ```
 
 ### Numbers.**reducedUnsignedInteger**
 
 ```grain
-reducedUnsignedInteger : (x: WasmI64) -> WasmI32
+reducedUnsignedInteger : (x: WasmI64) => WasmI32
 ```
 
 ### Numbers.**boxedNumberTag**
 
 ```grain
-boxedNumberTag : (xptr: WasmI32) -> WasmI32
+boxedNumberTag : (xptr: WasmI32) => WasmI32
 ```
 
 ### Numbers.**boxedInt64Number**
 
 ```grain
-boxedInt64Number : (xptr: WasmI32) -> WasmI64
+boxedInt64Number : (xptr: WasmI32) => WasmI64
 ```
 
 ### Numbers.**boxedFloat64Number**
 
 ```grain
-boxedFloat64Number : (xptr: WasmI32) -> WasmF64
+boxedFloat64Number : (xptr: WasmI32) => WasmF64
 ```
 
 ### Numbers.**boxedRationalNumerator**
 
 ```grain
-boxedRationalNumerator : (xptr: WasmI32) -> WasmI32
+boxedRationalNumerator : (xptr: WasmI32) => WasmI32
 ```
 
 ### Numbers.**boxedRationalDenominator**
 
 ```grain
-boxedRationalDenominator : (xptr: WasmI32) -> WasmI32
+boxedRationalDenominator : (xptr: WasmI32) => WasmI32
 ```
 
 ### Numbers.**coerceNumberToWasmF32**
 
 ```grain
-coerceNumberToWasmF32 : (x: Number) -> WasmF32
+coerceNumberToWasmF32 : (x: Number) => WasmF32
 ```
 
 ### Numbers.**coerceNumberToWasmF64**
 
 ```grain
-coerceNumberToWasmF64 : (x: Number) -> WasmF64
+coerceNumberToWasmF64 : (x: Number) => WasmF64
 ```
 
 ### Numbers.**coerceNumberToWasmI64**
 
 ```grain
-coerceNumberToWasmI64 : (x: Number) -> WasmI64
+coerceNumberToWasmI64 : (x: Number) => WasmI64
 ```
 
 ### Numbers.**coerceNumberToWasmI32**
 
 ```grain
-coerceNumberToWasmI32 : (x: Number) -> WasmI32
+coerceNumberToWasmI32 : (x: Number) => WasmI32
 ```
 
 ### Numbers.**coerceNumberToUnsignedWasmI64**
 
 ```grain
-coerceNumberToUnsignedWasmI64 : (x: Number) -> WasmI64
+coerceNumberToUnsignedWasmI64 : (x: Number) => WasmI64
 ```
 
 ### Numbers.**coerceNumberToUnsignedWasmI32**
 
 ```grain
-coerceNumberToUnsignedWasmI32 : (x: Number) -> WasmI32
+coerceNumberToUnsignedWasmI32 : (x: Number) => WasmI32
 ```
 
 ### Numbers.**numberEqual**
 
 ```grain
-numberEqual : (x: WasmI32, y: WasmI32) -> Bool
+numberEqual : (x: WasmI32, y: WasmI32) => Bool
 ```
 
 ### Numbers.**addSubRational**
 
 ```grain
 addSubRational :
-  (x: WasmI32, y: WasmI32, isSub: Bool, keepRational: Bool) -> WasmI32
+  (x: WasmI32, y: WasmI32, isSub: Bool, keepRational: Bool) => WasmI32
 ```
 
 ### Numbers.**timesDivideRational**
 
 ```grain
 timesDivideRational :
-  (x: WasmI32, y: WasmI32, isDivide: Bool, keepRational: Bool) -> WasmI32
+  (x: WasmI32, y: WasmI32, isDivide: Bool, keepRational: Bool) => WasmI32
 ```
 
 ### Numbers.**rationalsEqual**
 
 ```grain
-rationalsEqual : (x: WasmI32, y: WasmI32) -> Bool
+rationalsEqual : (x: WasmI32, y: WasmI32) => Bool
 ```
 
 ### Numbers.**cmpRationals**
 
 ```grain
-cmpRationals : (x: WasmI32, y: WasmI32) -> WasmI32
+cmpRationals : (x: WasmI32, y: WasmI32) => WasmI32
 ```
 
 ### Numbers.**rationalNumerator**
@@ -166,7 +166,7 @@ No other changes yet.
 </details>
 
 ```grain
-rationalNumerator : (x: Rational) -> Number
+rationalNumerator : (x: Rational) => Number
 ```
 
 Finds the numerator of the rational number.
@@ -191,7 +191,7 @@ No other changes yet.
 </details>
 
 ```grain
-rationalDenominator : (x: Rational) -> Number
+rationalDenominator : (x: Rational) => Number
 ```
 
 Finds the denominator of the rational number.
@@ -211,7 +211,7 @@ Returns:
 ### Numbers.**cmp**
 
 ```grain
-cmp : (x: WasmI32, y: WasmI32) -> WasmI32
+cmp : (x: WasmI32, y: WasmI32) => WasmI32
 ```
 
 ### Numbers.**(<)**
@@ -222,7 +222,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<) : (x: Number, y: Number) -> Bool
+(<) : (x: Number, y: Number) => Bool
 ```
 
 Checks if the first operand is less than the second operand.
@@ -248,7 +248,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>) : (x: Number, y: Number) -> Bool
+(>) : (x: Number, y: Number) => Bool
 ```
 
 Checks if the first operand is greater than the second operand.
@@ -274,7 +274,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<=) : (x: Number, y: Number) -> Bool
+(<=) : (x: Number, y: Number) => Bool
 ```
 
 Checks if the first operand is less than or equal to the second operand.
@@ -300,7 +300,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>=) : (x: Number, y: Number) -> Bool
+(>=) : (x: Number, y: Number) => Bool
 ```
 
 Checks if the first operand is greater than or equal to the second operand.
@@ -321,13 +321,13 @@ Returns:
 ### Numbers.**compare**
 
 ```grain
-compare : (x: Number, y: Number) -> Number
+compare : (x: Number, y: Number) => Number
 ```
 
 ### Numbers.**numberEq**
 
 ```grain
-numberEq : (x: Number, y: Number) -> Bool
+numberEq : (x: Number, y: Number) => Bool
 ```
 
 ### Numbers.**lnot**
@@ -338,7 +338,7 @@ No other changes yet.
 </details>
 
 ```grain
-lnot : (x: Number) -> Number
+lnot : (x: Number) => Number
 ```
 
 Computes the bitwise NOT of the operand.
@@ -371,7 +371,7 @@ Returns:
 </details>
 
 ```grain
-(<<) : (x: Number, y: Number) -> Number
+(<<) : (x: Number, y: Number) => Number
 ```
 
 Shifts the bits of the value left by the given number of bits.
@@ -405,7 +405,7 @@ Returns:
 </details>
 
 ```grain
-(>>>) : (x: Number, y: Number) -> Number
+(>>>) : (x: Number, y: Number) => Number
 ```
 
 Shifts the bits of the value right by the given number of bits, preserving the sign bit.
@@ -439,7 +439,7 @@ Returns:
 </details>
 
 ```grain
-(&) : (x: Number, y: Number) -> Number
+(&) : (x: Number, y: Number) => Number
 ```
 
 Computes the bitwise AND (`&`) on the given operands.
@@ -473,7 +473,7 @@ Returns:
 </details>
 
 ```grain
-(|) : (x: Number, y: Number) -> Number
+(|) : (x: Number, y: Number) => Number
 ```
 
 Computes the bitwise OR (`|`) on the given operands.
@@ -508,7 +508,7 @@ Returns:
 </details>
 
 ```grain
-(^) : (x: Number, y: Number) -> Number
+(^) : (x: Number, y: Number) => Number
 ```
 
 Computes the bitwise XOR (`^`) on the given operands.
@@ -542,7 +542,7 @@ Returns:
 </details>
 
 ```grain
-(>>) : (x: Number, y: Number) -> Number
+(>>) : (x: Number, y: Number) => Number
 ```
 
 Shifts the bits of the value right by the given number of bits.
@@ -568,7 +568,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceNumberToInt8 : (number: Number) -> Int8
+coerceNumberToInt8 : (number: Number) => Int8
 ```
 
 Converts a Number to an Int8.
@@ -593,7 +593,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceNumberToInt16 : (number: Number) -> Int16
+coerceNumberToInt16 : (number: Number) => Int16
 ```
 
 Converts a Number to an Int16.
@@ -618,7 +618,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceNumberToUint8 : (number: Number) -> Uint8
+coerceNumberToUint8 : (number: Number) => Uint8
 ```
 
 Converts a Number to a Uint8.
@@ -643,7 +643,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceNumberToUint16 : (number: Number) -> Uint16
+coerceNumberToUint16 : (number: Number) => Uint16
 ```
 
 Converts a Number to a Uint16.
@@ -668,7 +668,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceNumberToInt32 : (x: Number) -> Int32
+coerceNumberToInt32 : (x: Number) => Int32
 ```
 
 Converts a Number to an Int32.
@@ -693,7 +693,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceNumberToInt64 : (x: Number) -> Int64
+coerceNumberToInt64 : (x: Number) => Int64
 ```
 
 Converts a Number to an Int64.
@@ -718,7 +718,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceNumberToBigInt : (x: Number) -> BigInt
+coerceNumberToBigInt : (x: Number) => BigInt
 ```
 
 Converts a Number to a BigInt.
@@ -743,7 +743,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceNumberToRational : (x: Number) -> Rational
+coerceNumberToRational : (x: Number) => Rational
 ```
 
 Converts a Number to a Rational.
@@ -768,7 +768,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceNumberToFloat32 : (x: Number) -> Float32
+coerceNumberToFloat32 : (x: Number) => Float32
 ```
 
 Converts a Number to a Float32.
@@ -793,7 +793,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceNumberToFloat64 : (x: Number) -> Float64
+coerceNumberToFloat64 : (x: Number) => Float64
 ```
 
 Converts a Number to a Float64.
@@ -818,7 +818,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceInt8ToNumber : (value: Int8) -> Number
+coerceInt8ToNumber : (value: Int8) => Number
 ```
 
 Converts an Int8 to a Number.
@@ -843,7 +843,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceInt16ToNumber : (value: Int16) -> Number
+coerceInt16ToNumber : (value: Int16) => Number
 ```
 
 Converts an Int16 to a Number.
@@ -868,7 +868,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceUint8ToNumber : (value: Uint8) -> Number
+coerceUint8ToNumber : (value: Uint8) => Number
 ```
 
 Converts a Uint8 to a Number.
@@ -893,7 +893,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceUint16ToNumber : (value: Uint16) -> Number
+coerceUint16ToNumber : (value: Uint16) => Number
 ```
 
 Converts a Uint16 to a Number.
@@ -918,7 +918,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceInt32ToNumber : (x: Int32) -> Number
+coerceInt32ToNumber : (x: Int32) => Number
 ```
 
 Converts an Int32 to a Number.
@@ -943,7 +943,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceInt64ToNumber : (x: Int64) -> Number
+coerceInt64ToNumber : (x: Int64) => Number
 ```
 
 Converts an Int64 to a Number.
@@ -968,7 +968,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceBigIntToNumber : (x: BigInt) -> Number
+coerceBigIntToNumber : (x: BigInt) => Number
 ```
 
 Converts a BigInt to a Number.
@@ -993,7 +993,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceRationalToNumber : (x: Rational) -> Number
+coerceRationalToNumber : (x: Rational) => Number
 ```
 
 Converts a Rational to a Number.
@@ -1018,7 +1018,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceFloat32ToNumber : (x: Float32) -> Number
+coerceFloat32ToNumber : (x: Float32) => Number
 ```
 
 Converts a Float32 to a Number.
@@ -1043,7 +1043,7 @@ No other changes yet.
 </details>
 
 ```grain
-coerceFloat64ToNumber : (x: Float64) -> Number
+coerceFloat64ToNumber : (x: Float64) => Number
 ```
 
 Converts a Float64 to a Number.
@@ -1063,13 +1063,13 @@ Returns:
 ### Numbers.**convertExactToInexact**
 
 ```grain
-convertExactToInexact : (x: Number) -> Number
+convertExactToInexact : (x: Number) => Number
 ```
 
 ### Numbers.**convertInexactToExact**
 
 ```grain
-convertInexactToExact : (x: Number) -> Number
+convertInexactToExact : (x: Number) => Number
 ```
 
 ### Numbers.**(+)**
@@ -1080,7 +1080,7 @@ No other changes yet.
 </details>
 
 ```grain
-(+) : (x: Number, y: Number) -> Number
+(+) : (x: Number, y: Number) => Number
 ```
 
 Computes the sum of its operands.
@@ -1106,7 +1106,7 @@ No other changes yet.
 </details>
 
 ```grain
-(-) : (x: Number, y: Number) -> Number
+(-) : (x: Number, y: Number) => Number
 ```
 
 Computes the difference of its operands.
@@ -1132,7 +1132,7 @@ No other changes yet.
 </details>
 
 ```grain
-(*) : (x: Number, y: Number) -> Number
+(*) : (x: Number, y: Number) => Number
 ```
 
 Computes the product of its operands.
@@ -1158,7 +1158,7 @@ No other changes yet.
 </details>
 
 ```grain
-(/) : (x: Number, y: Number) -> Number
+(/) : (x: Number, y: Number) => Number
 ```
 
 Computes the quotient of its operands.
@@ -1184,7 +1184,7 @@ No other changes yet.
 </details>
 
 ```grain
-(%) : (x: Number, y: Number) -> Number
+(%) : (x: Number, y: Number) => Number
 ```
 
 Computes the remainder of the division of the first operand by the second.
@@ -1211,7 +1211,7 @@ No other changes yet.
 </details>
 
 ```grain
-incr : (x: Number) -> Number
+incr : (x: Number) => Number
 ```
 
 Increments the value by one.
@@ -1236,7 +1236,7 @@ No other changes yet.
 </details>
 
 ```grain
-decr : (x: Number) -> Number
+decr : (x: Number) => Number
 ```
 
 Decrements the value by one.
@@ -1256,7 +1256,7 @@ Returns:
 ### Numbers.**isBigInt**
 
 ```grain
-isBigInt : (x: a) -> Bool
+isBigInt : (x: a) => Bool
 ```
 
 ### Numbers.**scalbn**
@@ -1267,7 +1267,7 @@ No other changes yet.
 </details>
 
 ```grain
-scalbn : (x: WasmF64, n: WasmI32) -> WasmF64
+scalbn : (x: WasmF64, n: WasmI32) => WasmF64
 ```
 
 Multiplies a floating-point number by an integral power of 2.
@@ -1300,7 +1300,7 @@ Returns:
 </details>
 
 ```grain
-(**) : (base: Number, power: Number) -> Number
+(**) : (base: Number, power: Number) => Number
 ```
 
 Computes the exponentiation of the given base and power.

--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -36,7 +36,7 @@ foreign wasm fd_write: (
   WasmI32,
   WasmI32,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 
 primitive (!) = "@not"
 primitive (&&) = "@and"

--- a/stdlib/runtime/string.md
+++ b/stdlib/runtime/string.md
@@ -14,7 +14,7 @@ No other changes yet.
 </details>
 
 ```grain
-concat : (s1: String, s2: String) -> String
+concat : (s1: String, s2: String) => String
 ```
 
 Concatenate two strings.
@@ -46,7 +46,7 @@ No other changes yet.
 </details>
 
 ```grain
-toString : (value: a) -> String
+toString : (value: a) => String
 ```
 
 Converts the given operand to a string.
@@ -72,7 +72,7 @@ No other changes yet.
 </details>
 
 ```grain
-print : (value: a) -> Void
+print : (value: a) => Void
 ```
 
 Prints the given operand to the console. Works for any type. Internally, calls `toString`

--- a/stdlib/runtime/unsafe/conv.md
+++ b/stdlib/runtime/unsafe/conv.md
@@ -9,79 +9,79 @@ Functions and constants included in the Conv module.
 ### Conv.**toInt32**
 
 ```grain
-toInt32 : (n: WasmI32) -> Int32
+toInt32 : (n: WasmI32) => Int32
 ```
 
 ### Conv.**toUint32**
 
 ```grain
-toUint32 : (n: WasmI32) -> Uint32
+toUint32 : (n: WasmI32) => Uint32
 ```
 
 ### Conv.**fromInt32**
 
 ```grain
-fromInt32 : (n: Int32) -> WasmI32
+fromInt32 : (n: Int32) => WasmI32
 ```
 
 ### Conv.**fromUint32**
 
 ```grain
-fromUint32 : (n: Uint32) -> WasmI32
+fromUint32 : (n: Uint32) => WasmI32
 ```
 
 ### Conv.**toInt64**
 
 ```grain
-toInt64 : (n: WasmI64) -> Int64
+toInt64 : (n: WasmI64) => Int64
 ```
 
 ### Conv.**toUint64**
 
 ```grain
-toUint64 : (n: WasmI64) -> Uint64
+toUint64 : (n: WasmI64) => Uint64
 ```
 
 ### Conv.**fromInt64**
 
 ```grain
-fromInt64 : (n: Int64) -> WasmI64
+fromInt64 : (n: Int64) => WasmI64
 ```
 
 ### Conv.**fromUint64**
 
 ```grain
-fromUint64 : (n: Uint64) -> WasmI64
+fromUint64 : (n: Uint64) => WasmI64
 ```
 
 ### Conv.**toFloat32**
 
 ```grain
-toFloat32 : (n: WasmF32) -> Float32
+toFloat32 : (n: WasmF32) => Float32
 ```
 
 ### Conv.**fromFloat32**
 
 ```grain
-fromFloat32 : (n: Float32) -> WasmF32
+fromFloat32 : (n: Float32) => WasmF32
 ```
 
 ### Conv.**toFloat64**
 
 ```grain
-toFloat64 : (n: WasmF64) -> Float64
+toFloat64 : (n: WasmF64) => Float64
 ```
 
 ### Conv.**fromFloat64**
 
 ```grain
-fromFloat64 : (n: Float64) -> WasmF64
+fromFloat64 : (n: Float64) => WasmF64
 ```
 
 ### Conv.**wasmI32ToNumber**
 
 ```grain
-wasmI32ToNumber : (n: WasmI32) -> Number
+wasmI32ToNumber : (n: WasmI32) => Number
 ```
 
 Converts a WasmI32 value to Number.

--- a/stdlib/runtime/unsafe/memory.md
+++ b/stdlib/runtime/unsafe/memory.md
@@ -9,42 +9,42 @@ Functions and constants included in the Memory module.
 ### Memory.**malloc**
 
 ```grain
-malloc : (size: WasmI32) -> WasmI32
+malloc : (size: WasmI32) => WasmI32
 ```
 
 ### Memory.**free**
 
 ```grain
-free : (userPtr: WasmI32) -> Void
+free : (userPtr: WasmI32) => Void
 ```
 
 ### Memory.**incRef**
 
 ```grain
-incRef : (userPtr: WasmI32) -> WasmI32
+incRef : (userPtr: WasmI32) => WasmI32
 ```
 
 ### Memory.**decRef**
 
 ```grain
-decRef : (userPtr: WasmI32) -> WasmI32
+decRef : (userPtr: WasmI32) => WasmI32
 ```
 
 ### Memory.**copy**
 
 ```grain
-copy : (dest: WasmI32, src: WasmI32, n: WasmI32) -> Void
+copy : (dest: WasmI32, src: WasmI32, n: WasmI32) => Void
 ```
 
 ### Memory.**fill**
 
 ```grain
-fill : (dest: WasmI32, c: WasmI32, n: WasmI32) -> Void
+fill : (dest: WasmI32, c: WasmI32, n: WasmI32) => Void
 ```
 
 ### Memory.**compare**
 
 ```grain
-compare : (WasmI32, WasmI32, WasmI32) -> WasmI32
+compare : (WasmI32, WasmI32, WasmI32) => WasmI32
 ```
 

--- a/stdlib/runtime/unsafe/wasmf32.md
+++ b/stdlib/runtime/unsafe/wasmf32.md
@@ -9,168 +9,168 @@ Functions and constants included in the WasmF32 module.
 ### WasmF32.**load**
 
 ```grain
-load : (WasmI32, WasmI32) -> WasmF32
+load : (WasmI32, WasmI32) => WasmF32
 ```
 
 ### WasmF32.**store**
 
 ```grain
-store : (WasmI32, WasmF32, WasmI32) -> Void
+store : (WasmI32, WasmF32, WasmI32) => Void
 ```
 
 ### WasmF32.**neg**
 
 ```grain
-neg : WasmF32 -> WasmF32
+neg : WasmF32 => WasmF32
 ```
 
 ### WasmF32.**abs**
 
 ```grain
-abs : WasmF32 -> WasmF32
+abs : WasmF32 => WasmF32
 ```
 
 ### WasmF32.**ceil**
 
 ```grain
-ceil : WasmF32 -> WasmF32
+ceil : WasmF32 => WasmF32
 ```
 
 ### WasmF32.**floor**
 
 ```grain
-floor : WasmF32 -> WasmF32
+floor : WasmF32 => WasmF32
 ```
 
 ### WasmF32.**trunc**
 
 ```grain
-trunc : WasmF32 -> WasmF32
+trunc : WasmF32 => WasmF32
 ```
 
 ### WasmF32.**nearest**
 
 ```grain
-nearest : WasmF32 -> WasmF32
+nearest : WasmF32 => WasmF32
 ```
 
 ### WasmF32.**sqrt**
 
 ```grain
-sqrt : WasmF32 -> WasmF32
+sqrt : WasmF32 => WasmF32
 ```
 
 ### WasmF32.**(+)**
 
 ```grain
-(+) : (WasmF32, WasmF32) -> WasmF32
+(+) : (WasmF32, WasmF32) => WasmF32
 ```
 
 ### WasmF32.**(-)**
 
 ```grain
-(-) : (WasmF32, WasmF32) -> WasmF32
+(-) : (WasmF32, WasmF32) => WasmF32
 ```
 
 ### WasmF32.**(*)**
 
 ```grain
-(*) : (WasmF32, WasmF32) -> WasmF32
+(*) : (WasmF32, WasmF32) => WasmF32
 ```
 
 ### WasmF32.**(/)**
 
 ```grain
-(/) : (WasmF32, WasmF32) -> WasmF32
+(/) : (WasmF32, WasmF32) => WasmF32
 ```
 
 ### WasmF32.**copySign**
 
 ```grain
-copySign : (WasmF32, WasmF32) -> WasmF32
+copySign : (WasmF32, WasmF32) => WasmF32
 ```
 
 ### WasmF32.**min**
 
 ```grain
-min : (WasmF32, WasmF32) -> WasmF32
+min : (WasmF32, WasmF32) => WasmF32
 ```
 
 ### WasmF32.**max**
 
 ```grain
-max : (WasmF32, WasmF32) -> WasmF32
+max : (WasmF32, WasmF32) => WasmF32
 ```
 
 ### WasmF32.**(==)**
 
 ```grain
-(==) : (WasmF32, WasmF32) -> Bool
+(==) : (WasmF32, WasmF32) => Bool
 ```
 
 ### WasmF32.**(!=)**
 
 ```grain
-(!=) : (WasmF32, WasmF32) -> Bool
+(!=) : (WasmF32, WasmF32) => Bool
 ```
 
 ### WasmF32.**(<)**
 
 ```grain
-(<) : (WasmF32, WasmF32) -> Bool
+(<) : (WasmF32, WasmF32) => Bool
 ```
 
 ### WasmF32.**(<=)**
 
 ```grain
-(<=) : (WasmF32, WasmF32) -> Bool
+(<=) : (WasmF32, WasmF32) => Bool
 ```
 
 ### WasmF32.**(>)**
 
 ```grain
-(>) : (WasmF32, WasmF32) -> Bool
+(>) : (WasmF32, WasmF32) => Bool
 ```
 
 ### WasmF32.**(>=)**
 
 ```grain
-(>=) : (WasmF32, WasmF32) -> Bool
+(>=) : (WasmF32, WasmF32) => Bool
 ```
 
 ### WasmF32.**reinterpretI32**
 
 ```grain
-reinterpretI32 : WasmI32 -> WasmF32
+reinterpretI32 : WasmI32 => WasmF32
 ```
 
 ### WasmF32.**convertI32S**
 
 ```grain
-convertI32S : WasmI32 -> WasmF32
+convertI32S : WasmI32 => WasmF32
 ```
 
 ### WasmF32.**convertI32U**
 
 ```grain
-convertI32U : WasmI32 -> WasmF32
+convertI32U : WasmI32 => WasmF32
 ```
 
 ### WasmF32.**convertI64S**
 
 ```grain
-convertI64S : WasmI64 -> WasmF32
+convertI64S : WasmI64 => WasmF32
 ```
 
 ### WasmF32.**convertI64U**
 
 ```grain
-convertI64U : WasmI64 -> WasmF32
+convertI64U : WasmI64 => WasmF32
 ```
 
 ### WasmF32.**demoteF64**
 
 ```grain
-demoteF64 : WasmF64 -> WasmF32
+demoteF64 : WasmF64 => WasmF32
 ```
 

--- a/stdlib/runtime/unsafe/wasmf64.md
+++ b/stdlib/runtime/unsafe/wasmf64.md
@@ -9,168 +9,168 @@ Functions and constants included in the WasmF64 module.
 ### WasmF64.**load**
 
 ```grain
-load : (WasmI32, WasmI32) -> WasmF64
+load : (WasmI32, WasmI32) => WasmF64
 ```
 
 ### WasmF64.**store**
 
 ```grain
-store : (WasmI32, WasmF64, WasmI32) -> Void
+store : (WasmI32, WasmF64, WasmI32) => Void
 ```
 
 ### WasmF64.**neg**
 
 ```grain
-neg : WasmF64 -> WasmF64
+neg : WasmF64 => WasmF64
 ```
 
 ### WasmF64.**abs**
 
 ```grain
-abs : WasmF64 -> WasmF64
+abs : WasmF64 => WasmF64
 ```
 
 ### WasmF64.**ceil**
 
 ```grain
-ceil : WasmF64 -> WasmF64
+ceil : WasmF64 => WasmF64
 ```
 
 ### WasmF64.**floor**
 
 ```grain
-floor : WasmF64 -> WasmF64
+floor : WasmF64 => WasmF64
 ```
 
 ### WasmF64.**trunc**
 
 ```grain
-trunc : WasmF64 -> WasmF64
+trunc : WasmF64 => WasmF64
 ```
 
 ### WasmF64.**nearest**
 
 ```grain
-nearest : WasmF64 -> WasmF64
+nearest : WasmF64 => WasmF64
 ```
 
 ### WasmF64.**sqrt**
 
 ```grain
-sqrt : WasmF64 -> WasmF64
+sqrt : WasmF64 => WasmF64
 ```
 
 ### WasmF64.**(+)**
 
 ```grain
-(+) : (WasmF64, WasmF64) -> WasmF64
+(+) : (WasmF64, WasmF64) => WasmF64
 ```
 
 ### WasmF64.**(-)**
 
 ```grain
-(-) : (WasmF64, WasmF64) -> WasmF64
+(-) : (WasmF64, WasmF64) => WasmF64
 ```
 
 ### WasmF64.**(*)**
 
 ```grain
-(*) : (WasmF64, WasmF64) -> WasmF64
+(*) : (WasmF64, WasmF64) => WasmF64
 ```
 
 ### WasmF64.**(/)**
 
 ```grain
-(/) : (WasmF64, WasmF64) -> WasmF64
+(/) : (WasmF64, WasmF64) => WasmF64
 ```
 
 ### WasmF64.**copySign**
 
 ```grain
-copySign : (WasmF64, WasmF64) -> WasmF64
+copySign : (WasmF64, WasmF64) => WasmF64
 ```
 
 ### WasmF64.**min**
 
 ```grain
-min : (WasmF64, WasmF64) -> WasmF64
+min : (WasmF64, WasmF64) => WasmF64
 ```
 
 ### WasmF64.**max**
 
 ```grain
-max : (WasmF64, WasmF64) -> WasmF64
+max : (WasmF64, WasmF64) => WasmF64
 ```
 
 ### WasmF64.**(==)**
 
 ```grain
-(==) : (WasmF64, WasmF64) -> Bool
+(==) : (WasmF64, WasmF64) => Bool
 ```
 
 ### WasmF64.**(!=)**
 
 ```grain
-(!=) : (WasmF64, WasmF64) -> Bool
+(!=) : (WasmF64, WasmF64) => Bool
 ```
 
 ### WasmF64.**(<)**
 
 ```grain
-(<) : (WasmF64, WasmF64) -> Bool
+(<) : (WasmF64, WasmF64) => Bool
 ```
 
 ### WasmF64.**(<=)**
 
 ```grain
-(<=) : (WasmF64, WasmF64) -> Bool
+(<=) : (WasmF64, WasmF64) => Bool
 ```
 
 ### WasmF64.**(>)**
 
 ```grain
-(>) : (WasmF64, WasmF64) -> Bool
+(>) : (WasmF64, WasmF64) => Bool
 ```
 
 ### WasmF64.**(>=)**
 
 ```grain
-(>=) : (WasmF64, WasmF64) -> Bool
+(>=) : (WasmF64, WasmF64) => Bool
 ```
 
 ### WasmF64.**reinterpretI64**
 
 ```grain
-reinterpretI64 : WasmI64 -> WasmF64
+reinterpretI64 : WasmI64 => WasmF64
 ```
 
 ### WasmF64.**convertI32S**
 
 ```grain
-convertI32S : WasmI32 -> WasmF64
+convertI32S : WasmI32 => WasmF64
 ```
 
 ### WasmF64.**convertI32U**
 
 ```grain
-convertI32U : WasmI32 -> WasmF64
+convertI32U : WasmI32 => WasmF64
 ```
 
 ### WasmF64.**convertI64S**
 
 ```grain
-convertI64S : WasmI64 -> WasmF64
+convertI64S : WasmI64 => WasmF64
 ```
 
 ### WasmF64.**convertI64U**
 
 ```grain
-convertI64U : WasmI64 -> WasmF64
+convertI64U : WasmI64 => WasmF64
 ```
 
 ### WasmF64.**promoteF32**
 
 ```grain
-promoteF32 : WasmF32 -> WasmF64
+promoteF32 : WasmF32 => WasmF64
 ```
 

--- a/stdlib/runtime/unsafe/wasmi32.md
+++ b/stdlib/runtime/unsafe/wasmi32.md
@@ -9,282 +9,282 @@ Functions and constants included in the WasmI32 module.
 ### WasmI32.**load**
 
 ```grain
-load : (WasmI32, WasmI32) -> WasmI32
+load : (WasmI32, WasmI32) => WasmI32
 ```
 
 ### WasmI32.**load8S**
 
 ```grain
-load8S : (WasmI32, WasmI32) -> WasmI32
+load8S : (WasmI32, WasmI32) => WasmI32
 ```
 
 ### WasmI32.**load8U**
 
 ```grain
-load8U : (WasmI32, WasmI32) -> WasmI32
+load8U : (WasmI32, WasmI32) => WasmI32
 ```
 
 ### WasmI32.**load16S**
 
 ```grain
-load16S : (WasmI32, WasmI32) -> WasmI32
+load16S : (WasmI32, WasmI32) => WasmI32
 ```
 
 ### WasmI32.**load16U**
 
 ```grain
-load16U : (WasmI32, WasmI32) -> WasmI32
+load16U : (WasmI32, WasmI32) => WasmI32
 ```
 
 ### WasmI32.**store**
 
 ```grain
-store : (WasmI32, WasmI32, WasmI32) -> Void
+store : (WasmI32, WasmI32, WasmI32) => Void
 ```
 
 ### WasmI32.**store8**
 
 ```grain
-store8 : (WasmI32, WasmI32, WasmI32) -> Void
+store8 : (WasmI32, WasmI32, WasmI32) => Void
 ```
 
 ### WasmI32.**store16**
 
 ```grain
-store16 : (WasmI32, WasmI32, WasmI32) -> Void
+store16 : (WasmI32, WasmI32, WasmI32) => Void
 ```
 
 ### WasmI32.**clz**
 
 ```grain
-clz : WasmI32 -> WasmI32
+clz : WasmI32 => WasmI32
 ```
 
 ### WasmI32.**ctz**
 
 ```grain
-ctz : WasmI32 -> WasmI32
+ctz : WasmI32 => WasmI32
 ```
 
 ### WasmI32.**popcnt**
 
 ```grain
-popcnt : WasmI32 -> WasmI32
+popcnt : WasmI32 => WasmI32
 ```
 
 ### WasmI32.**eqz**
 
 ```grain
-eqz : WasmI32 -> Bool
+eqz : WasmI32 => Bool
 ```
 
 ### WasmI32.**(+)**
 
 ```grain
-(+) : (WasmI32, WasmI32) -> WasmI32
+(+) : (WasmI32, WasmI32) => WasmI32
 ```
 
 ### WasmI32.**(-)**
 
 ```grain
-(-) : (WasmI32, WasmI32) -> WasmI32
+(-) : (WasmI32, WasmI32) => WasmI32
 ```
 
 ### WasmI32.**(*)**
 
 ```grain
-(*) : (WasmI32, WasmI32) -> WasmI32
+(*) : (WasmI32, WasmI32) => WasmI32
 ```
 
 ### WasmI32.**(/)**
 
 ```grain
-(/) : (WasmI32, WasmI32) -> WasmI32
+(/) : (WasmI32, WasmI32) => WasmI32
 ```
 
 ### WasmI32.**divU**
 
 ```grain
-divU : (WasmI32, WasmI32) -> WasmI32
+divU : (WasmI32, WasmI32) => WasmI32
 ```
 
 ### WasmI32.**remS**
 
 ```grain
-remS : (WasmI32, WasmI32) -> WasmI32
+remS : (WasmI32, WasmI32) => WasmI32
 ```
 
 ### WasmI32.**remU**
 
 ```grain
-remU : (WasmI32, WasmI32) -> WasmI32
+remU : (WasmI32, WasmI32) => WasmI32
 ```
 
 ### WasmI32.**(&)**
 
 ```grain
-(&) : (WasmI32, WasmI32) -> WasmI32
+(&) : (WasmI32, WasmI32) => WasmI32
 ```
 
 ### WasmI32.**(|)**
 
 ```grain
-(|) : (WasmI32, WasmI32) -> WasmI32
+(|) : (WasmI32, WasmI32) => WasmI32
 ```
 
 ### WasmI32.**(^)**
 
 ```grain
-(^) : (WasmI32, WasmI32) -> WasmI32
+(^) : (WasmI32, WasmI32) => WasmI32
 ```
 
 ### WasmI32.**(<<)**
 
 ```grain
-(<<) : (WasmI32, WasmI32) -> WasmI32
+(<<) : (WasmI32, WasmI32) => WasmI32
 ```
 
 ### WasmI32.**(>>)**
 
 ```grain
-(>>) : (WasmI32, WasmI32) -> WasmI32
+(>>) : (WasmI32, WasmI32) => WasmI32
 ```
 
 ### WasmI32.**(>>>)**
 
 ```grain
-(>>>) : (WasmI32, WasmI32) -> WasmI32
+(>>>) : (WasmI32, WasmI32) => WasmI32
 ```
 
 ### WasmI32.**rotl**
 
 ```grain
-rotl : (WasmI32, WasmI32) -> WasmI32
+rotl : (WasmI32, WasmI32) => WasmI32
 ```
 
 ### WasmI32.**rotr**
 
 ```grain
-rotr : (WasmI32, WasmI32) -> WasmI32
+rotr : (WasmI32, WasmI32) => WasmI32
 ```
 
 ### WasmI32.**(==)**
 
 ```grain
-(==) : (WasmI32, WasmI32) -> Bool
+(==) : (WasmI32, WasmI32) => Bool
 ```
 
 ### WasmI32.**(!=)**
 
 ```grain
-(!=) : (WasmI32, WasmI32) -> Bool
+(!=) : (WasmI32, WasmI32) => Bool
 ```
 
 ### WasmI32.**(<)**
 
 ```grain
-(<) : (WasmI32, WasmI32) -> Bool
+(<) : (WasmI32, WasmI32) => Bool
 ```
 
 ### WasmI32.**ltU**
 
 ```grain
-ltU : (WasmI32, WasmI32) -> Bool
+ltU : (WasmI32, WasmI32) => Bool
 ```
 
 ### WasmI32.**(<=)**
 
 ```grain
-(<=) : (WasmI32, WasmI32) -> Bool
+(<=) : (WasmI32, WasmI32) => Bool
 ```
 
 ### WasmI32.**leU**
 
 ```grain
-leU : (WasmI32, WasmI32) -> Bool
+leU : (WasmI32, WasmI32) => Bool
 ```
 
 ### WasmI32.**(>)**
 
 ```grain
-(>) : (WasmI32, WasmI32) -> Bool
+(>) : (WasmI32, WasmI32) => Bool
 ```
 
 ### WasmI32.**gtU**
 
 ```grain
-gtU : (WasmI32, WasmI32) -> Bool
+gtU : (WasmI32, WasmI32) => Bool
 ```
 
 ### WasmI32.**(>=)**
 
 ```grain
-(>=) : (WasmI32, WasmI32) -> Bool
+(>=) : (WasmI32, WasmI32) => Bool
 ```
 
 ### WasmI32.**geU**
 
 ```grain
-geU : (WasmI32, WasmI32) -> Bool
+geU : (WasmI32, WasmI32) => Bool
 ```
 
 ### WasmI32.**wrapI64**
 
 ```grain
-wrapI64 : WasmI64 -> WasmI32
+wrapI64 : WasmI64 => WasmI32
 ```
 
 ### WasmI32.**truncF32S**
 
 ```grain
-truncF32S : WasmF32 -> WasmI32
+truncF32S : WasmF32 => WasmI32
 ```
 
 ### WasmI32.**truncF32U**
 
 ```grain
-truncF32U : WasmF32 -> WasmI32
+truncF32U : WasmF32 => WasmI32
 ```
 
 ### WasmI32.**truncF64S**
 
 ```grain
-truncF64S : WasmF64 -> WasmI32
+truncF64S : WasmF64 => WasmI32
 ```
 
 ### WasmI32.**truncF64U**
 
 ```grain
-truncF64U : WasmF64 -> WasmI32
+truncF64U : WasmF64 => WasmI32
 ```
 
 ### WasmI32.**reinterpretF32**
 
 ```grain
-reinterpretF32 : WasmF32 -> WasmI32
+reinterpretF32 : WasmF32 => WasmI32
 ```
 
 ### WasmI32.**extendS8**
 
 ```grain
-extendS8 : WasmI32 -> WasmI32
+extendS8 : WasmI32 => WasmI32
 ```
 
 ### WasmI32.**extendS16**
 
 ```grain
-extendS16 : WasmI32 -> WasmI32
+extendS16 : WasmI32 => WasmI32
 ```
 
 ### WasmI32.**fromGrain**
 
 ```grain
-fromGrain : a -> WasmI32
+fromGrain : a => WasmI32
 ```
 
 ### WasmI32.**toGrain**
 
 ```grain
-toGrain : WasmI32 -> a
+toGrain : WasmI32 => a
 ```
 

--- a/stdlib/runtime/unsafe/wasmi64.md
+++ b/stdlib/runtime/unsafe/wasmi64.md
@@ -9,300 +9,300 @@ Functions and constants included in the WasmI64 module.
 ### WasmI64.**load**
 
 ```grain
-load : (WasmI32, WasmI32) -> WasmI64
+load : (WasmI32, WasmI32) => WasmI64
 ```
 
 ### WasmI64.**load8S**
 
 ```grain
-load8S : (WasmI32, WasmI32) -> WasmI64
+load8S : (WasmI32, WasmI32) => WasmI64
 ```
 
 ### WasmI64.**load8U**
 
 ```grain
-load8U : (WasmI32, WasmI32) -> WasmI64
+load8U : (WasmI32, WasmI32) => WasmI64
 ```
 
 ### WasmI64.**load16S**
 
 ```grain
-load16S : (WasmI32, WasmI32) -> WasmI64
+load16S : (WasmI32, WasmI32) => WasmI64
 ```
 
 ### WasmI64.**load16U**
 
 ```grain
-load16U : (WasmI32, WasmI32) -> WasmI64
+load16U : (WasmI32, WasmI32) => WasmI64
 ```
 
 ### WasmI64.**load32S**
 
 ```grain
-load32S : (WasmI32, WasmI32) -> WasmI64
+load32S : (WasmI32, WasmI32) => WasmI64
 ```
 
 ### WasmI64.**load32U**
 
 ```grain
-load32U : (WasmI32, WasmI32) -> WasmI64
+load32U : (WasmI32, WasmI32) => WasmI64
 ```
 
 ### WasmI64.**store**
 
 ```grain
-store : (WasmI32, WasmI64, WasmI32) -> Void
+store : (WasmI32, WasmI64, WasmI32) => Void
 ```
 
 ### WasmI64.**store8**
 
 ```grain
-store8 : (WasmI32, WasmI64, WasmI32) -> Void
+store8 : (WasmI32, WasmI64, WasmI32) => Void
 ```
 
 ### WasmI64.**store16**
 
 ```grain
-store16 : (WasmI32, WasmI64, WasmI32) -> Void
+store16 : (WasmI32, WasmI64, WasmI32) => Void
 ```
 
 ### WasmI64.**store32**
 
 ```grain
-store32 : (WasmI32, WasmI64, WasmI32) -> Void
+store32 : (WasmI32, WasmI64, WasmI32) => Void
 ```
 
 ### WasmI64.**clz**
 
 ```grain
-clz : WasmI64 -> WasmI64
+clz : WasmI64 => WasmI64
 ```
 
 ### WasmI64.**ctz**
 
 ```grain
-ctz : WasmI64 -> WasmI64
+ctz : WasmI64 => WasmI64
 ```
 
 ### WasmI64.**popcnt**
 
 ```grain
-popcnt : WasmI64 -> WasmI64
+popcnt : WasmI64 => WasmI64
 ```
 
 ### WasmI64.**eqz**
 
 ```grain
-eqz : WasmI64 -> Bool
+eqz : WasmI64 => Bool
 ```
 
 ### WasmI64.**(+)**
 
 ```grain
-(+) : (WasmI64, WasmI64) -> WasmI64
+(+) : (WasmI64, WasmI64) => WasmI64
 ```
 
 ### WasmI64.**(-)**
 
 ```grain
-(-) : (WasmI64, WasmI64) -> WasmI64
+(-) : (WasmI64, WasmI64) => WasmI64
 ```
 
 ### WasmI64.**(*)**
 
 ```grain
-(*) : (WasmI64, WasmI64) -> WasmI64
+(*) : (WasmI64, WasmI64) => WasmI64
 ```
 
 ### WasmI64.**(/)**
 
 ```grain
-(/) : (WasmI64, WasmI64) -> WasmI64
+(/) : (WasmI64, WasmI64) => WasmI64
 ```
 
 ### WasmI64.**divU**
 
 ```grain
-divU : (WasmI64, WasmI64) -> WasmI64
+divU : (WasmI64, WasmI64) => WasmI64
 ```
 
 ### WasmI64.**remS**
 
 ```grain
-remS : (WasmI64, WasmI64) -> WasmI64
+remS : (WasmI64, WasmI64) => WasmI64
 ```
 
 ### WasmI64.**remU**
 
 ```grain
-remU : (WasmI64, WasmI64) -> WasmI64
+remU : (WasmI64, WasmI64) => WasmI64
 ```
 
 ### WasmI64.**(&)**
 
 ```grain
-(&) : (WasmI64, WasmI64) -> WasmI64
+(&) : (WasmI64, WasmI64) => WasmI64
 ```
 
 ### WasmI64.**(|)**
 
 ```grain
-(|) : (WasmI64, WasmI64) -> WasmI64
+(|) : (WasmI64, WasmI64) => WasmI64
 ```
 
 ### WasmI64.**(^)**
 
 ```grain
-(^) : (WasmI64, WasmI64) -> WasmI64
+(^) : (WasmI64, WasmI64) => WasmI64
 ```
 
 ### WasmI64.**(<<)**
 
 ```grain
-(<<) : (WasmI64, WasmI64) -> WasmI64
+(<<) : (WasmI64, WasmI64) => WasmI64
 ```
 
 ### WasmI64.**(>>>)**
 
 ```grain
-(>>>) : (WasmI64, WasmI64) -> WasmI64
+(>>>) : (WasmI64, WasmI64) => WasmI64
 ```
 
 ### WasmI64.**(>>)**
 
 ```grain
-(>>) : (WasmI64, WasmI64) -> WasmI64
+(>>) : (WasmI64, WasmI64) => WasmI64
 ```
 
 ### WasmI64.**rotl**
 
 ```grain
-rotl : (WasmI64, WasmI64) -> WasmI64
+rotl : (WasmI64, WasmI64) => WasmI64
 ```
 
 ### WasmI64.**rotr**
 
 ```grain
-rotr : (WasmI64, WasmI64) -> WasmI64
+rotr : (WasmI64, WasmI64) => WasmI64
 ```
 
 ### WasmI64.**(==)**
 
 ```grain
-(==) : (WasmI64, WasmI64) -> Bool
+(==) : (WasmI64, WasmI64) => Bool
 ```
 
 ### WasmI64.**(!=)**
 
 ```grain
-(!=) : (WasmI64, WasmI64) -> Bool
+(!=) : (WasmI64, WasmI64) => Bool
 ```
 
 ### WasmI64.**(<)**
 
 ```grain
-(<) : (WasmI64, WasmI64) -> Bool
+(<) : (WasmI64, WasmI64) => Bool
 ```
 
 ### WasmI64.**ltU**
 
 ```grain
-ltU : (WasmI64, WasmI64) -> Bool
+ltU : (WasmI64, WasmI64) => Bool
 ```
 
 ### WasmI64.**(<=)**
 
 ```grain
-(<=) : (WasmI64, WasmI64) -> Bool
+(<=) : (WasmI64, WasmI64) => Bool
 ```
 
 ### WasmI64.**leU**
 
 ```grain
-leU : (WasmI64, WasmI64) -> Bool
+leU : (WasmI64, WasmI64) => Bool
 ```
 
 ### WasmI64.**(>)**
 
 ```grain
-(>) : (WasmI64, WasmI64) -> Bool
+(>) : (WasmI64, WasmI64) => Bool
 ```
 
 ### WasmI64.**gtU**
 
 ```grain
-gtU : (WasmI64, WasmI64) -> Bool
+gtU : (WasmI64, WasmI64) => Bool
 ```
 
 ### WasmI64.**(>=)**
 
 ```grain
-(>=) : (WasmI64, WasmI64) -> Bool
+(>=) : (WasmI64, WasmI64) => Bool
 ```
 
 ### WasmI64.**geU**
 
 ```grain
-geU : (WasmI64, WasmI64) -> Bool
+geU : (WasmI64, WasmI64) => Bool
 ```
 
 ### WasmI64.**extendI32S**
 
 ```grain
-extendI32S : WasmI32 -> WasmI64
+extendI32S : WasmI32 => WasmI64
 ```
 
 ### WasmI64.**extendI32U**
 
 ```grain
-extendI32U : WasmI32 -> WasmI64
+extendI32U : WasmI32 => WasmI64
 ```
 
 ### WasmI64.**truncF32S**
 
 ```grain
-truncF32S : WasmF32 -> WasmI64
+truncF32S : WasmF32 => WasmI64
 ```
 
 ### WasmI64.**truncF32U**
 
 ```grain
-truncF32U : WasmF32 -> WasmI64
+truncF32U : WasmF32 => WasmI64
 ```
 
 ### WasmI64.**truncF64S**
 
 ```grain
-truncF64S : WasmF64 -> WasmI64
+truncF64S : WasmF64 => WasmI64
 ```
 
 ### WasmI64.**truncF64U**
 
 ```grain
-truncF64U : WasmF64 -> WasmI64
+truncF64U : WasmF64 => WasmI64
 ```
 
 ### WasmI64.**reinterpretF64**
 
 ```grain
-reinterpretF64 : WasmF64 -> WasmI64
+reinterpretF64 : WasmF64 => WasmI64
 ```
 
 ### WasmI64.**extendS8**
 
 ```grain
-extendS8 : WasmI64 -> WasmI64
+extendS8 : WasmI64 => WasmI64
 ```
 
 ### WasmI64.**extendS16**
 
 ```grain
-extendS16 : WasmI64 -> WasmI64
+extendS16 : WasmI64 => WasmI64
 ```
 
 ### WasmI64.**extendS32**
 
 ```grain
-extendS32 : WasmI64 -> WasmI64
+extendS32 : WasmI64 => WasmI64
 ```
 

--- a/stdlib/runtime/utils/printing.gr
+++ b/stdlib/runtime/utils/printing.gr
@@ -11,7 +11,7 @@ foreign wasm fd_write: (
   WasmI32,
   WasmI32,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 
 @unsafe
 provide let numberToString = (n: WasmI64) => {

--- a/stdlib/runtime/utils/printing.md
+++ b/stdlib/runtime/utils/printing.md
@@ -9,18 +9,18 @@ Functions and constants included in the Printing module.
 ### Printing.**numberToString**
 
 ```grain
-numberToString : (n: WasmI64) -> String
+numberToString : (n: WasmI64) => String
 ```
 
 ### Printing.**printNumber**
 
 ```grain
-printNumber : (n: WasmI64) -> Void
+printNumber : (n: WasmI64) => Void
 ```
 
 ### Printing.**printString**
 
 ```grain
-printString : (s: String) -> Void
+printString : (s: String) => Void
 ```
 

--- a/stdlib/runtime/wasi.gr
+++ b/stdlib/runtime/wasi.gr
@@ -8,37 +8,37 @@ include "exception"
 provide foreign wasm args_get: (
   WasmI32,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 provide foreign wasm args_sizes_get: (
   WasmI32,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 provide foreign wasm environ_get: (
   WasmI32,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 provide foreign wasm environ_sizes_get: (
   WasmI32,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 
 // proc
-provide foreign wasm proc_exit: WasmI32 -> Void from "wasi_snapshot_preview1"
-provide foreign wasm proc_raise: WasmI32 -> WasmI32 from "wasi_snapshot_preview1"
-provide foreign wasm sched_yield: () -> WasmI32 from "wasi_snapshot_preview1"
+provide foreign wasm proc_exit: WasmI32 => Void from "wasi_snapshot_preview1"
+provide foreign wasm proc_raise: WasmI32 => WasmI32 from "wasi_snapshot_preview1"
+provide foreign wasm sched_yield: () => WasmI32 from "wasi_snapshot_preview1"
 
 // random
 provide foreign wasm random_get: (
   WasmI32,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 
 // time
 provide foreign wasm clock_time_get: (
   WasmI32,
   WasmI64,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 
 // file
 provide foreign wasm path_open: (
@@ -51,29 +51,29 @@ provide foreign wasm path_open: (
   WasmI64,
   WasmI32,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 provide foreign wasm fd_read: (
   WasmI32,
   WasmI32,
   WasmI32,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 provide foreign wasm fd_pread: (
   WasmI32,
   WasmI32,
   WasmI32,
   WasmI64,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 provide foreign wasm fd_prestat_get: (
   WasmI32,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 provide foreign wasm fd_prestat_dir_name: (
   WasmI32,
   WasmI32,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 /**
  * Invokes the `fd_write` system call.
  *
@@ -88,82 +88,82 @@ provide foreign wasm fd_write: (
   WasmI32,
   WasmI32,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 provide foreign wasm fd_pwrite: (
   WasmI32,
   WasmI32,
   WasmI32,
   WasmI64,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 provide foreign wasm fd_allocate: (
   WasmI32,
   WasmI64,
   WasmI64,
-) -> WasmI32 from "wasi_snapshot_preview1"
-provide foreign wasm fd_close: WasmI32 -> WasmI32 from "wasi_snapshot_preview1"
-provide foreign wasm fd_datasync: WasmI32 -> WasmI32 from "wasi_snapshot_preview1"
-provide foreign wasm fd_sync: WasmI32 -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
+provide foreign wasm fd_close: WasmI32 => WasmI32 from "wasi_snapshot_preview1"
+provide foreign wasm fd_datasync: WasmI32 => WasmI32 from "wasi_snapshot_preview1"
+provide foreign wasm fd_sync: WasmI32 => WasmI32 from "wasi_snapshot_preview1"
 provide foreign wasm fd_fdstat_get: (
   WasmI32,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 provide foreign wasm fd_fdstat_set_flags: (
   WasmI32,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 provide foreign wasm fd_fdstat_set_rights: (
   WasmI32,
   WasmI64,
   WasmI64,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 provide foreign wasm fd_filestat_get: (
   WasmI32,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 provide foreign wasm fd_filestat_set_size: (
   WasmI32,
   WasmI64,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 provide foreign wasm fd_filestat_set_times: (
   WasmI32,
   WasmI64,
   WasmI64,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 provide foreign wasm fd_readdir: (
   WasmI32,
   WasmI32,
   WasmI32,
   WasmI64,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 provide foreign wasm fd_renumber: (
   WasmI32,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 provide foreign wasm fd_seek: (
   WasmI32,
   WasmI64,
   WasmI32,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 provide foreign wasm fd_tell: (
   WasmI32,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 provide foreign wasm path_create_directory: (
   WasmI32,
   WasmI32,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 provide foreign wasm path_filestat_get: (
   WasmI32,
   WasmI32,
   WasmI32,
   WasmI32,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 provide foreign wasm path_filestat_set_times: (
   WasmI32,
   WasmI32,
@@ -172,7 +172,7 @@ provide foreign wasm path_filestat_set_times: (
   WasmI64,
   WasmI64,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 provide foreign wasm path_link: (
   WasmI32,
   WasmI32,
@@ -181,19 +181,19 @@ provide foreign wasm path_link: (
   WasmI32,
   WasmI32,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 provide foreign wasm path_symlink: (
   WasmI32,
   WasmI32,
   WasmI32,
   WasmI32,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 provide foreign wasm path_unlink_file: (
   WasmI32,
   WasmI32,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 provide foreign wasm path_readlink: (
   WasmI32,
   WasmI32,
@@ -201,12 +201,12 @@ provide foreign wasm path_readlink: (
   WasmI32,
   WasmI32,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 provide foreign wasm path_remove_directory: (
   WasmI32,
   WasmI32,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 provide foreign wasm path_rename: (
   WasmI32,
   WasmI32,
@@ -214,7 +214,7 @@ provide foreign wasm path_rename: (
   WasmI32,
   WasmI32,
   WasmI32,
-) -> WasmI32 from "wasi_snapshot_preview1"
+) => WasmI32 from "wasi_snapshot_preview1"
 
 // clocks
 provide let _CLOCK_REALTIME = 0n

--- a/stdlib/runtime/wasi.md
+++ b/stdlib/runtime/wasi.md
@@ -9,55 +9,55 @@ Functions and constants included in the Wasi module.
 ### Wasi.**args_get**
 
 ```grain
-args_get : (WasmI32, WasmI32) -> WasmI32
+args_get : (WasmI32, WasmI32) => WasmI32
 ```
 
 ### Wasi.**args_sizes_get**
 
 ```grain
-args_sizes_get : (WasmI32, WasmI32) -> WasmI32
+args_sizes_get : (WasmI32, WasmI32) => WasmI32
 ```
 
 ### Wasi.**environ_get**
 
 ```grain
-environ_get : (WasmI32, WasmI32) -> WasmI32
+environ_get : (WasmI32, WasmI32) => WasmI32
 ```
 
 ### Wasi.**environ_sizes_get**
 
 ```grain
-environ_sizes_get : (WasmI32, WasmI32) -> WasmI32
+environ_sizes_get : (WasmI32, WasmI32) => WasmI32
 ```
 
 ### Wasi.**proc_exit**
 
 ```grain
-proc_exit : WasmI32 -> Void
+proc_exit : WasmI32 => Void
 ```
 
 ### Wasi.**proc_raise**
 
 ```grain
-proc_raise : WasmI32 -> WasmI32
+proc_raise : WasmI32 => WasmI32
 ```
 
 ### Wasi.**sched_yield**
 
 ```grain
-sched_yield : () -> WasmI32
+sched_yield : () => WasmI32
 ```
 
 ### Wasi.**random_get**
 
 ```grain
-random_get : (WasmI32, WasmI32) -> WasmI32
+random_get : (WasmI32, WasmI32) => WasmI32
 ```
 
 ### Wasi.**clock_time_get**
 
 ```grain
-clock_time_get : (WasmI32, WasmI64, WasmI32) -> WasmI32
+clock_time_get : (WasmI32, WasmI64, WasmI32) => WasmI32
 ```
 
 ### Wasi.**path_open**
@@ -65,37 +65,37 @@ clock_time_get : (WasmI32, WasmI64, WasmI32) -> WasmI32
 ```grain
 path_open :
   (WasmI32, WasmI32, WasmI32, WasmI32, WasmI32, WasmI64, WasmI64, WasmI32,
-   WasmI32) -> WasmI32
+   WasmI32) => WasmI32
 ```
 
 ### Wasi.**fd_read**
 
 ```grain
-fd_read : (WasmI32, WasmI32, WasmI32, WasmI32) -> WasmI32
+fd_read : (WasmI32, WasmI32, WasmI32, WasmI32) => WasmI32
 ```
 
 ### Wasi.**fd_pread**
 
 ```grain
-fd_pread : (WasmI32, WasmI32, WasmI32, WasmI64, WasmI32) -> WasmI32
+fd_pread : (WasmI32, WasmI32, WasmI32, WasmI64, WasmI32) => WasmI32
 ```
 
 ### Wasi.**fd_prestat_get**
 
 ```grain
-fd_prestat_get : (WasmI32, WasmI32) -> WasmI32
+fd_prestat_get : (WasmI32, WasmI32) => WasmI32
 ```
 
 ### Wasi.**fd_prestat_dir_name**
 
 ```grain
-fd_prestat_dir_name : (WasmI32, WasmI32, WasmI32) -> WasmI32
+fd_prestat_dir_name : (WasmI32, WasmI32, WasmI32) => WasmI32
 ```
 
 ### Wasi.**fd_write**
 
 ```grain
-fd_write : (WasmI32, WasmI32, WasmI32, WasmI32) -> WasmI32
+fd_write : (WasmI32, WasmI32, WasmI32, WasmI32) => WasmI32
 ```
 
 Invokes the `fd_write` system call.
@@ -118,149 +118,149 @@ Returns:
 ### Wasi.**fd_pwrite**
 
 ```grain
-fd_pwrite : (WasmI32, WasmI32, WasmI32, WasmI64, WasmI32) -> WasmI32
+fd_pwrite : (WasmI32, WasmI32, WasmI32, WasmI64, WasmI32) => WasmI32
 ```
 
 ### Wasi.**fd_allocate**
 
 ```grain
-fd_allocate : (WasmI32, WasmI64, WasmI64) -> WasmI32
+fd_allocate : (WasmI32, WasmI64, WasmI64) => WasmI32
 ```
 
 ### Wasi.**fd_close**
 
 ```grain
-fd_close : WasmI32 -> WasmI32
+fd_close : WasmI32 => WasmI32
 ```
 
 ### Wasi.**fd_datasync**
 
 ```grain
-fd_datasync : WasmI32 -> WasmI32
+fd_datasync : WasmI32 => WasmI32
 ```
 
 ### Wasi.**fd_sync**
 
 ```grain
-fd_sync : WasmI32 -> WasmI32
+fd_sync : WasmI32 => WasmI32
 ```
 
 ### Wasi.**fd_fdstat_get**
 
 ```grain
-fd_fdstat_get : (WasmI32, WasmI32) -> WasmI32
+fd_fdstat_get : (WasmI32, WasmI32) => WasmI32
 ```
 
 ### Wasi.**fd_fdstat_set_flags**
 
 ```grain
-fd_fdstat_set_flags : (WasmI32, WasmI32) -> WasmI32
+fd_fdstat_set_flags : (WasmI32, WasmI32) => WasmI32
 ```
 
 ### Wasi.**fd_fdstat_set_rights**
 
 ```grain
-fd_fdstat_set_rights : (WasmI32, WasmI64, WasmI64) -> WasmI32
+fd_fdstat_set_rights : (WasmI32, WasmI64, WasmI64) => WasmI32
 ```
 
 ### Wasi.**fd_filestat_get**
 
 ```grain
-fd_filestat_get : (WasmI32, WasmI32) -> WasmI32
+fd_filestat_get : (WasmI32, WasmI32) => WasmI32
 ```
 
 ### Wasi.**fd_filestat_set_size**
 
 ```grain
-fd_filestat_set_size : (WasmI32, WasmI64) -> WasmI32
+fd_filestat_set_size : (WasmI32, WasmI64) => WasmI32
 ```
 
 ### Wasi.**fd_filestat_set_times**
 
 ```grain
-fd_filestat_set_times : (WasmI32, WasmI64, WasmI64, WasmI32) -> WasmI32
+fd_filestat_set_times : (WasmI32, WasmI64, WasmI64, WasmI32) => WasmI32
 ```
 
 ### Wasi.**fd_readdir**
 
 ```grain
-fd_readdir : (WasmI32, WasmI32, WasmI32, WasmI64, WasmI32) -> WasmI32
+fd_readdir : (WasmI32, WasmI32, WasmI32, WasmI64, WasmI32) => WasmI32
 ```
 
 ### Wasi.**fd_renumber**
 
 ```grain
-fd_renumber : (WasmI32, WasmI32) -> WasmI32
+fd_renumber : (WasmI32, WasmI32) => WasmI32
 ```
 
 ### Wasi.**fd_seek**
 
 ```grain
-fd_seek : (WasmI32, WasmI64, WasmI32, WasmI32) -> WasmI32
+fd_seek : (WasmI32, WasmI64, WasmI32, WasmI32) => WasmI32
 ```
 
 ### Wasi.**fd_tell**
 
 ```grain
-fd_tell : (WasmI32, WasmI32) -> WasmI32
+fd_tell : (WasmI32, WasmI32) => WasmI32
 ```
 
 ### Wasi.**path_create_directory**
 
 ```grain
-path_create_directory : (WasmI32, WasmI32, WasmI32) -> WasmI32
+path_create_directory : (WasmI32, WasmI32, WasmI32) => WasmI32
 ```
 
 ### Wasi.**path_filestat_get**
 
 ```grain
-path_filestat_get : (WasmI32, WasmI32, WasmI32, WasmI32, WasmI32) -> WasmI32
+path_filestat_get : (WasmI32, WasmI32, WasmI32, WasmI32, WasmI32) => WasmI32
 ```
 
 ### Wasi.**path_filestat_set_times**
 
 ```grain
 path_filestat_set_times :
-  (WasmI32, WasmI32, WasmI32, WasmI32, WasmI64, WasmI64, WasmI32) -> WasmI32
+  (WasmI32, WasmI32, WasmI32, WasmI32, WasmI64, WasmI64, WasmI32) => WasmI32
 ```
 
 ### Wasi.**path_link**
 
 ```grain
 path_link :
-  (WasmI32, WasmI32, WasmI32, WasmI32, WasmI32, WasmI32, WasmI32) -> WasmI32
+  (WasmI32, WasmI32, WasmI32, WasmI32, WasmI32, WasmI32, WasmI32) => WasmI32
 ```
 
 ### Wasi.**path_symlink**
 
 ```grain
-path_symlink : (WasmI32, WasmI32, WasmI32, WasmI32, WasmI32) -> WasmI32
+path_symlink : (WasmI32, WasmI32, WasmI32, WasmI32, WasmI32) => WasmI32
 ```
 
 ### Wasi.**path_unlink_file**
 
 ```grain
-path_unlink_file : (WasmI32, WasmI32, WasmI32) -> WasmI32
+path_unlink_file : (WasmI32, WasmI32, WasmI32) => WasmI32
 ```
 
 ### Wasi.**path_readlink**
 
 ```grain
 path_readlink :
-  (WasmI32, WasmI32, WasmI32, WasmI32, WasmI32, WasmI32) -> WasmI32
+  (WasmI32, WasmI32, WasmI32, WasmI32, WasmI32, WasmI32) => WasmI32
 ```
 
 ### Wasi.**path_remove_directory**
 
 ```grain
-path_remove_directory : (WasmI32, WasmI32, WasmI32) -> WasmI32
+path_remove_directory : (WasmI32, WasmI32, WasmI32) => WasmI32
 ```
 
 ### Wasi.**path_rename**
 
 ```grain
 path_rename :
-  (WasmI32, WasmI32, WasmI32, WasmI32, WasmI32, WasmI32) -> WasmI32
+  (WasmI32, WasmI32, WasmI32, WasmI32, WasmI32, WasmI32) => WasmI32
 ```
 
 ### Wasi.**_CLOCK_REALTIME**
@@ -854,6 +854,6 @@ _ENOTCAPABLE : WasmI32
 ### Wasi.**stringOfSystemError**
 
 ```grain
-stringOfSystemError : (code: a) -> String
+stringOfSystemError : (code: a) => String
 ```
 

--- a/stdlib/set.md
+++ b/stdlib/set.md
@@ -37,7 +37,7 @@ No other changes yet.
 </details>
 
 ```grain
-makeSized : (size: Number) -> Set<a>
+makeSized : (size: Number) => Set<a>
 ```
 
 Creates a new empty set with an initial storage of the given size. As values are added or removed, the internal storage may grow or shrink. Generally, you won't need to care about the storage size of your set and can use `Set.make()` instead.
@@ -62,7 +62,7 @@ No other changes yet.
 </details>
 
 ```grain
-make : () -> Set<a>
+make : () => Set<a>
 ```
 
 Creates a new, empty set.
@@ -81,7 +81,7 @@ No other changes yet.
 </details>
 
 ```grain
-add : (key: a, set: Set<a>) -> Void
+add : (key: a, set: Set<a>) => Void
 ```
 
 Adds a new value to the set. If the value already exists, nothing happens.
@@ -101,7 +101,7 @@ No other changes yet.
 </details>
 
 ```grain
-contains : (key: a, set: Set<a>) -> Bool
+contains : (key: a, set: Set<a>) => Bool
 ```
 
 Determines if the set contains the given value.
@@ -127,7 +127,7 @@ No other changes yet.
 </details>
 
 ```grain
-remove : (key: a, set: Set<a>) -> Void
+remove : (key: a, set: Set<a>) => Void
 ```
 
 Removes the given value from the set. If the value doesn't exist, nothing happens.
@@ -147,7 +147,7 @@ No other changes yet.
 </details>
 
 ```grain
-size : (set: Set<a>) -> Number
+size : (set: Set<a>) => Number
 ```
 
 Provides the count of values within the set.
@@ -172,7 +172,7 @@ No other changes yet.
 </details>
 
 ```grain
-isEmpty : (set: Set<a>) -> Bool
+isEmpty : (set: Set<a>) => Bool
 ```
 
 Determines if the set contains no elements.
@@ -197,7 +197,7 @@ No other changes yet.
 </details>
 
 ```grain
-clear : (set: Set<a>) -> Void
+clear : (set: Set<a>) => Void
 ```
 
 Resets the set by removing all values.
@@ -223,7 +223,7 @@ Parameters:
 </details>
 
 ```grain
-forEach : (fn: (a -> Void), set: Set<a>) -> Void
+forEach : (fn: (a => Void), set: Set<a>) => Void
 ```
 
 Iterates the set, calling an iterator function on each element.
@@ -232,7 +232,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Void`|The iterator function to call with each element|
+|`fn`|`a => Void`|The iterator function to call with each element|
 |`set`|`Set<a>`|The set to iterate|
 
 ### Set.**reduce**
@@ -243,7 +243,7 @@ No other changes yet.
 </details>
 
 ```grain
-reduce : (fn: ((a, b) -> a), init: a, set: Set<b>) -> a
+reduce : (fn: ((a, b) => a), init: a, set: Set<b>) => a
 ```
 
 Combines all elements of a set using a reducer function.
@@ -252,7 +252,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`(a, b) -> a`|The reducer function to call on each element, where the value returned will be the next accumulator value|
+|`fn`|`(a, b) => a`|The reducer function to call on each element, where the value returned will be the next accumulator value|
 |`init`|`a`|The initial value to use for the accumulator on the first iteration|
 |`set`|`Set<b>`|The set to iterate|
 
@@ -270,7 +270,7 @@ No other changes yet.
 </details>
 
 ```grain
-filter : (fn: (a -> Bool), set: Set<a>) -> Void
+filter : (fn: (a => Bool), set: Set<a>) => Void
 ```
 
 Removes elements from a set where a predicate function returns `false`.
@@ -279,7 +279,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Bool`|The predicate function to indicate which elements to remove from the set, where returning `false` indicates the value should be removed|
+|`fn`|`a => Bool`|The predicate function to indicate which elements to remove from the set, where returning `false` indicates the value should be removed|
 |`set`|`Set<a>`|The set to iterate|
 
 ### Set.**reject**
@@ -290,7 +290,7 @@ No other changes yet.
 </details>
 
 ```grain
-reject : (fn: (a -> Bool), set: Set<a>) -> Void
+reject : (fn: (a => Bool), set: Set<a>) => Void
 ```
 
 Removes elements from a set where a predicate function returns `true`.
@@ -299,7 +299,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Bool`|The predicate function to indicate which elements to remove from the set, where returning `true` indicates the value should be removed|
+|`fn`|`a => Bool`|The predicate function to indicate which elements to remove from the set, where returning `true` indicates the value should be removed|
 |`set`|`Set<a>`|The set to iterate|
 
 ### Set.**toList**
@@ -310,7 +310,7 @@ No other changes yet.
 </details>
 
 ```grain
-toList : (set: Set<a>) -> List<a>
+toList : (set: Set<a>) => List<a>
 ```
 
 Converts a set into a list of its elements.
@@ -335,7 +335,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromList : (list: List<a>) -> Set<a>
+fromList : (list: List<a>) => Set<a>
 ```
 
 Creates a set from a list.
@@ -360,7 +360,7 @@ No other changes yet.
 </details>
 
 ```grain
-toArray : (set: Set<a>) -> Array<a>
+toArray : (set: Set<a>) => Array<a>
 ```
 
 Converts a set into an array of its elements.
@@ -385,7 +385,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromArray : (array: Array<a>) -> Set<a>
+fromArray : (array: Array<a>) => Set<a>
 ```
 
 Creates a set from an array.
@@ -410,7 +410,7 @@ No other changes yet.
 </details>
 
 ```grain
-union : (set1: Set<a>, set2: Set<a>) -> Set<a>
+union : (set1: Set<a>, set2: Set<a>) => Set<a>
 ```
 
 Combines two sets into a single set containing all elements from both sets.
@@ -436,7 +436,7 @@ No other changes yet.
 </details>
 
 ```grain
-diff : (set1: Set<a>, set2: Set<a>) -> Set<a>
+diff : (set1: Set<a>, set2: Set<a>) => Set<a>
 ```
 
 Combines two sets into a single set containing only the elements not shared between both sets.
@@ -462,7 +462,7 @@ No other changes yet.
 </details>
 
 ```grain
-intersect : (set1: Set<a>, set2: Set<a>) -> Set<a>
+intersect : (set1: Set<a>, set2: Set<a>) => Set<a>
 ```
 
 Combines two sets into a single set containing only the elements shared between both sets.
@@ -488,7 +488,7 @@ No other changes yet.
 </details>
 
 ```grain
-getInternalStats : (set: Set<a>) -> (Number, Number)
+getInternalStats : (set: Set<a>) => (Number, Number)
 ```
 
 Provides data representing the internal state state of the set.
@@ -570,7 +570,7 @@ An empty set
 </details>
 
 ```grain
-size : (set: Set<a>) -> Number
+size : (set: Set<a>) => Number
 ```
 
 Provides the count of values within the set.
@@ -602,7 +602,7 @@ Returns:
 </details>
 
 ```grain
-isEmpty : (set: Set<a>) -> Bool
+isEmpty : (set: Set<a>) => Bool
 ```
 
 Determines if the set contains no elements.
@@ -634,7 +634,7 @@ Returns:
 </details>
 
 ```grain
-add : (key: a, set: Set<a>) -> Set<a>
+add : (key: a, set: Set<a>) => Set<a>
 ```
 
 Produces a new set by inserting the given value into the set. If the value
@@ -668,7 +668,7 @@ Returns:
 </details>
 
 ```grain
-contains : (key: a, set: Set<a>) -> Bool
+contains : (key: a, set: Set<a>) => Bool
 ```
 
 Determines if the set contains the given value.
@@ -701,7 +701,7 @@ Returns:
 </details>
 
 ```grain
-remove : (key: a, set: Set<a>) -> Set<a>
+remove : (key: a, set: Set<a>) => Set<a>
 ```
 
 Produces a new set without the given element. If the value doesn't exist in
@@ -735,7 +735,7 @@ Returns:
 </details>
 
 ```grain
-forEach : (fn: (a -> Void), set: Set<a>) -> Void
+forEach : (fn: (a => Void), set: Set<a>) => Void
 ```
 
 Iterates the set, calling an iterator function on each element.
@@ -744,7 +744,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Void`|The iterator function to call with each element|
+|`fn`|`a => Void`|The iterator function to call with each element|
 |`set`|`Set<a>`|The set to iterate|
 
 #### Set.Immutable.**reduce**
@@ -762,7 +762,7 @@ Parameters:
 </details>
 
 ```grain
-reduce : (fn: ((a, b) -> a), init: a, set: Set<b>) -> a
+reduce : (fn: ((a, b) => a), init: a, set: Set<b>) => a
 ```
 
 Combines all elements of a set using a reducer function.
@@ -771,7 +771,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`(a, b) -> a`|The reducer function to call on each element, where the value returned will be the next accumulator value|
+|`fn`|`(a, b) => a`|The reducer function to call on each element, where the value returned will be the next accumulator value|
 |`init`|`a`|The initial value to use for the accumulator on the first iteration|
 |`set`|`Set<b>`|The set to iterate|
 
@@ -796,7 +796,7 @@ Returns:
 </details>
 
 ```grain
-filter : (fn: (a -> Bool), set: Set<a>) -> Set<a>
+filter : (fn: (a => Bool), set: Set<a>) => Set<a>
 ```
 
 Produces a new set without the elements from the input set where a predicate function returns `false`.
@@ -805,7 +805,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Bool`|The predicate function to indicate which elements to exclude from the set, where returning `false` indicates the value should be excluded|
+|`fn`|`a => Bool`|The predicate function to indicate which elements to exclude from the set, where returning `false` indicates the value should be excluded|
 |`set`|`Set<a>`|The set to iterate|
 
 Returns:
@@ -829,7 +829,7 @@ Returns:
 </details>
 
 ```grain
-reject : (fn: (a -> Bool), set: Set<a>) -> Set<a>
+reject : (fn: (a => Bool), set: Set<a>) => Set<a>
 ```
 
 Produces a new set without the elements from the input set where a predicate function returns `true`.
@@ -838,7 +838,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`a -> Bool`|The predicate function to indicate which elements to exclude from the set, where returning `true` indicates the value should be excluded|
+|`fn`|`a => Bool`|The predicate function to indicate which elements to exclude from the set, where returning `true` indicates the value should be excluded|
 |`set`|`Set<a>`|The set to iterate|
 
 Returns:
@@ -862,7 +862,7 @@ Returns:
 </details>
 
 ```grain
-union : (set1: Set<a>, set2: Set<a>) -> Set<a>
+union : (set1: Set<a>, set2: Set<a>) => Set<a>
 ```
 
 Combines two sets into a single set containing all elements from both sets.
@@ -895,7 +895,7 @@ Returns:
 </details>
 
 ```grain
-diff : (set1: Set<a>, set2: Set<a>) -> Set<a>
+diff : (set1: Set<a>, set2: Set<a>) => Set<a>
 ```
 
 Combines two sets into a single set containing only the elements not shared between both sets.
@@ -928,7 +928,7 @@ Returns:
 </details>
 
 ```grain
-intersect : (set1: Set<a>, set2: Set<a>) -> Set<a>
+intersect : (set1: Set<a>, set2: Set<a>) => Set<a>
 ```
 
 Combines two sets into a single set containing only the elements shared between both sets.
@@ -961,7 +961,7 @@ Returns:
 </details>
 
 ```grain
-fromList : (list: List<a>) -> Set<a>
+fromList : (list: List<a>) => Set<a>
 ```
 
 Creates a set from a list.
@@ -993,7 +993,7 @@ Returns:
 </details>
 
 ```grain
-toList : (set: Set<a>) -> List<a>
+toList : (set: Set<a>) => List<a>
 ```
 
 Converts a set into a list of its elements.
@@ -1025,7 +1025,7 @@ Returns:
 </details>
 
 ```grain
-fromArray : (array: Array<a>) -> Set<a>
+fromArray : (array: Array<a>) => Set<a>
 ```
 
 Creates a set from an array.
@@ -1057,7 +1057,7 @@ Returns:
 </details>
 
 ```grain
-toArray : (set: Set<a>) -> Array<a>
+toArray : (set: Set<a>) => Array<a>
 ```
 
 Converts a set into an array of its elements.

--- a/stdlib/stack.md
+++ b/stdlib/stack.md
@@ -41,7 +41,7 @@ No other changes yet.
 </details>
 
 ```grain
-makeSized : (size: Number) -> Stack<a>
+makeSized : (size: Number) => Stack<a>
 ```
 
 Creates a new stack with an initial storage of the given size. As values are
@@ -69,7 +69,7 @@ No other changes yet.
 </details>
 
 ```grain
-make : () -> Stack<a>
+make : () => Stack<a>
 ```
 
 Creates a new stack.
@@ -88,7 +88,7 @@ No other changes yet.
 </details>
 
 ```grain
-isEmpty : (stack: Stack<a>) -> Bool
+isEmpty : (stack: Stack<a>) => Bool
 ```
 
 Checks if the given stack contains no items.
@@ -113,7 +113,7 @@ No other changes yet.
 </details>
 
 ```grain
-size : (stack: Stack<a>) -> Number
+size : (stack: Stack<a>) => Number
 ```
 
 Computes the size of the input stack.
@@ -138,7 +138,7 @@ No other changes yet.
 </details>
 
 ```grain
-peek : (stack: Stack<a>) -> Option<a>
+peek : (stack: Stack<a>) => Option<a>
 ```
 
 Provides the value at the top of the stack, if it exists.
@@ -163,7 +163,7 @@ No other changes yet.
 </details>
 
 ```grain
-push : (value: a, stack: Stack<a>) -> Void
+push : (value: a, stack: Stack<a>) => Void
 ```
 
 Adds a new item to the top of the stack.
@@ -183,7 +183,7 @@ No other changes yet.
 </details>
 
 ```grain
-pop : (stack: Stack<a>) -> Option<a>
+pop : (stack: Stack<a>) => Option<a>
 ```
 
 Removes the item at the top of the stack.
@@ -208,7 +208,7 @@ No other changes yet.
 </details>
 
 ```grain
-clear : (stack: Stack<a>) -> Void
+clear : (stack: Stack<a>) => Void
 ```
 
 Clears the stack by removing all of its elements
@@ -227,7 +227,7 @@ No other changes yet.
 </details>
 
 ```grain
-copy : (stack: Stack<a>) -> Stack<a>
+copy : (stack: Stack<a>) => Stack<a>
 ```
 
 Produces a shallow copy of the input stack.
@@ -299,7 +299,7 @@ An empty stack.
 </details>
 
 ```grain
-isEmpty : (stack: ImmutableStack<a>) -> Bool
+isEmpty : (stack: ImmutableStack<a>) => Bool
 ```
 
 Checks if the given stack contains no items.
@@ -332,7 +332,7 @@ Returns:
 </details>
 
 ```grain
-peek : (stack: ImmutableStack<a>) -> Option<a>
+peek : (stack: ImmutableStack<a>) => Option<a>
 ```
 
 Provides the value at the top of the stack, if it exists.
@@ -364,7 +364,7 @@ Returns:
 </details>
 
 ```grain
-push : (value: a, stack: ImmutableStack<a>) -> ImmutableStack<a>
+push : (value: a, stack: ImmutableStack<a>) => ImmutableStack<a>
 ```
 
 Adds a new item to the top of the stack.
@@ -397,7 +397,7 @@ Returns:
 </details>
 
 ```grain
-pop : (stack: ImmutableStack<a>) -> ImmutableStack<a>
+pop : (stack: ImmutableStack<a>) => ImmutableStack<a>
 ```
 
 Removes the item at the top of the stack.
@@ -429,7 +429,7 @@ Returns:
 </details>
 
 ```grain
-size : (stack: ImmutableStack<a>) -> Number
+size : (stack: ImmutableStack<a>) => Number
 ```
 
 Computes the size of the input stack.

--- a/stdlib/string.gr
+++ b/stdlib/string.gr
@@ -1925,7 +1925,7 @@ provide let decodeKeepBom = (bytes: Bytes, encoding: Encoding) => {
  * @since v0.4.0
  */
 @unsafe
-provide let forEachCodePoint = (fn: Number -> Void, str: String) => {
+provide let forEachCodePoint = (fn: Number => Void, str: String) => {
   from WasmI32 use { (+), (-), (&), (>>>), ltU as (<), leU as (<=), (==) }
 
   let strPtr = WasmI32.fromGrain(str)
@@ -1977,7 +1977,7 @@ provide let forEachCodePoint = (fn: Number -> Void, str: String) => {
  * @since v0.4.0
  */
 @unsafe
-provide let forEachCodePointi = (fn: (Number, Number) -> Void, str: String) => {
+provide let forEachCodePointi = (fn: (Number, Number) => Void, str: String) => {
   from WasmI32 use { (+), (-), (&), (>>>), ltU as (<), leU as (<=), (==) }
 
   let strPtr = WasmI32.fromGrain(str)

--- a/stdlib/string.md
+++ b/stdlib/string.md
@@ -51,7 +51,7 @@ No other changes yet.
 </details>
 
 ```grain
-concat : (s1: String, s2: String) -> String
+concat : (s1: String, s2: String) => String
 ```
 
 Concatenate two strings.
@@ -83,7 +83,7 @@ No other changes yet.
 </details>
 
 ```grain
-length : (string: String) -> Number
+length : (string: String) => Number
 ```
 
 Returns the character length of the input string.
@@ -114,7 +114,7 @@ No other changes yet.
 </details>
 
 ```grain
-byteLength : (string: String) -> Number
+byteLength : (string: String) => Number
 ```
 
 Returns the byte length of the input string.
@@ -145,7 +145,7 @@ No other changes yet.
 </details>
 
 ```grain
-indexOf : (search: String, string: String) -> Option<Number>
+indexOf : (search: String, string: String) => Option<Number>
 ```
 
 Finds the first position of a substring in the input string.
@@ -177,7 +177,7 @@ No other changes yet.
 </details>
 
 ```grain
-lastIndexOf : (search: String, string: String) -> Option<Number>
+lastIndexOf : (search: String, string: String) => Option<Number>
 ```
 
 Finds the last position of a substring in the input string.
@@ -209,7 +209,7 @@ No other changes yet.
 </details>
 
 ```grain
-charCodeAt : (position: Number, string: String) -> Number
+charCodeAt : (position: Number, string: String) => Number
 ```
 
 Get the Unicode code point at the position in the input string.
@@ -251,7 +251,7 @@ No other changes yet.
 </details>
 
 ```grain
-charAt : (position: Number, string: String) -> Char
+charAt : (position: Number, string: String) => Char
 ```
 
 Get the character at the position in the input string.
@@ -293,7 +293,7 @@ No other changes yet.
 </details>
 
 ```grain
-explode : (string: String) -> Array<Char>
+explode : (string: String) => Array<Char>
 ```
 
 Split a string into its Unicode characters.
@@ -330,7 +330,7 @@ No other changes yet.
 </details>
 
 ```grain
-implode : (arr: Array<Char>) -> String
+implode : (arr: Array<Char>) => String
 ```
 
 Create a string from an array of characters.
@@ -361,7 +361,7 @@ No other changes yet.
 </details>
 
 ```grain
-reverse : (string: String) -> String
+reverse : (string: String) => String
 ```
 
 Create a string that is the given string reversed.
@@ -387,7 +387,7 @@ String.reverse("olleH") == "Hello"
 ### String.**split**
 
 ```grain
-split : (separator: String, string: String) -> Array<String>
+split : (separator: String, string: String) => Array<String>
 ```
 
 Split a string by the given separator.
@@ -432,7 +432,7 @@ String.split(" ", "Hello world") == [> "Hello", "world"]
 </details>
 
 ```grain
-slice : (start: Number, ?end: Number, string: String) -> String
+slice : (start: Number, ?end: Number, string: String) => String
 ```
 
 Get a portion of a string.
@@ -482,7 +482,7 @@ No other changes yet.
 </details>
 
 ```grain
-contains : (search: String, string: String) -> Bool
+contains : (search: String, string: String) => Bool
 ```
 
 Check if a string contains a substring.
@@ -514,7 +514,7 @@ No other changes yet.
 </details>
 
 ```grain
-startsWith : (search: String, string: String) -> Bool
+startsWith : (search: String, string: String) => Bool
 ```
 
 Check if a string begins with another string.
@@ -546,7 +546,7 @@ No other changes yet.
 </details>
 
 ```grain
-endsWith : (search: String, string: String) -> Bool
+endsWith : (search: String, string: String) => Bool
 ```
 
 Check if a string ends with another string.
@@ -579,7 +579,7 @@ No other changes yet.
 
 ```grain
 replaceFirst :
-  (searchPattern: String, replacement: String, string: String) -> String
+  (searchPattern: String, replacement: String, string: String) => String
 ```
 
 Replaces the first appearance of the search pattern in the string with the replacement value.
@@ -613,7 +613,7 @@ No other changes yet.
 
 ```grain
 replaceLast :
-  (searchPattern: String, replacement: String, string: String) -> String
+  (searchPattern: String, replacement: String, string: String) => String
 ```
 
 Replaces the last appearance of the search pattern in the string with the replacement value.
@@ -647,7 +647,7 @@ No other changes yet.
 
 ```grain
 replaceAll :
-  (searchPattern: String, replacement: String, string: String) -> String
+  (searchPattern: String, replacement: String, string: String) => String
 ```
 
 Replaces every appearance of the search pattern in the string with the replacement value.
@@ -681,7 +681,7 @@ No other changes yet.
 
 ```grain
 encodeAt :
-  (string: String, encoding: Encoding, dest: Bytes, destPos: Number) -> Bytes
+  (string: String, encoding: Encoding, dest: Bytes, destPos: Number) => Bytes
 ```
 
 Encodes the given string into a byte sequence at the supplied position, excluding any byte-order marker, using the encoding scheme provided.
@@ -717,7 +717,7 @@ No other changes yet.
 
 ```grain
 encodeAtWithBom :
-  (string: String, encoding: Encoding, dest: Bytes, destPos: Number) -> Bytes
+  (string: String, encoding: Encoding, dest: Bytes, destPos: Number) => Bytes
 ```
 
 Encodes the given string into a byte sequence at the supplied position, including any byte-order marker, using the encoding scheme provided.
@@ -752,7 +752,7 @@ No other changes yet.
 </details>
 
 ```grain
-encode : (string: String, encoding: Encoding) -> Bytes
+encode : (string: String, encoding: Encoding) => Bytes
 ```
 
 Encodes the given string using the given encoding scheme, excluding any byte-order marker.
@@ -778,7 +778,7 @@ No other changes yet.
 </details>
 
 ```grain
-encodeWithBom : (string: String, encoding: Encoding) -> Bytes
+encodeWithBom : (string: String, encoding: Encoding) => Bytes
 ```
 
 Encodes the given string using the given encoding scheme, including any byte-order marker.
@@ -805,7 +805,7 @@ No other changes yet.
 
 ```grain
 decodeRange :
-  (bytes: Bytes, encoding: Encoding, start: Number, size: Number) -> String
+  (bytes: Bytes, encoding: Encoding, start: Number, size: Number) => String
 ```
 
 Decodes the given byte sequence of the specified range into a string, excluding any byte-order marker, using encoding scheme provided.
@@ -843,7 +843,7 @@ No other changes yet.
 
 ```grain
 decodeRangeKeepBom :
-  (bytes: Bytes, encoding: Encoding, start: Number, size: Number) -> String
+  (bytes: Bytes, encoding: Encoding, start: Number, size: Number) => String
 ```
 
 Decodes the given byte sequence of the specified range into a string, including any byte-order marker, using encoding scheme provided.
@@ -880,7 +880,7 @@ No other changes yet.
 </details>
 
 ```grain
-decode : (bytes: Bytes, encoding: Encoding) -> String
+decode : (bytes: Bytes, encoding: Encoding) => String
 ```
 
 Decodes the given byte sequence into a string using the given encoding scheme, excluding any byte-order marker.
@@ -906,7 +906,7 @@ No other changes yet.
 </details>
 
 ```grain
-decodeKeepBom : (bytes: Bytes, encoding: Encoding) -> String
+decodeKeepBom : (bytes: Bytes, encoding: Encoding) => String
 ```
 
 Decodes the given byte sequence into a string using the given encoding scheme, including any byte-order marker.
@@ -932,7 +932,7 @@ No other changes yet.
 </details>
 
 ```grain
-forEachCodePoint : (fn: (Number -> Void), str: String) -> Void
+forEachCodePoint : (fn: (Number => Void), str: String) => Void
 ```
 
 Iterates over Unicode code points in a string.
@@ -941,7 +941,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`Number -> Void`|The iterator function|
+|`fn`|`Number => Void`|The iterator function|
 |`str`|`String`|The string to iterate|
 
 Examples:
@@ -958,7 +958,7 @@ No other changes yet.
 </details>
 
 ```grain
-forEachCodePointi : (fn: ((Number, Number) -> Void), str: String) -> Void
+forEachCodePointi : (fn: ((Number, Number) => Void), str: String) => Void
 ```
 
 Iterates over Unicode code points in a string. This is the same as
@@ -969,7 +969,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`fn`|`(Number, Number) -> Void`|The iterator function|
+|`fn`|`(Number, Number) => Void`|The iterator function|
 |`str`|`String`|The string to iterate|
 
 Examples:
@@ -986,7 +986,7 @@ No other changes yet.
 </details>
 
 ```grain
-trimStart : (string: String) -> String
+trimStart : (string: String) => String
 ```
 
 Trims the beginning of a string—removing any leading whitespace characters.
@@ -1017,7 +1017,7 @@ No other changes yet.
 </details>
 
 ```grain
-trimEnd : (string: String) -> String
+trimEnd : (string: String) => String
 ```
 
 Trims the end of a string—removing any trailing whitespace characters.
@@ -1048,7 +1048,7 @@ No other changes yet.
 </details>
 
 ```grain
-trim : (string: String) -> String
+trim : (string: String) => String
 ```
 
 Trims a string—removing all leading and trailing whitespace characters.

--- a/stdlib/sys/file.md
+++ b/stdlib/sys/file.md
@@ -218,7 +218,7 @@ The `FileDescriptor` for `stderr`.
 pathOpen :
   (dirFd: FileDescriptor, dirFlags: List<LookupFlag>, path: String,
    openFlags: List<OpenFlag>, rights: List<Rights>,
-   rightsInheriting: List<Rights>, flags: List<FdFlag>) ->
+   rightsInheriting: List<Rights>, flags: List<FdFlag>) =>
    Result<FileDescriptor, Exception>
 ```
 
@@ -246,7 +246,7 @@ Returns:
 
 ```grain
 fdRead :
-  (fd: FileDescriptor, size: Number) -> Result<(Bytes, Number), Exception>
+  (fd: FileDescriptor, size: Number) => Result<(Bytes, Number), Exception>
 ```
 
 Read from a file descriptor.
@@ -268,7 +268,7 @@ Returns:
 
 ```grain
 fdPread :
-  (fd: FileDescriptor, offset: Int64, size: Number) ->
+  (fd: FileDescriptor, offset: Int64, size: Number) =>
    Result<(Bytes, Number), Exception>
 ```
 
@@ -296,7 +296,7 @@ No other changes yet.
 </details>
 
 ```grain
-fdPrestatGet : (fd: FileDescriptor) -> Result<Prestat, Exception>
+fdPrestatGet : (fd: FileDescriptor) => Result<Prestat, Exception>
 ```
 
 Get information about a preopened directory.
@@ -316,7 +316,7 @@ Returns:
 ### File.**fdWrite**
 
 ```grain
-fdWrite : (fd: FileDescriptor, data: Bytes) -> Result<Number, Exception>
+fdWrite : (fd: FileDescriptor, data: Bytes) => Result<Number, Exception>
 ```
 
 Write to a file descriptor.
@@ -338,7 +338,7 @@ Returns:
 
 ```grain
 fdPwrite :
-  (fd: FileDescriptor, data: Bytes, offset: Int64) ->
+  (fd: FileDescriptor, data: Bytes, offset: Int64) =>
    Result<Number, Exception>
 ```
 
@@ -362,7 +362,7 @@ Returns:
 
 ```grain
 fdAllocate :
-  (fd: FileDescriptor, offset: Int64, size: Int64) -> Result<Void, Exception>
+  (fd: FileDescriptor, offset: Int64, size: Int64) => Result<Void, Exception>
 ```
 
 Allocate space within a file.
@@ -384,7 +384,7 @@ Returns:
 ### File.**fdClose**
 
 ```grain
-fdClose : (fd: FileDescriptor) -> Result<Void, Exception>
+fdClose : (fd: FileDescriptor) => Result<Void, Exception>
 ```
 
 Close a file descriptor.
@@ -404,7 +404,7 @@ Returns:
 ### File.**fdDatasync**
 
 ```grain
-fdDatasync : (fd: FileDescriptor) -> Result<Void, Exception>
+fdDatasync : (fd: FileDescriptor) => Result<Void, Exception>
 ```
 
 Synchronize the data of a file to disk.
@@ -424,7 +424,7 @@ Returns:
 ### File.**fdSync**
 
 ```grain
-fdSync : (fd: FileDescriptor) -> Result<Void, Exception>
+fdSync : (fd: FileDescriptor) => Result<Void, Exception>
 ```
 
 Synchronize the data and metadata of a file to disk.
@@ -444,7 +444,7 @@ Returns:
 ### File.**fdStats**
 
 ```grain
-fdStats : (fd: FileDescriptor) -> Result<Stats, Exception>
+fdStats : (fd: FileDescriptor) => Result<Stats, Exception>
 ```
 
 Retrieve information about a file descriptor.
@@ -465,7 +465,7 @@ Returns:
 
 ```grain
 fdSetFlags :
-  (fd: FileDescriptor, flags: List<FdFlag>) -> Result<Void, Exception>
+  (fd: FileDescriptor, flags: List<FdFlag>) => Result<Void, Exception>
 ```
 
 Update the flags associated with a file descriptor.
@@ -487,7 +487,7 @@ Returns:
 
 ```grain
 fdSetRights :
-  (fd: FileDescriptor, rights: List<Rights>, rightsInheriting: List<Rights>) ->
+  (fd: FileDescriptor, rights: List<Rights>, rightsInheriting: List<Rights>) =>
    Result<Void, Exception>
 ```
 
@@ -510,7 +510,7 @@ Returns:
 ### File.**fdFilestats**
 
 ```grain
-fdFilestats : (fd: FileDescriptor) -> Result<Filestats, Exception>
+fdFilestats : (fd: FileDescriptor) => Result<Filestats, Exception>
 ```
 
 Retrieve information about a file.
@@ -530,7 +530,7 @@ Returns:
 ### File.**fdSetSize**
 
 ```grain
-fdSetSize : (fd: FileDescriptor, size: Int64) -> Result<Void, Exception>
+fdSetSize : (fd: FileDescriptor, size: Int64) => Result<Void, Exception>
 ```
 
 Set (truncate) the size of a file.
@@ -552,7 +552,7 @@ Returns:
 
 ```grain
 fdSetAccessTime :
-  (fd: FileDescriptor, timestamp: Int64) -> Result<Void, Exception>
+  (fd: FileDescriptor, timestamp: Int64) => Result<Void, Exception>
 ```
 
 Set the access (created) time of a file.
@@ -573,7 +573,7 @@ Returns:
 ### File.**fdSetAccessTimeNow**
 
 ```grain
-fdSetAccessTimeNow : (fd: FileDescriptor) -> Result<Void, Exception>
+fdSetAccessTimeNow : (fd: FileDescriptor) => Result<Void, Exception>
 ```
 
 Set the access (created) time of a file to the current time.
@@ -594,7 +594,7 @@ Returns:
 
 ```grain
 fdSetModifiedTime :
-  (fd: FileDescriptor, timestamp: Int64) -> Result<Void, Exception>
+  (fd: FileDescriptor, timestamp: Int64) => Result<Void, Exception>
 ```
 
 Set the modified time of a file.
@@ -615,7 +615,7 @@ Returns:
 ### File.**fdSetModifiedTimeNow**
 
 ```grain
-fdSetModifiedTimeNow : (fd: FileDescriptor) -> Result<Void, Exception>
+fdSetModifiedTimeNow : (fd: FileDescriptor) => Result<Void, Exception>
 ```
 
 Set the modified time of a file to the current time.
@@ -635,7 +635,7 @@ Returns:
 ### File.**fdReaddir**
 
 ```grain
-fdReaddir : (fd: FileDescriptor) -> Result<Array<DirectoryEntry>, Exception>
+fdReaddir : (fd: FileDescriptor) => Result<Array<DirectoryEntry>, Exception>
 ```
 
 Read the entires of a directory.
@@ -656,7 +656,7 @@ Returns:
 
 ```grain
 fdRenumber :
-  (fromFd: FileDescriptor, toFd: FileDescriptor) -> Result<Void, Exception>
+  (fromFd: FileDescriptor, toFd: FileDescriptor) => Result<Void, Exception>
 ```
 
 Atomically replace a file descriptor by renumbering another file descriptor.
@@ -678,7 +678,7 @@ Returns:
 
 ```grain
 fdSeek :
-  (fd: FileDescriptor, offset: Int64, whence: Whence) ->
+  (fd: FileDescriptor, offset: Int64, whence: Whence) =>
    Result<Int64, Exception>
 ```
 
@@ -701,7 +701,7 @@ Returns:
 ### File.**fdTell**
 
 ```grain
-fdTell : (fd: FileDescriptor) -> Result<Int64, Exception>
+fdTell : (fd: FileDescriptor) => Result<Int64, Exception>
 ```
 
 Read a file descriptor's offset.
@@ -722,7 +722,7 @@ Returns:
 
 ```grain
 pathCreateDirectory :
-  (fd: FileDescriptor, path: String) -> Result<Void, Exception>
+  (fd: FileDescriptor, path: String) => Result<Void, Exception>
 ```
 
 Create a directory.
@@ -744,7 +744,7 @@ Returns:
 
 ```grain
 pathFilestats :
-  (fd: FileDescriptor, dirFlags: List<LookupFlag>, path: String) ->
+  (fd: FileDescriptor, dirFlags: List<LookupFlag>, path: String) =>
    Result<Filestats, Exception>
 ```
 
@@ -769,7 +769,7 @@ Returns:
 ```grain
 pathSetAccessTime :
   (fd: FileDescriptor, dirFlags: List<LookupFlag>, path: String,
-   timestamp: Int64) -> Result<Void, Exception>
+   timestamp: Int64) => Result<Void, Exception>
 ```
 
 Set the access (created) time of a file.
@@ -793,7 +793,7 @@ Returns:
 
 ```grain
 pathSetAccessTimeNow :
-  (fd: FileDescriptor, dirFlags: List<LookupFlag>, path: String) ->
+  (fd: FileDescriptor, dirFlags: List<LookupFlag>, path: String) =>
    Result<Void, Exception>
 ```
 
@@ -818,7 +818,7 @@ Returns:
 ```grain
 pathSetModifiedTime :
   (fd: FileDescriptor, dirFlags: List<LookupFlag>, path: String,
-   timestamp: Int64) -> Result<Void, Exception>
+   timestamp: Int64) => Result<Void, Exception>
 ```
 
 Set the modified time of a file.
@@ -842,7 +842,7 @@ Returns:
 
 ```grain
 pathSetModifiedTimeNow :
-  (fd: FileDescriptor, dirFlags: List<LookupFlag>, path: String) ->
+  (fd: FileDescriptor, dirFlags: List<LookupFlag>, path: String) =>
    Result<Void, Exception>
 ```
 
@@ -867,7 +867,7 @@ Returns:
 ```grain
 pathLink :
   (sourceFd: FileDescriptor, dirFlags: List<LookupFlag>, sourcePath: 
-   String, targetFd: FileDescriptor, targetPath: String) ->
+   String, targetFd: FileDescriptor, targetPath: String) =>
    Result<Void, Exception>
 ```
 
@@ -893,7 +893,7 @@ Returns:
 
 ```grain
 pathSymlink :
-  (fd: FileDescriptor, sourcePath: String, targetPath: String) ->
+  (fd: FileDescriptor, sourcePath: String, targetPath: String) =>
    Result<Void, Exception>
 ```
 
@@ -916,7 +916,7 @@ Returns:
 ### File.**pathUnlink**
 
 ```grain
-pathUnlink : (fd: FileDescriptor, path: String) -> Result<Void, Exception>
+pathUnlink : (fd: FileDescriptor, path: String) => Result<Void, Exception>
 ```
 
 Unlink a file.
@@ -938,7 +938,7 @@ Returns:
 
 ```grain
 pathReadlink :
-  (fd: FileDescriptor, path: String, size: Number) ->
+  (fd: FileDescriptor, path: String, size: Number) =>
    Result<(String, Number), Exception>
 ```
 
@@ -962,7 +962,7 @@ Returns:
 
 ```grain
 pathRemoveDirectory :
-  (fd: FileDescriptor, path: String) -> Result<Void, Exception>
+  (fd: FileDescriptor, path: String) => Result<Void, Exception>
 ```
 
 Remove a directory.
@@ -985,7 +985,7 @@ Returns:
 ```grain
 pathRename :
   (sourceFd: FileDescriptor, sourcePath: String, targetFd: FileDescriptor,
-   targetPath: String) -> Result<Void, Exception>
+   targetPath: String) => Result<Void, Exception>
 ```
 
 Rename a file or directory.
@@ -1015,7 +1015,7 @@ No other changes yet.
 ```grain
 open :
   (path: String, openFlags: List<OpenFlag>, rights: List<Rights>,
-   rightsInheriting: List<Rights>, flags: List<FdFlag>) ->
+   rightsInheriting: List<Rights>, flags: List<FdFlag>) =>
    Result<FileDescriptor, Exception>
 ```
 

--- a/stdlib/sys/process.md
+++ b/stdlib/sys/process.md
@@ -60,7 +60,7 @@ Functions and constants included in the Process module.
 ### Process.**argv**
 
 ```grain
-argv : () -> Result<Array<String>, Exception>
+argv : () => Result<Array<String>, Exception>
 ```
 
 Access command line arguments.
@@ -74,7 +74,7 @@ Returns:
 ### Process.**env**
 
 ```grain
-env : () -> Result<Array<String>, Exception>
+env : () => Result<Array<String>, Exception>
 ```
 
 Access environment variables.
@@ -88,7 +88,7 @@ Returns:
 ### Process.**exit**
 
 ```grain
-exit : (code: Number) -> Result<Void, Exception>
+exit : (code: Number) => Result<Void, Exception>
 ```
 
 Terminate the process normally.
@@ -108,7 +108,7 @@ Returns:
 ### Process.**sigRaise**
 
 ```grain
-sigRaise : (signalPtr: Signal) -> Result<Void, Exception>
+sigRaise : (signalPtr: Signal) => Result<Void, Exception>
 ```
 
 Send a signal to the process of the calling thread.
@@ -128,7 +128,7 @@ Returns:
 ### Process.**schedYield**
 
 ```grain
-schedYield : () -> Result<Void, Exception>
+schedYield : () => Result<Void, Exception>
 ```
 
 Yield execution to the calling thread.

--- a/stdlib/sys/random.md
+++ b/stdlib/sys/random.md
@@ -27,7 +27,7 @@ Functions and constants included in the Random module.
 </details>
 
 ```grain
-randomUint32 : () -> Result<Uint32, Exception>
+randomUint32 : () => Result<Uint32, Exception>
 ```
 
 Produce a random 32-bit integer. This function can be slow, so it's best to seed a generator if lots of random data is needed.
@@ -53,7 +53,7 @@ Returns:
 </details>
 
 ```grain
-randomUint64 : () -> Result<Uint64, Exception>
+randomUint64 : () => Result<Uint64, Exception>
 ```
 
 Produce a random 64-bit integer. This function can be slow, so it's best to seed a generator if lots of random data is needed.
@@ -67,7 +67,7 @@ Returns:
 ### Random.**random**
 
 ```grain
-random : () -> Result<Number, Exception>
+random : () => Result<Number, Exception>
 ```
 
 Produce a random number. This function can be slow, so it's best to seed a generator if lots of random data is needed.

--- a/stdlib/sys/time.md
+++ b/stdlib/sys/time.md
@@ -15,7 +15,7 @@ Functions and constants included in the Time module.
 ### Time.**realTime**
 
 ```grain
-realTime : () -> Result<Int64, Exception>
+realTime : () => Result<Int64, Exception>
 ```
 
 Get the current time, in nanoseconds.
@@ -30,7 +30,7 @@ Returns:
 ### Time.**monotonicTime**
 
 ```grain
-monotonicTime : () -> Result<Int64, Exception>
+monotonicTime : () => Result<Int64, Exception>
 ```
 
 Get the time of the system's high-resolution clock, in nanoseconds.
@@ -47,7 +47,7 @@ Returns:
 ### Time.**processCpuTime**
 
 ```grain
-processCpuTime : () -> Result<Int64, Exception>
+processCpuTime : () => Result<Int64, Exception>
 ```
 
 Get the number of nanoseconds elapsed since the process began.
@@ -61,7 +61,7 @@ Returns:
 ### Time.**threadCpuTime**
 
 ```grain
-threadCpuTime : () -> Result<Int64, Exception>
+threadCpuTime : () => Result<Int64, Exception>
 ```
 
 Get the number of nanoseconds elapsed since the thread began.

--- a/stdlib/uint16.md
+++ b/stdlib/uint16.md
@@ -25,7 +25,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromNumber : (number: Number) -> Uint16
+fromNumber : (number: Number) => Uint16
 ```
 
 Converts a Number to a Uint16.
@@ -50,7 +50,7 @@ No other changes yet.
 </details>
 
 ```grain
-toNumber : (value: Uint16) -> Number
+toNumber : (value: Uint16) => Number
 ```
 
 Converts a Uint16 to a Number.
@@ -75,7 +75,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromInt16 : (x: Int16) -> Uint16
+fromInt16 : (x: Int16) => Uint16
 ```
 
 Converts an Int16 to a Uint16.
@@ -100,7 +100,7 @@ No other changes yet.
 </details>
 
 ```grain
-incr : (value: Uint16) -> Uint16
+incr : (value: Uint16) => Uint16
 ```
 
 Increments the value by one.
@@ -125,7 +125,7 @@ No other changes yet.
 </details>
 
 ```grain
-decr : (value: Uint16) -> Uint16
+decr : (value: Uint16) => Uint16
 ```
 
 Decrements the value by one.
@@ -150,7 +150,7 @@ No other changes yet.
 </details>
 
 ```grain
-(+) : (x: Uint16, y: Uint16) -> Uint16
+(+) : (x: Uint16, y: Uint16) => Uint16
 ```
 
 Computes the sum of its operands.
@@ -176,7 +176,7 @@ No other changes yet.
 </details>
 
 ```grain
-(-) : (x: Uint16, y: Uint16) -> Uint16
+(-) : (x: Uint16, y: Uint16) => Uint16
 ```
 
 Computes the difference of its operands.
@@ -202,7 +202,7 @@ No other changes yet.
 </details>
 
 ```grain
-(*) : (x: Uint16, y: Uint16) -> Uint16
+(*) : (x: Uint16, y: Uint16) => Uint16
 ```
 
 Computes the product of its operands.
@@ -228,7 +228,7 @@ No other changes yet.
 </details>
 
 ```grain
-(/) : (x: Uint16, y: Uint16) -> Uint16
+(/) : (x: Uint16, y: Uint16) => Uint16
 ```
 
 Computes the quotient of its operands.
@@ -254,7 +254,7 @@ No other changes yet.
 </details>
 
 ```grain
-rem : (x: Uint16, y: Uint16) -> Uint16
+rem : (x: Uint16, y: Uint16) => Uint16
 ```
 
 Computes the remainder of the division of its operands.
@@ -280,7 +280,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<<) : (value: Uint16, amount: Uint16) -> Uint16
+(<<) : (value: Uint16, amount: Uint16) => Uint16
 ```
 
 Shifts the bits of the value left by the given number of bits.
@@ -306,7 +306,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>>>) : (value: Uint16, amount: Uint16) -> Uint16
+(>>>) : (value: Uint16, amount: Uint16) => Uint16
 ```
 
 Shifts the bits of the value right by the given number of bits.
@@ -332,7 +332,7 @@ No other changes yet.
 </details>
 
 ```grain
-(==) : (x: Uint16, y: Uint16) -> Bool
+(==) : (x: Uint16, y: Uint16) => Bool
 ```
 
 Checks if the first value is equal to the second value.
@@ -358,7 +358,7 @@ No other changes yet.
 </details>
 
 ```grain
-(!=) : (x: Uint16, y: Uint16) -> Bool
+(!=) : (x: Uint16, y: Uint16) => Bool
 ```
 
 Checks if the first value is not equal to the second value.
@@ -384,7 +384,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<) : (x: Uint16, y: Uint16) -> Bool
+(<) : (x: Uint16, y: Uint16) => Bool
 ```
 
 Checks if the first value is less than the second value.
@@ -410,7 +410,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>) : (x: Uint16, y: Uint16) -> Bool
+(>) : (x: Uint16, y: Uint16) => Bool
 ```
 
 Checks if the first value is greater than the second value.
@@ -436,7 +436,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<=) : (x: Uint16, y: Uint16) -> Bool
+(<=) : (x: Uint16, y: Uint16) => Bool
 ```
 
 Checks if the first value is less than or equal to the second value.
@@ -462,7 +462,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>=) : (x: Uint16, y: Uint16) -> Bool
+(>=) : (x: Uint16, y: Uint16) => Bool
 ```
 
 Checks if the first value is greater than or equal to the second value.
@@ -488,7 +488,7 @@ No other changes yet.
 </details>
 
 ```grain
-lnot : (value: Uint16) -> Uint16
+lnot : (value: Uint16) => Uint16
 ```
 
 Computes the bitwise NOT of the given value.
@@ -513,7 +513,7 @@ No other changes yet.
 </details>
 
 ```grain
-(&) : (x: Uint16, y: Uint16) -> Uint16
+(&) : (x: Uint16, y: Uint16) => Uint16
 ```
 
 Computes the bitwise AND (`&`) on the given operands.
@@ -539,7 +539,7 @@ No other changes yet.
 </details>
 
 ```grain
-(|) : (x: Uint16, y: Uint16) -> Uint16
+(|) : (x: Uint16, y: Uint16) => Uint16
 ```
 
 Computes the bitwise OR (`|`) on the given operands.
@@ -565,7 +565,7 @@ No other changes yet.
 </details>
 
 ```grain
-(^) : (x: Uint16, y: Uint16) -> Uint16
+(^) : (x: Uint16, y: Uint16) => Uint16
 ```
 
 Computes the bitwise XOR (`^`) on the given operands.

--- a/stdlib/uint32.md
+++ b/stdlib/uint32.md
@@ -25,7 +25,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromNumber : (x: Number) -> Uint32
+fromNumber : (x: Number) => Uint32
 ```
 
 Converts a Number to a Uint32.
@@ -50,7 +50,7 @@ No other changes yet.
 </details>
 
 ```grain
-toNumber : (x: Uint32) -> Number
+toNumber : (x: Uint32) => Number
 ```
 
 Converts a Uint32 to a Number.
@@ -75,7 +75,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromInt32 : (x: Int32) -> Uint32
+fromInt32 : (x: Int32) => Uint32
 ```
 
 Converts an Int32 to a Uint32.
@@ -100,7 +100,7 @@ No other changes yet.
 </details>
 
 ```grain
-incr : (value: Uint32) -> Uint32
+incr : (value: Uint32) => Uint32
 ```
 
 Increments the value by one.
@@ -125,7 +125,7 @@ No other changes yet.
 </details>
 
 ```grain
-decr : (value: Uint32) -> Uint32
+decr : (value: Uint32) => Uint32
 ```
 
 Decrements the value by one.
@@ -150,7 +150,7 @@ No other changes yet.
 </details>
 
 ```grain
-(+) : (x: Uint32, y: Uint32) -> Uint32
+(+) : (x: Uint32, y: Uint32) => Uint32
 ```
 
 Computes the sum of its operands.
@@ -176,7 +176,7 @@ No other changes yet.
 </details>
 
 ```grain
-(-) : (x: Uint32, y: Uint32) -> Uint32
+(-) : (x: Uint32, y: Uint32) => Uint32
 ```
 
 Computes the difference of its operands.
@@ -202,7 +202,7 @@ No other changes yet.
 </details>
 
 ```grain
-(*) : (x: Uint32, y: Uint32) -> Uint32
+(*) : (x: Uint32, y: Uint32) => Uint32
 ```
 
 Computes the product of its operands.
@@ -228,7 +228,7 @@ No other changes yet.
 </details>
 
 ```grain
-(/) : (x: Uint32, y: Uint32) -> Uint32
+(/) : (x: Uint32, y: Uint32) => Uint32
 ```
 
 Computes the quotient of its operands.
@@ -254,7 +254,7 @@ No other changes yet.
 </details>
 
 ```grain
-rem : (x: Uint32, y: Uint32) -> Uint32
+rem : (x: Uint32, y: Uint32) => Uint32
 ```
 
 Computes the remainder of the division of its operands.
@@ -280,7 +280,7 @@ No other changes yet.
 </details>
 
 ```grain
-rotl : (value: Uint32, amount: Uint32) -> Uint32
+rotl : (value: Uint32, amount: Uint32) => Uint32
 ```
 
 Rotates the bits of the value left by the given number of bits.
@@ -306,7 +306,7 @@ No other changes yet.
 </details>
 
 ```grain
-rotr : (value: Uint32, amount: Uint32) -> Uint32
+rotr : (value: Uint32, amount: Uint32) => Uint32
 ```
 
 Rotates the bits of the value right by the given number of bits.
@@ -332,7 +332,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<<) : (value: Uint32, amount: Uint32) -> Uint32
+(<<) : (value: Uint32, amount: Uint32) => Uint32
 ```
 
 Shifts the bits of the value left by the given number of bits.
@@ -358,7 +358,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>>>) : (value: Uint32, amount: Uint32) -> Uint32
+(>>>) : (value: Uint32, amount: Uint32) => Uint32
 ```
 
 Shifts the bits of the value right by the given number of bits.
@@ -384,7 +384,7 @@ No other changes yet.
 </details>
 
 ```grain
-(==) : (x: Uint32, y: Uint32) -> Bool
+(==) : (x: Uint32, y: Uint32) => Bool
 ```
 
 Checks if the first value is equal to the second value.
@@ -410,7 +410,7 @@ No other changes yet.
 </details>
 
 ```grain
-(!=) : (x: Uint32, y: Uint32) -> Bool
+(!=) : (x: Uint32, y: Uint32) => Bool
 ```
 
 Checks if the first value is not equal to the second value.
@@ -436,7 +436,7 @@ No other changes yet.
 </details>
 
 ```grain
-eqz : (value: Uint32) -> Bool
+eqz : (value: Uint32) => Bool
 ```
 
 Checks if the given value is equal to zero.
@@ -461,7 +461,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<) : (x: Uint32, y: Uint32) -> Bool
+(<) : (x: Uint32, y: Uint32) => Bool
 ```
 
 Checks if the first value is less than the second value.
@@ -487,7 +487,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>) : (x: Uint32, y: Uint32) -> Bool
+(>) : (x: Uint32, y: Uint32) => Bool
 ```
 
 Checks if the first value is greater than the second value.
@@ -513,7 +513,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<=) : (x: Uint32, y: Uint32) -> Bool
+(<=) : (x: Uint32, y: Uint32) => Bool
 ```
 
 Checks if the first value is less than or equal to the second value.
@@ -539,7 +539,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>=) : (x: Uint32, y: Uint32) -> Bool
+(>=) : (x: Uint32, y: Uint32) => Bool
 ```
 
 Checks if the first value is greater than or equal to the second value.
@@ -565,7 +565,7 @@ No other changes yet.
 </details>
 
 ```grain
-lnot : (value: Uint32) -> Uint32
+lnot : (value: Uint32) => Uint32
 ```
 
 Computes the bitwise NOT of the given value.
@@ -590,7 +590,7 @@ No other changes yet.
 </details>
 
 ```grain
-(&) : (x: Uint32, y: Uint32) -> Uint32
+(&) : (x: Uint32, y: Uint32) => Uint32
 ```
 
 Computes the bitwise AND (`&`) on the given operands.
@@ -616,7 +616,7 @@ No other changes yet.
 </details>
 
 ```grain
-(|) : (x: Uint32, y: Uint32) -> Uint32
+(|) : (x: Uint32, y: Uint32) => Uint32
 ```
 
 Computes the bitwise OR (`|`) on the given operands.
@@ -642,7 +642,7 @@ No other changes yet.
 </details>
 
 ```grain
-(^) : (x: Uint32, y: Uint32) -> Uint32
+(^) : (x: Uint32, y: Uint32) => Uint32
 ```
 
 Computes the bitwise XOR (`^`) on the given operands.
@@ -668,7 +668,7 @@ No other changes yet.
 </details>
 
 ```grain
-clz : (value: Uint32) -> Uint32
+clz : (value: Uint32) => Uint32
 ```
 
 Counts the number of leading zero bits in the value.
@@ -693,7 +693,7 @@ No other changes yet.
 </details>
 
 ```grain
-ctz : (value: Uint32) -> Uint32
+ctz : (value: Uint32) => Uint32
 ```
 
 Counts the number of trailing zero bits in the value.
@@ -718,7 +718,7 @@ No other changes yet.
 </details>
 
 ```grain
-popcnt : (value: Uint32) -> Uint32
+popcnt : (value: Uint32) => Uint32
 ```
 
 Counts the number of bits set to `1` in the value, also known as a population count.

--- a/stdlib/uint64.md
+++ b/stdlib/uint64.md
@@ -25,7 +25,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromNumber : (x: Number) -> Uint64
+fromNumber : (x: Number) => Uint64
 ```
 
 Converts a Number to a Uint64.
@@ -50,7 +50,7 @@ No other changes yet.
 </details>
 
 ```grain
-toNumber : (x: Uint64) -> Number
+toNumber : (x: Uint64) => Number
 ```
 
 Converts a Uint64 to a Number.
@@ -75,7 +75,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromInt64 : (x: Int64) -> Uint64
+fromInt64 : (x: Int64) => Uint64
 ```
 
 Converts an Int64 to a Uint64.
@@ -100,7 +100,7 @@ No other changes yet.
 </details>
 
 ```grain
-incr : (value: Uint64) -> Uint64
+incr : (value: Uint64) => Uint64
 ```
 
 Increments the value by one.
@@ -125,7 +125,7 @@ No other changes yet.
 </details>
 
 ```grain
-decr : (value: Uint64) -> Uint64
+decr : (value: Uint64) => Uint64
 ```
 
 Decrements the value by one.
@@ -150,7 +150,7 @@ No other changes yet.
 </details>
 
 ```grain
-(+) : (x: Uint64, y: Uint64) -> Uint64
+(+) : (x: Uint64, y: Uint64) => Uint64
 ```
 
 Computes the sum of its operands.
@@ -176,7 +176,7 @@ No other changes yet.
 </details>
 
 ```grain
-(-) : (x: Uint64, y: Uint64) -> Uint64
+(-) : (x: Uint64, y: Uint64) => Uint64
 ```
 
 Computes the difference of its operands.
@@ -202,7 +202,7 @@ No other changes yet.
 </details>
 
 ```grain
-(*) : (x: Uint64, y: Uint64) -> Uint64
+(*) : (x: Uint64, y: Uint64) => Uint64
 ```
 
 Computes the product of its operands.
@@ -228,7 +228,7 @@ No other changes yet.
 </details>
 
 ```grain
-(/) : (x: Uint64, y: Uint64) -> Uint64
+(/) : (x: Uint64, y: Uint64) => Uint64
 ```
 
 Computes the quotient of its operands.
@@ -254,7 +254,7 @@ No other changes yet.
 </details>
 
 ```grain
-rem : (x: Uint64, y: Uint64) -> Uint64
+rem : (x: Uint64, y: Uint64) => Uint64
 ```
 
 Computes the remainder of the division of its operands.
@@ -280,7 +280,7 @@ No other changes yet.
 </details>
 
 ```grain
-rotl : (value: Uint64, amount: Uint64) -> Uint64
+rotl : (value: Uint64, amount: Uint64) => Uint64
 ```
 
 Rotates the bits of the value left by the given number of bits.
@@ -306,7 +306,7 @@ No other changes yet.
 </details>
 
 ```grain
-rotr : (value: Uint64, amount: Uint64) -> Uint64
+rotr : (value: Uint64, amount: Uint64) => Uint64
 ```
 
 Rotates the bits of the value right by the given number of bits.
@@ -332,7 +332,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<<) : (value: Uint64, amount: Uint64) -> Uint64
+(<<) : (value: Uint64, amount: Uint64) => Uint64
 ```
 
 Shifts the bits of the value left by the given number of bits.
@@ -358,7 +358,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>>>) : (value: Uint64, amount: Uint64) -> Uint64
+(>>>) : (value: Uint64, amount: Uint64) => Uint64
 ```
 
 Shifts the bits of the value right by the given number of bits.
@@ -384,7 +384,7 @@ No other changes yet.
 </details>
 
 ```grain
-(==) : (x: Uint64, y: Uint64) -> Bool
+(==) : (x: Uint64, y: Uint64) => Bool
 ```
 
 Checks if the first value is equal to the second value.
@@ -410,7 +410,7 @@ No other changes yet.
 </details>
 
 ```grain
-(!=) : (x: Uint64, y: Uint64) -> Bool
+(!=) : (x: Uint64, y: Uint64) => Bool
 ```
 
 Checks if the first value is not equal to the second value.
@@ -436,7 +436,7 @@ No other changes yet.
 </details>
 
 ```grain
-eqz : (value: Uint64) -> Bool
+eqz : (value: Uint64) => Bool
 ```
 
 Checks if the given value is equal to zero.
@@ -461,7 +461,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<) : (x: Uint64, y: Uint64) -> Bool
+(<) : (x: Uint64, y: Uint64) => Bool
 ```
 
 Checks if the first value is less than the second value.
@@ -487,7 +487,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>) : (x: Uint64, y: Uint64) -> Bool
+(>) : (x: Uint64, y: Uint64) => Bool
 ```
 
 Checks if the first value is greater than the second value.
@@ -513,7 +513,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<=) : (x: Uint64, y: Uint64) -> Bool
+(<=) : (x: Uint64, y: Uint64) => Bool
 ```
 
 Checks if the first value is less than or equal to the second value.
@@ -539,7 +539,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>=) : (x: Uint64, y: Uint64) -> Bool
+(>=) : (x: Uint64, y: Uint64) => Bool
 ```
 
 Checks if the first value is greater than or equal to the second value.
@@ -565,7 +565,7 @@ No other changes yet.
 </details>
 
 ```grain
-lnot : (value: Uint64) -> Uint64
+lnot : (value: Uint64) => Uint64
 ```
 
 Computes the bitwise NOT of the given value.
@@ -590,7 +590,7 @@ No other changes yet.
 </details>
 
 ```grain
-(&) : (x: Uint64, y: Uint64) -> Uint64
+(&) : (x: Uint64, y: Uint64) => Uint64
 ```
 
 Computes the bitwise AND (`&`) on the given operands.
@@ -616,7 +616,7 @@ No other changes yet.
 </details>
 
 ```grain
-(|) : (x: Uint64, y: Uint64) -> Uint64
+(|) : (x: Uint64, y: Uint64) => Uint64
 ```
 
 Computes the bitwise OR (`|`) on the given operands.
@@ -642,7 +642,7 @@ No other changes yet.
 </details>
 
 ```grain
-(^) : (x: Uint64, y: Uint64) -> Uint64
+(^) : (x: Uint64, y: Uint64) => Uint64
 ```
 
 Computes the bitwise XOR (`^`) on the given operands.
@@ -668,7 +668,7 @@ No other changes yet.
 </details>
 
 ```grain
-clz : (value: Uint64) -> Uint64
+clz : (value: Uint64) => Uint64
 ```
 
 Counts the number of leading zero bits in the value.
@@ -693,7 +693,7 @@ No other changes yet.
 </details>
 
 ```grain
-ctz : (value: Uint64) -> Uint64
+ctz : (value: Uint64) => Uint64
 ```
 
 Counts the number of trailing zero bits in the value.
@@ -718,7 +718,7 @@ No other changes yet.
 </details>
 
 ```grain
-popcnt : (value: Uint64) -> Uint64
+popcnt : (value: Uint64) => Uint64
 ```
 
 Counts the number of bits set to `1` in the value, also known as a population count.

--- a/stdlib/uint8.md
+++ b/stdlib/uint8.md
@@ -25,7 +25,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromNumber : (number: Number) -> Uint8
+fromNumber : (number: Number) => Uint8
 ```
 
 Converts a Number to a Uint8.
@@ -50,7 +50,7 @@ No other changes yet.
 </details>
 
 ```grain
-toNumber : (value: Uint8) -> Number
+toNumber : (value: Uint8) => Number
 ```
 
 Converts a Uint8 to a Number.
@@ -75,7 +75,7 @@ No other changes yet.
 </details>
 
 ```grain
-fromInt8 : (x: Int8) -> Uint8
+fromInt8 : (x: Int8) => Uint8
 ```
 
 Converts an Int8 to a Uint8.
@@ -100,7 +100,7 @@ No other changes yet.
 </details>
 
 ```grain
-incr : (value: Uint8) -> Uint8
+incr : (value: Uint8) => Uint8
 ```
 
 Increments the value by one.
@@ -125,7 +125,7 @@ No other changes yet.
 </details>
 
 ```grain
-decr : (value: Uint8) -> Uint8
+decr : (value: Uint8) => Uint8
 ```
 
 Decrements the value by one.
@@ -150,7 +150,7 @@ No other changes yet.
 </details>
 
 ```grain
-(+) : (x: Uint8, y: Uint8) -> Uint8
+(+) : (x: Uint8, y: Uint8) => Uint8
 ```
 
 Computes the sum of its operands.
@@ -176,7 +176,7 @@ No other changes yet.
 </details>
 
 ```grain
-(-) : (x: Uint8, y: Uint8) -> Uint8
+(-) : (x: Uint8, y: Uint8) => Uint8
 ```
 
 Computes the difference of its operands.
@@ -202,7 +202,7 @@ No other changes yet.
 </details>
 
 ```grain
-(*) : (x: Uint8, y: Uint8) -> Uint8
+(*) : (x: Uint8, y: Uint8) => Uint8
 ```
 
 Computes the product of its operands.
@@ -228,7 +228,7 @@ No other changes yet.
 </details>
 
 ```grain
-(/) : (x: Uint8, y: Uint8) -> Uint8
+(/) : (x: Uint8, y: Uint8) => Uint8
 ```
 
 Computes the quotient of its operands.
@@ -254,7 +254,7 @@ No other changes yet.
 </details>
 
 ```grain
-rem : (x: Uint8, y: Uint8) -> Uint8
+rem : (x: Uint8, y: Uint8) => Uint8
 ```
 
 Computes the remainder of the division of its operands.
@@ -280,7 +280,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<<) : (value: Uint8, amount: Uint8) -> Uint8
+(<<) : (value: Uint8, amount: Uint8) => Uint8
 ```
 
 Shifts the bits of the value left by the given number of bits.
@@ -306,7 +306,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>>>) : (value: Uint8, amount: Uint8) -> Uint8
+(>>>) : (value: Uint8, amount: Uint8) => Uint8
 ```
 
 Shifts the bits of the value right by the given number of bits.
@@ -332,7 +332,7 @@ No other changes yet.
 </details>
 
 ```grain
-(==) : (x: Uint8, y: Uint8) -> Bool
+(==) : (x: Uint8, y: Uint8) => Bool
 ```
 
 Checks if the first value is equal to the second value.
@@ -358,7 +358,7 @@ No other changes yet.
 </details>
 
 ```grain
-(!=) : (x: Uint8, y: Uint8) -> Bool
+(!=) : (x: Uint8, y: Uint8) => Bool
 ```
 
 Checks if the first value is not equal to the second value.
@@ -384,7 +384,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<) : (x: Uint8, y: Uint8) -> Bool
+(<) : (x: Uint8, y: Uint8) => Bool
 ```
 
 Checks if the first value is less than the second value.
@@ -410,7 +410,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>) : (x: Uint8, y: Uint8) -> Bool
+(>) : (x: Uint8, y: Uint8) => Bool
 ```
 
 Checks if the first value is greater than the second value.
@@ -436,7 +436,7 @@ No other changes yet.
 </details>
 
 ```grain
-(<=) : (x: Uint8, y: Uint8) -> Bool
+(<=) : (x: Uint8, y: Uint8) => Bool
 ```
 
 Checks if the first value is less than or equal to the second value.
@@ -462,7 +462,7 @@ No other changes yet.
 </details>
 
 ```grain
-(>=) : (x: Uint8, y: Uint8) -> Bool
+(>=) : (x: Uint8, y: Uint8) => Bool
 ```
 
 Checks if the first value is greater than or equal to the second value.
@@ -488,7 +488,7 @@ No other changes yet.
 </details>
 
 ```grain
-lnot : (value: Uint8) -> Uint8
+lnot : (value: Uint8) => Uint8
 ```
 
 Computes the bitwise NOT of the given value.
@@ -513,7 +513,7 @@ No other changes yet.
 </details>
 
 ```grain
-(&) : (x: Uint8, y: Uint8) -> Uint8
+(&) : (x: Uint8, y: Uint8) => Uint8
 ```
 
 Computes the bitwise AND (`&`) on the given operands.
@@ -539,7 +539,7 @@ No other changes yet.
 </details>
 
 ```grain
-(|) : (x: Uint8, y: Uint8) -> Uint8
+(|) : (x: Uint8, y: Uint8) => Uint8
 ```
 
 Computes the bitwise OR (`|`) on the given operands.
@@ -565,7 +565,7 @@ No other changes yet.
 </details>
 
 ```grain
-(^) : (x: Uint8, y: Uint8) -> Uint8
+(^) : (x: Uint8, y: Uint8) => Uint8
 ```
 
 Computes the bitwise XOR (`^`) on the given operands.


### PR DESCRIPTION
Closes #1179 (supersedes)