### PR TITLE
fix(stdlib): Properly resize empty Queue on push

### DIFF
--- a/compiler/test/stdlib/queue.test.gr
+++ b/compiler/test/stdlib/queue.test.gr
@@ -47,6 +47,11 @@ assert Queue.pop(queue) == Some(1)
 assert Queue.pop(queue) == Some(2)
 assert Queue.pop(queue) == Some(3)
 assert Queue.pop(queue) == None
+let queue = Queue.makeSized(0)
+Queue.push(0, queue)
+let queue2 = Queue.makeSized(1)
+Queue.push(0, queue2)
+assert queue == queue2
 
 // test that the "circular" behavior of the circular queue works as expected
 let queue = Queue.makeSized(4)

--- a/stdlib/queue.gr
+++ b/stdlib/queue.gr
@@ -90,7 +90,6 @@ provide let peek = queue => {
  * @param queue: The queue being updated
  *
  * @since v0.6.0
- * @history v0.6.0: No longer errors when pushing a new item
  */
 provide let push = (value, queue) => {
   let arrLen = Array.length(queue.array)

--- a/stdlib/queue.gr
+++ b/stdlib/queue.gr
@@ -90,11 +90,14 @@ provide let peek = queue => {
  * @param queue: The queue being updated
  *
  * @since v0.6.0
+ * @history v0.6.0: No longer errors when pushing a new item
  */
 provide let push = (value, queue) => {
   let arrLen = Array.length(queue.array)
   // expand the array if needed
-  if (queue.size == arrLen) {
+  if (arrLen == 0) {
+    queue.array = Array.make(1, None)
+  } else if (queue.size == arrLen) {
     let newArray = Array.make(arrLen * 2, None)
 
     newArray[0] = queue.array[queue.headIndex]

--- a/stdlib/queue.md
+++ b/stdlib/queue.md
@@ -157,16 +157,9 @@ Returns:
 
 ### Queue.**push**
 
-<details>
-<summary>Added in <code>next</code></summary>
-<table>
-<thead>
-<tr><th>version</th><th>changes</th></tr>
-</thead>
-<tbody>
-<tr><td><code>next</code></td><td>No longer errors when pushing a new item</td></tr>
-</tbody>
-</table>
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
 </details>
 
 ```grain

--- a/stdlib/queue.md
+++ b/stdlib/queue.md
@@ -157,9 +157,16 @@ Returns:
 
 ### Queue.**push**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>next</code></td><td>No longer errors when pushing a new item</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain


### PR DESCRIPTION
This fixes a tiny bug where if you did:
```
let q = Queue.makeSized(0)
Queue.push(1, q)
```
you would get an index out of range error.

Breaking because you will no longer recieve an exception.