### PR TITLE
fix(cli)!: Ensure `--use-start-section` can only be used with compile command

### DIFF
--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -143,10 +143,6 @@ class GrainCommand extends commander.Command {
       "path to custom WASI implementation"
     );
     cmd.forwardOption(
-      "--use-start-section",
-      "replaces the _start export with a start section during linking"
-    );
-    cmd.forwardOption(
       "--no-pervasives",
       "don't automatically import the Grain Pervasives module"
     );
@@ -189,6 +185,10 @@ program
   .command("compile <file>")
   .description("compile a grain program into wasm")
   .forwardOption("-o <filename>", "output filename")
+  .forwardOption(
+    "--use-start-section",
+    "replaces the _start export with a start section during linking"
+  )
   .forwardOption("--no-link", "disable static linking")
   .action(exec.grainc);
 


### PR DESCRIPTION
This pr changes the cli to make it so `grain main.gr --use-start-section` no longer works and you have to use `grain compile main.gr --use-start-section` when using the `--use-start-section` flag.

This was done because in the move to the new wasi runner. the way the runner loads the wasm module changed meaning that if you tried to use the grain runner with `--use-start-section` you would get an error as wasi is not intialized when node calls the start function.

This is marked breaking because the flag can no longer be used with the runner.

This should be able to be reverted when grain switches to using wamr as a wasm runner.

closes: #1847 