### PR TITLE
chore(stdlib): Clarify `Byte.move` docs

### DIFF
--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -248,7 +248,7 @@ provide let resize = (left: Number, right: Number, bytes: Bytes) => {
  *
  * @param srcIndex: The starting index to copy bytes from
  * @param dstIndex: The starting index to copy bytes into
- * @param length: The amount of bytes to copy from the source buffer
+ * @param length: The amount of bytes to copy from the source byte sequence
  * @param src: The source byte sequence
  * @param dst: The destination byte sequence
  *

--- a/stdlib/bytes.md
+++ b/stdlib/bytes.md
@@ -245,7 +245,7 @@ Parameters:
 |-----|----|-----------|
 |`srcIndex`|`Number`|The starting index to copy bytes from|
 |`dstIndex`|`Number`|The starting index to copy bytes into|
-|`length`|`Number`|The amount of bytes to copy from the source buffer|
+|`length`|`Number`|The amount of bytes to copy from the source byte sequence|
 |`src`|`Bytes`|The source byte sequence|
 |`dst`|`Bytes`|The destination byte sequence|
 


### PR DESCRIPTION
This is a small pr changing the wording used in `Bytes.move`, it makes sense to stay away from the wording `Buffer` given grain has a specific `Buffer` type which is different than the `Bytes` type.


Closes: #1836 