### PR TITLE
chore(compiler): Upgrade to binaryen 112

### DIFF
--- a/compiler/esy.json
+++ b/compiler/esy.json
@@ -31,7 +31,7 @@
     "check-format": "dune build @fmt"
   },
   "dependencies": {
-    "@grain/binaryen.ml": ">= 0.21.0 < 0.22.0",
+    "@grain/binaryen.ml": ">= 0.22.0 < 0.23.0",
     "@opam/cmdliner": ">= 1.1.1",
     "@opam/dune": ">= 3.6.1 < 4.0.0",
     "@opam/dune-build-info": ">= 3.6.1 < 4.0.0",
@@ -58,6 +58,7 @@
     "@opam/rely": "^4.0.0"
   },
   "resolutions": {
+    "@grain/binaryen.ml": "grain-lang/binaryen.ml:package.json#46c97c2e92d95ffbe880c084ce3c13c503240e58",
     "@opam/fp": "reasonml/reason-native:fp.opam#fcb74949f8dcbe68f10d4daaee6b9b864b5baff0",
     "@opam/fs": "reasonml/reason-native:fs.opam#fcb74949f8dcbe68f10d4daaee6b9b864b5baff0",
     "@opam/ppx_deriving_cmdliner": "hammerlab/ppx_deriving_cmdliner:ppx_deriving_cmdliner.opam#1f086651fe7f8dd98e371b09c6fcc4dbc6db1c7c",

--- a/compiler/esy.json
+++ b/compiler/esy.json
@@ -44,7 +44,7 @@
     "@opam/ppx_deriving_cmdliner": ">= 0.6.1",
     "@opam/ppx_deriving_yojson": ">= 3.7.0 < 4.0.0",
     "@opam/ppx_sexp_conv": "v0.15.1",
-    "@opam/reason": ">= 3.8.2 < 4.0.0",
+    "@opam/reason": ">= 3.8.2 < 3.10.0",
     "@opam/sedlex": ">= 3.0 < 4.0",
     "@opam/sexplib": "v0.15.1",
     "@opam/uri": ">= 4.2.0 < 5.0.0",

--- a/compiler/esy.json
+++ b/compiler/esy.json
@@ -58,7 +58,6 @@
     "@opam/rely": "^4.0.0"
   },
   "resolutions": {
-    "@grain/binaryen.ml": "grain-lang/binaryen.ml:package.json#46c97c2e92d95ffbe880c084ce3c13c503240e58",
     "@opam/fp": "reasonml/reason-native:fp.opam#fcb74949f8dcbe68f10d4daaee6b9b864b5baff0",
     "@opam/fs": "reasonml/reason-native:fs.opam#fcb74949f8dcbe68f10d4daaee6b9b864b5baff0",
     "@opam/ppx_deriving_cmdliner": "hammerlab/ppx_deriving_cmdliner:ppx_deriving_cmdliner.opam#1f086651fe7f8dd98e371b09c6fcc4dbc6db1c7c",

--- a/compiler/esy.lock/index.json
+++ b/compiler/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "91b3af7020e2702051f10e4cd390389e",
+  "checksum": "d6ed51d9cbe737b5a060cac911114876",
   "root": "@grain/compiler@link-dev:./esy.json",
   "node": {
     "ocaml@4.14.1000@d41d8cd9": {
@@ -1887,7 +1887,7 @@
         "@opam/dune-build-info@opam:3.10.0@457c29c8",
         "@opam/dune@opam:3.10.0@d5991a42",
         "@opam/cmdliner@opam:1.2.0@b0c6143c",
-        "@grain/binaryen.ml@github:grain-lang/binaryen.ml:package.json#46c97c2e92d95ffbe880c084ce3c13c503240e58@d41d8cd9"
+        "@grain/binaryen.ml@0.22.0@d41d8cd9"
       ],
       "devDependencies": [
         "@opam/rely@github:reasonml/reason-native:rely.opam#fcb74949f8dcbe68f10d4daaee6b9b864b5baff0@d41d8cd9",
@@ -1896,16 +1896,14 @@
       ],
       "installConfig": { "pnp": false }
     },
-    "@grain/binaryen.ml@github:grain-lang/binaryen.ml:package.json#46c97c2e92d95ffbe880c084ce3c13c503240e58@d41d8cd9": {
-      "id":
-        "@grain/binaryen.ml@github:grain-lang/binaryen.ml:package.json#46c97c2e92d95ffbe880c084ce3c13c503240e58@d41d8cd9",
+    "@grain/binaryen.ml@0.22.0@d41d8cd9": {
+      "id": "@grain/binaryen.ml@0.22.0@d41d8cd9",
       "name": "@grain/binaryen.ml",
-      "version":
-        "github:grain-lang/binaryen.ml:package.json#46c97c2e92d95ffbe880c084ce3c13c503240e58",
+      "version": "0.22.0",
       "source": {
         "type": "install",
         "source": [
-          "github:grain-lang/binaryen.ml:package.json#46c97c2e92d95ffbe880c084ce3c13c503240e58"
+          "archive:https://registry.npmjs.org/@grain/binaryen.ml/-/binaryen.ml-0.22.0.tgz#sha1:1fc13085e1230f441265d2ba1148801a99677a7f"
         ]
       },
       "overrides": [],

--- a/compiler/esy.lock/index.json
+++ b/compiler/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "854b4beffa6f40acb189bb7e1d5c8b36",
+  "checksum": "91b3af7020e2702051f10e4cd390389e",
   "root": "@grain/compiler@link-dev:./esy.json",
   "node": {
     "ocaml@4.14.1000@d41d8cd9": {
@@ -1843,14 +1843,14 @@
         "@opam/bigstringaf@opam:0.9.1@e6f2e882"
       ]
     },
-    "@grain/libbinaryen@111.1.0@d41d8cd9": {
-      "id": "@grain/libbinaryen@111.1.0@d41d8cd9",
+    "@grain/libbinaryen@112.0.0@d41d8cd9": {
+      "id": "@grain/libbinaryen@112.0.0@d41d8cd9",
       "name": "@grain/libbinaryen",
-      "version": "111.1.0",
+      "version": "112.0.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@grain/libbinaryen/-/libbinaryen-111.1.0.tgz#sha1:30494cf7ffd2974afef179d269038b9a973130ca"
+          "archive:https://registry.npmjs.org/@grain/libbinaryen/-/libbinaryen-112.0.0.tgz#sha1:61093fba10c65c2dfa4c51ba4a1b4df65f226fd3"
         ]
       },
       "overrides": [],
@@ -1887,7 +1887,7 @@
         "@opam/dune-build-info@opam:3.10.0@457c29c8",
         "@opam/dune@opam:3.10.0@d5991a42",
         "@opam/cmdliner@opam:1.2.0@b0c6143c",
-        "@grain/binaryen.ml@0.21.0@d41d8cd9"
+        "@grain/binaryen.ml@github:grain-lang/binaryen.ml:package.json#46c97c2e92d95ffbe880c084ce3c13c503240e58@d41d8cd9"
       ],
       "devDependencies": [
         "@opam/rely@github:reasonml/reason-native:rely.opam#fcb74949f8dcbe68f10d4daaee6b9b864b5baff0@d41d8cd9",
@@ -1896,14 +1896,16 @@
       ],
       "installConfig": { "pnp": false }
     },
-    "@grain/binaryen.ml@0.21.0@d41d8cd9": {
-      "id": "@grain/binaryen.ml@0.21.0@d41d8cd9",
+    "@grain/binaryen.ml@github:grain-lang/binaryen.ml:package.json#46c97c2e92d95ffbe880c084ce3c13c503240e58@d41d8cd9": {
+      "id":
+        "@grain/binaryen.ml@github:grain-lang/binaryen.ml:package.json#46c97c2e92d95ffbe880c084ce3c13c503240e58@d41d8cd9",
       "name": "@grain/binaryen.ml",
-      "version": "0.21.0",
+      "version":
+        "github:grain-lang/binaryen.ml:package.json#46c97c2e92d95ffbe880c084ce3c13c503240e58",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@grain/binaryen.ml/-/binaryen.ml-0.21.0.tgz#sha1:f3c842cf71b8337faa998b49e937f68a87a0eed3"
+          "github:grain-lang/binaryen.ml:package.json#46c97c2e92d95ffbe880c084ce3c13c503240e58"
         ]
       },
       "overrides": [],
@@ -1911,7 +1913,7 @@
         "ocaml@4.14.1000@d41d8cd9",
         "@opam/dune-configurator@opam:3.10.0@f2df97f2",
         "@opam/dune@opam:3.10.0@d5991a42",
-        "@grain/libbinaryen@111.1.0@d41d8cd9"
+        "@grain/libbinaryen@112.0.0@d41d8cd9"
       ],
       "devDependencies": [],
       "installConfig": { "pnp": false }


### PR DESCRIPTION
This updates to binaryen.ml 0.22 which are our bindings for the binaryen 112 release