### PR TITLE
feat(stdlib): add `isEmpty` to `String` module

### DIFF
--- a/compiler/test/stdlib/string.test.gr
+++ b/compiler/test/stdlib/string.test.gr
@@ -63,6 +63,12 @@ assert String.byteLength("a") == 1
 assert String.byteLength(emoji) == 4
 assert String.byteLength(emojis) == 98
 
+// String.isEmpty
+assert String.isEmpty(empty) == true
+assert String.isEmpty(short) == false
+assert String.isEmpty(emoji) == false
+assert String.isEmpty(emojis) == false
+
 // indexOf tests
 assert String.indexOf(empty, empty) == Some(0)
 assert String.indexOf(empty, short) == Some(0)

--- a/stdlib/string.gr
+++ b/stdlib/string.gr
@@ -99,6 +99,21 @@ provide let byteLength = (string: String) => {
 }
 
 /**
+ * Determines if the string contains no characters.
+ *
+ * @param string: The string to inspect
+ * @returns `true` if the string is empty and `false` otherwise
+ *
+ * @since v0.6.0
+ */
+@unsafe
+provide let isEmpty = (string: String) => {
+  from WasmI32 use { (==) }
+  let strPtr = WasmI32.fromGrain(string)
+  WasmI32.load(strPtr, 4n) == 0n
+}
+
+/**
  * Finds the first position of a substring in the input string.
  *
  * @param search: The substring to find

--- a/stdlib/string.md
+++ b/stdlib/string.md
@@ -137,6 +137,31 @@ Examples:
 String.byteLength("🌾") == 4
 ```
 
+### String.**isEmpty**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+isEmpty : (string: String) -> Bool
+```
+
+Determines if the string contains no characters.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`string`|`String`|The string to inspect|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Bool`|`true` if the string is empty and `false` otherwise|
+
 ### String.**indexOf**
 
 <details disabled>

--- a/stdlib/string.md
+++ b/stdlib/string.md
@@ -145,7 +145,7 @@ No other changes yet.
 </details>
 
 ```grain
-isEmpty : (string: String) -> Bool
+isEmpty : (string: String) => Bool
 ```
 
 Determines if the string contains no characters.


### PR DESCRIPTION
This pr adds `String.isEmpty` to the string library to bring it in line with other api's from different modules, off of oscars in discord stdlib notes.

Benefit of adding this is making the api the same as other data types and providing more clarity in code.

Note: empty means no characters are included in the module so `bytelength` is equivalent to 0. 