### PR TITLE
fix(stdlib): Properly resize empty Stack on push

### DIFF
--- a/compiler/test/stdlib/stack.test.gr
+++ b/compiler/test/stdlib/stack.test.gr
@@ -50,6 +50,12 @@ assert Stack.pop(stack) == Some(2)
 assert Stack.pop(stack) == Some(1)
 assert Stack.pop(stack) == None
 
+let stack = Stack.makeSized(0)
+Stack.push(0, stack)
+let stack2 = Stack.makeSized(1)
+Stack.push(0, stack2)
+assert stack == stack2
+
 module Immutable {
   from Stack use { Immutable as Stack }
 

--- a/stdlib/stack.gr
+++ b/stdlib/stack.gr
@@ -86,7 +86,6 @@ provide let peek = stack => {
  * @param stack: The stack being updated
  *
  * @since v0.6.0
- * @history v0.6.0: No longer errors when stack size is `0`
  */
 provide let push = (value, stack) => {
   let arrLen = Array.length(stack.array)
@@ -212,6 +211,7 @@ provide module Immutable {
    * @returns A new stack with the item added to the end
    *
    * @since v0.6.0
+   * @history v0.3.0: Originally a module root API
    */
 
   provide let push = (value, stack) => {

--- a/stdlib/stack.gr
+++ b/stdlib/stack.gr
@@ -212,7 +212,6 @@ provide module Immutable {
    * @returns A new stack with the item added to the end
    *
    * @since v0.6.0
-   * @history v0.3.0: Originally a module root API
    */
 
   provide let push = (value, stack) => {

--- a/stdlib/stack.gr
+++ b/stdlib/stack.gr
@@ -86,10 +86,13 @@ provide let peek = stack => {
  * @param stack: The stack being updated
  *
  * @since v0.6.0
+ * @history v0.6.0: No longer errors when stack size is `0`
  */
 provide let push = (value, stack) => {
   let arrLen = Array.length(stack.array)
-  if (stack.size == arrLen) {
+  if (arrLen == 0) {
+    stack.array = Array.make(1, None)
+  } else if (stack.size == arrLen) {
     let newArray = Array.make(stack.size * 2, None)
     for (let mut i = 0; i < arrLen; i += 1) {
       newArray[i] = stack.array[i]

--- a/stdlib/stack.md
+++ b/stdlib/stack.md
@@ -358,16 +358,9 @@ Returns:
 
 #### Stack.Immutable.**push**
 
-<details>
-<summary>Added in <code>next</code></summary>
-<table>
-<thead>
-<tr><th>version</th><th>changes</th></tr>
-</thead>
-<tbody>
-<tr><td><code>0.3.0</code></td><td>Originally a module root API</td></tr>
-</tbody>
-</table>
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
 </details>
 
 ```grain

--- a/stdlib/stack.md
+++ b/stdlib/stack.md
@@ -157,16 +157,9 @@ Returns:
 
 ### Stack.**push**
 
-<details>
-<summary>Added in <code>next</code></summary>
-<table>
-<thead>
-<tr><th>version</th><th>changes</th></tr>
-</thead>
-<tbody>
-<tr><td><code>next</code></td><td>No longer errors when stack size is `0`</td></tr>
-</tbody>
-</table>
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
 </details>
 
 ```grain
@@ -358,9 +351,16 @@ Returns:
 
 #### Stack.Immutable.**push**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.3.0</code></td><td>Originally a module root API</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain

--- a/stdlib/stack.md
+++ b/stdlib/stack.md
@@ -157,9 +157,16 @@ Returns:
 
 ### Stack.**push**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>next</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>next</code></td><td>No longer errors when stack size is `0`</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain


### PR DESCRIPTION
Applies the fix made on queue in #1865 to the `Stack` Module