### PR TITLE
feat(compiler): Allow exporting the function table

### DIFF
--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -147,6 +147,10 @@ class GrainCommand extends commander.Command {
       "replaces the _start export with a start section during linking"
     );
     cmd.forwardOption(
+      "--export-function-table",
+      "causes the function table to be exported under the given name"
+    );
+    cmd.forwardOption(
       "--no-pervasives",
       "don't automatically import the Grain Pervasives module"
     );

--- a/compiler/src/linking/link.re
+++ b/compiler/src/linking/link.re
@@ -698,6 +698,17 @@ let link_all = (linked_mod, dependencies, signature) => {
     Type.funcref,
   );
 
+  switch (Grain_utils.Config.export_function_table^) {
+  | Some(name) =>
+    ignore @@
+    Export.add_table_export(
+      linked_mod,
+      Comp_utils.grain_global_function_table,
+      name,
+    )
+  | None => ()
+  };
+
   let (initial_memory, maximum_memory) =
     switch (Config.initial_memory_pages^, Config.maximum_memory_pages^) {
     | (initial_memory, Some(maximum_memory)) => (

--- a/compiler/src/utils/config.re
+++ b/compiler/src/utils/config.re
@@ -545,6 +545,14 @@ let use_start_section =
     false,
   );
 
+let export_function_table =
+  opt(
+    ~names=["export-function-table"],
+    ~conv=option_conv(Cmdliner.Arg.string),
+    ~doc="Causes the function table to be exported under the given name.",
+    None,
+  );
+
 let elide_type_info =
   toggle_flag(
     ~names=["elide-type-info"],

--- a/compiler/src/utils/config.rei
+++ b/compiler/src/utils/config.rei
@@ -40,6 +40,9 @@ let wasi_polyfill: ref(option(string));
 
 let use_start_section: ref(bool);
 
+/** Weather to export the function table under a specifed name */
+let export_function_table: ref(option(string));
+
 /** Compilation profile, e.g. release for production builds */
 
 let profile: ref(option(profile));

--- a/compiler/test/suites/linking.re
+++ b/compiler/test/suites/linking.re
@@ -122,43 +122,6 @@ describe("linking", ({test, testSkip}) => {
     );
   });
 
-  test("use_start_section", ({expect}) => {
-    let name = "use_start_section";
-    let outfile = wasmfile(name);
-    ignore @@
-    compile(
-      ~config_fn=() => {Grain_utils.Config.use_start_section := true},
-      name,
-      {|module Test; print("Hello, world!")|},
-    );
-    let ic = open_in_bin(outfile);
-    let sections = Grain_utils.Wasm_utils.get_wasm_sections(ic);
-    close_in(ic);
-    let start_section =
-      List.find_opt(
-        (sec: Grain_utils.Wasm_utils.wasm_bin_section) =>
-          switch (sec) {
-          | {sec_type: Start} => true
-          | _ => false
-          },
-        sections,
-      );
-    let export_sections =
-      List.find_map(
-        (sec: Grain_utils.Wasm_utils.wasm_bin_section) =>
-          switch (sec) {
-          | {sec_type: Export(exports)} => Some(exports)
-          | _ => None
-          },
-        sections,
-      );
-    expect.option(start_section).toBeSome();
-    expect.option(export_sections).toBeSome();
-    expect.list(Option.get(export_sections)).not.toContainEqual(
-      ~equals=tuple_equal,
-      (WasmFunction, "_start"),
-    );
-  });
   test("export_function_table", ({expect}) => {
     let name = "export_function_table";
     let outfile = wasmfile(name);


### PR DESCRIPTION
While trying to play arround with https://github.com/contextfreeinfo/taca/tree/main I noticed that it uses the function table for callbacks which grain didnt support. This pr adds the ability to run the compiler with the `--export-function-table` flag which takes a `name` as a string. which causes the function table to be exported under the given name during linking. This is primarily useful for writing foreign bindings.