### PR TITLE
feat!(stdlib): Add `Queue.toList` and `Queue.fromList`

### DIFF
--- a/compiler/test/stdlib/queue.test.gr
+++ b/compiler/test/stdlib/queue.test.gr
@@ -48,6 +48,28 @@ assert Queue.pop(queue) == Some(2)
 assert Queue.pop(queue) == Some(3)
 assert Queue.pop(queue) == None
 
+// Queue.toList
+let queue = Queue.makeSized(3)
+assert Queue.toList(queue) == []
+Queue.push(0, queue)
+Queue.push(1, queue)
+Queue.push(2, queue)
+Queue.push(3, queue)
+assert Queue.toList(queue) == [0,1,2,3]
+Queue.pop(queue)
+assert Queue.toList(queue) == [1,2,3]
+Queue.push(3, queue)
+assert Queue.toList(queue) == [1,2,3,3]
+
+// Queue.fromList
+let queue = Queue.makeSized(0)
+assert Queue.fromList([]) == queue
+Queue.push(0, queue)
+Queue.push(1, queue)
+Queue.push(2, queue)
+Queue.push(3, queue)
+assert Queue.fromList([0,1,2,3]) == queue
+
 // test that the "circular" behavior of the circular queue works as expected
 let queue = Queue.makeSized(4)
 let push = x => () => Queue.push(x, queue)
@@ -116,4 +138,15 @@ module Immutable {
   assert Queue.size(Queue.empty) == 0
   assert Queue.size(sampleQueue) == 3
   assert Queue.size(Queue.pop(Queue.pop(sampleQueue))) == 1
+
+  // Queue.toList
+  let sampleQueue = Queue.push(3, Queue.push(2, Queue.push(1, Queue.empty)))
+  assert Queue.toList(Queue.empty) == []
+  assert Queue.toList(sampleQueue) == [1,2,3]
+  assert Queue.toList(Queue.pop(sampleQueue)) == [2,3]
+
+  // Queue.fromList
+  assert Queue.fromList([]) == Queue.empty
+  assert Queue.fromList([1,2,3]) == sampleQueue
+
 }

--- a/compiler/test/stdlib/queue.test.gr
+++ b/compiler/test/stdlib/queue.test.gr
@@ -47,6 +47,11 @@ assert Queue.pop(queue) == Some(1)
 assert Queue.pop(queue) == Some(2)
 assert Queue.pop(queue) == Some(3)
 assert Queue.pop(queue) == None
+let queue = Queue.makeSized(0)
+Queue.push(0, queue)
+let queue2 = Queue.makeSized(1)
+Queue.push(0, queue2)
+assert queue == queue2
 
 // Queue.toList
 let queue = Queue.makeSized(3)

--- a/stdlib/queue.gr
+++ b/stdlib/queue.gr
@@ -90,11 +90,14 @@ provide let peek = queue => {
  * @param queue: The queue being updated
  *
  * @since v0.6.0
+ * @history v0.6.0: No longer errors when pushing a new item
  */
 provide let push = (value, queue) => {
   let arrLen = Array.length(queue.array)
   // expand the array if needed
-  if (queue.size == arrLen) {
+  if (arrLen == 0) {
+    queue.array = Array.make(1, None)
+  } else if (queue.size == arrLen) {
     let newArray = Array.make(arrLen * 2, None)
 
     newArray[0] = queue.array[queue.headIndex]
@@ -133,6 +136,37 @@ provide let pop = queue => {
     queue.size -= 1
     elem
   }
+}
+
+/**
+ * Converts a queue into a list of its elements.
+ *
+ * @param queue: The queue to convert
+ * @returns A list containing all queue values
+ *
+ * @since v0.6.0
+ */
+provide let toList = queue => {
+  let lst = List.init(size(queue), i => match (queue.array[queue.headIndex +
+    i]) {
+    Some(n) => n,
+    None => fail "Impossible",
+  })
+  lst
+}
+
+/**
+ * Creates a queue from a list.
+ *
+ * @param list: The list to convert
+ * @returns A queue containing all list values
+ *
+ * @since v0.6.0
+ */
+provide let fromList = list => {
+  let queue = makeSized(List.length(list))
+  List.forEach(e => push(e, queue), list)
+  queue
 }
 
 /**
@@ -292,5 +326,44 @@ provide module Immutable {
       { forwards: [], backwards } => List.length(backwards),
       { forwards, backwards } => List.length(forwards) + List.length(backwards),
     }
+  }
+
+  /**
+   * Converts a queue into a list of its elements.
+   *
+   * @param queue: The queue to convert
+   * @returns A list containing all queue values
+   *
+   * @since v0.6.0
+   */
+
+  provide let toList = queue => {
+    let mut queue = queue
+    let mut lst = []
+    while (!isEmpty(queue)) {
+      match (peek(queue)) {
+        Some(value) => {
+          queue = pop(queue)
+          lst = [value, ...lst]
+        },
+        None => break,
+      }
+    }
+    List.reverse(lst)
+  }
+
+  /**
+   * Creates a queue from a list.
+   *
+   * @param list: The list to convert
+   * @returns A queue containing all list values
+   *
+   * @since v0.6.0
+   */
+
+  provide let fromList = list => {
+    let mut queue = empty
+    List.forEach(e => queue = push(e, queue), list)
+    queue
   }
 }

--- a/stdlib/queue.md
+++ b/stdlib/queue.md
@@ -157,9 +157,16 @@ Returns:
 
 ### Queue.**push**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>next</code></td><td>No longer errors when pushing a new item</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
@@ -199,6 +206,56 @@ Returns:
 |type|description|
 |----|-----------|
 |`Option<a>`|The element removed from the queue|
+
+### Queue.**toList**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+toList : (queue: Queue<a>) -> List<a>
+```
+
+Converts a queue into a list of its elements.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`queue`|`Queue<a>`|The queue to convert|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`List<a>`|A list containing all queue values|
+
+### Queue.**fromList**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+fromList : (list: List<a>) -> Queue<a>
+```
+
+Creates a queue from a list.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`list`|`List<a>`|The list to convert|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Queue<a>`|A queue containing all list values|
 
 ### Queue.**clear**
 
@@ -453,4 +510,54 @@ Returns:
 |type|description|
 |----|-----------|
 |`Number`|The number of values in the queue|
+
+#### Queue.Immutable.**toList**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+toList : (queue: ImmutableQueue<a>) -> List<a>
+```
+
+Converts a queue into a list of its elements.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`queue`|`ImmutableQueue<a>`|The queue to convert|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`List<a>`|A list containing all queue values|
+
+#### Queue.Immutable.**fromList**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+fromList : (list: List<a>) -> ImmutableQueue<a>
+```
+
+Creates a queue from a list.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`list`|`List<a>`|The list to convert|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`ImmutableQueue<a>`|A queue containing all list values|
 


### PR DESCRIPTION
This adds `Queue.fromList`, `Queue.toList`, `Queue.Immutable.toList` and `Queue.Immutable.fromList` to the stdlib.

Marked breaking as while working on this I found a bug where if you did `Queue.makeSized(0)` it wouldnt resize properly on push and would throw an exception instead. I can move that fix to a seperate pr if needed but kept it because I need the proper behaviour for the tests.