### PR TITLE
feat(stdlib): Add `isEmpty` to `List` module

### DIFF
--- a/compiler/test/stdlib/list.test.gr
+++ b/compiler/test/stdlib/list.test.gr
@@ -16,6 +16,11 @@ assert reverse(list) == [3, 2, 1]
 assert length([]) == 0
 assert length(list) == 3
 
+// List.isEmpty
+assert isEmpty([]) == true
+assert isEmpty(list) == false
+assert isEmpty([1]) == false
+
 // List.append
 
 assert append(list, [4]) == [1, 2, 3, 4]

--- a/stdlib/list.gr
+++ b/stdlib/list.gr
@@ -57,6 +57,21 @@ provide let length = list => {
 }
 
 /**
+ * Determines if the list contains no elements.
+ *
+ * @param list: The list to inspect
+ * @returns `true` if the list is empty and `false` otherwise
+ *
+ * @since v0.6.0
+ */
+provide let isEmpty = list => {
+  match (list) {
+    [] => true,
+    _ => false,
+  }
+}
+
+/**
  * Creates a new list with all elements in reverse order.
  *
  * @param list: The list to reverse

--- a/stdlib/list.md
+++ b/stdlib/list.md
@@ -91,6 +91,31 @@ Returns:
 |----|-----------|
 |`Number`|The number of elements in the list|
 
+### List.**isEmpty**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+isEmpty : (list: List<a>) -> Bool
+```
+
+Determines if the list contains no elements.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`list`|`List<a>`|The list to inspect|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Bool`|`true` if the list is empty and `false` otherwise|
+
 ### List.**reverse**
 
 <details disabled>

--- a/stdlib/list.md
+++ b/stdlib/list.md
@@ -99,7 +99,7 @@ No other changes yet.
 </details>
 
 ```grain
-isEmpty : (list: List<a>) -> Bool
+isEmpty : (list: List<a>) => Bool
 ```
 
 Determines if the list contains no elements.


### PR DESCRIPTION
This pr adds `List.isEmpty` bringing the api inline with the other data types. This is beneficial for `List` especially as the common way of checking if a `List` is empty is `List.length(i) == 0` which in the case of list would have to iterate the entire list to calculate the length.


closes: #1784 