### PR TITLE
fix(lsp): Improve lsp behaviour on goto definition

### DIFF
--- a/compiler/src/language_server/definition.re
+++ b/compiler/src/language_server/definition.re
@@ -84,7 +84,7 @@ let rec find_definition =
   | None =>
     if (check_position == Forward && position.character > 0) {
       // If a user selects from left to right, their pointer ends up after the identifier
-      // this trys to check if the identifier was selected.
+      // this tries to check if the identifier was selected.
       find_definition(
         ~check_position=Backward,
         sourcetree,

--- a/compiler/src/language_server/definition.re
+++ b/compiler/src/language_server/definition.re
@@ -53,9 +53,12 @@ let send_definition =
     }),
   );
 };
+type check_position =
+  | Forward
+  | Backward;
 let rec find_definition =
         (
-          ~try_last_char=false,
+          ~check_position=Forward,
           sourcetree: Sourcetree.sourcetree,
           position: Protocol.position,
         ) => {
@@ -79,11 +82,11 @@ let rec find_definition =
     };
   switch (result) {
   | None =>
-    if (!try_last_char && position.character > 0) {
+    if (check_position == Forward && position.character > 0) {
       // If a user selects from left to right, their pointer ends up after the identifier
       // this trys to check if the identifier was selected.
       find_definition(
-        ~try_last_char=true,
+        ~check_position=Backward,
         sourcetree,
         {line: position.line, character: position.character - 1},
       );

--- a/compiler/src/language_server/definition.re
+++ b/compiler/src/language_server/definition.re
@@ -53,10 +53,9 @@ let send_definition =
     }),
   );
 };
-
 let rec find_definition =
         (
-          ~depth=0,
+          ~try_last_char=false,
           sourcetree: Sourcetree.sourcetree,
           position: Protocol.position,
         ) => {
@@ -80,9 +79,11 @@ let rec find_definition =
     };
   switch (result) {
   | None =>
-    if (depth == 0 && position.character > 0) {
+    if (!try_last_char && position.character > 0) {
+      // If a user selects from left to right, their pointer ends up after the identifier
+      // this trys to check if the identifier was selected.
       find_definition(
-        ~depth=1,
+        ~try_last_char=true,
         sourcetree,
         {line: position.line, character: position.character - 1},
       );


### PR DESCRIPTION
The previous behaviour of the lsp with goto definition failed when you selected a variable from `left to right`, we now try and account for this by trying to find again, but one char over if we fail the first check.