### PR TITLE
chore(cli): Ensure our WASI runner works on node 20+

### DIFF
--- a/cli/bin/grainrun.js
+++ b/cli/bin/grainrun.js
@@ -23,6 +23,8 @@ const wasi = new WASI({
   args: argv.slice(2),
   env: envVars,
   preopens,
+  version: "preview1",
+  returnOnExit: false,
 });
 
 const importObject = { wasi_snapshot_preview1: wasi.wasiImport };


### PR DESCRIPTION
I was trying to run our tests with node 20 globally and they were failing.

We don't want to upgrade our version in CI yet (though soon!) but we also want them to run if people don't have the exact setup.