### PR TITLE
feat: Generate tree-sitter grammar from parser

### DIFF
--- a/compiler/esy.json
+++ b/compiler/esy.json
@@ -3,7 +3,7 @@
   "version": "0.5.13",
   "esy": {
     "build": [
-      "dune build @native --no-buffer"
+      "dune build @native @install --no-buffer"
     ],
     "buildEnv": {
       "DUNE_BUILD_DIR": "#{self.target_dir}",

--- a/compiler/src/dune
+++ b/compiler/src/dune
@@ -1,11 +1,31 @@
 (library
  (name grain)
  (public_name grain)
+ (modules compile)
  (libraries cmdliner compiler-libs.common grain_codegen grain_linking
    grain_middle_end grain_parsing grain_typed grain_utils grain_diagnostics
    ppx_sexp_conv.runtime-lib sexplib)
  (preprocess
   (pps ppx_sexp_conv)))
+
+(rule
+ (action
+  (with-stdout-to
+   tree-sitter.json
+   (run %{dep:tree_sitter.exe}))))
+
+(install
+ (section share)
+ (files tree-sitter.json)
+ (package grain))
+
+(executable
+ (name tree_sitter)
+ (modules tree_sitter)
+ (libraries menhirSdk grain_parsing ppx_deriving_yojson.runtime yojson
+   grain_utils)
+ (preprocess
+  (pps ppx_sexp_conv ppx_deriving_yojson sedlex.ppx)))
 
 (install
  (section lib)

--- a/compiler/src/parsing/dune
+++ b/compiler/src/parsing/dune
@@ -1,6 +1,6 @@
 (menhir
  (modules parser)
- (flags --explain --unused-tokens --strict))
+ (flags --explain --unused-tokens --strict --cmly))
 
 ;; The following two rules create a copy of the file parser.mly named
 ;; unitActionsParser.mly. This is a copy of the grammar where the semantic
@@ -20,7 +20,7 @@
 (menhir
  (modules unitActionsParser)
  (flags --table --external-tokens Parser --unused-tokens
-   --unused-precedence-levels))
+   --unused-precedence-levels --cmly))
 
 ;; This rule compiles the parser.messages file into OCaml code.
 

--- a/compiler/src/parsing/parser.mly
+++ b/compiler/src/parsing/parser.mly
@@ -16,7 +16,7 @@ module Grain_parsing = struct end
 %token <string> NUMBER_INT NUMBER_FLOAT
 %token <string> INT8 INT16 INT32 INT64 UINT8 UINT16 UINT32 UINT64 FLOAT32 FLOAT64 BIGINT
 %token <string> WASMI32 WASMI64 WASMF32 WASMF64
-%token <string> LIDENT UIDENT
+%token <string> LIDENT [@pattern "[a-z][a-zA-Z_]\\w*"] UIDENT [@pattern "[A-Z][a-zA-Z_]\\w*"]
 %token <string> STRING BYTES CHAR
 %token LBRACK LBRACKRCARET RBRACK LPAREN RPAREN LBRACE RBRACE LCARET RCARET
 %token COMMA SEMI AS

--- a/compiler/src/tree_sitter.re
+++ b/compiler/src/tree_sitter.re
@@ -1,0 +1,111 @@
+module Grammar =
+  MenhirSdk.Cmly_read.Read({
+    let filename = "parsing/parser.cmly";
+  });
+
+type tree_sitter_node =
+  | String({value: string});
+
+let yojson_of_tree_sitter_node = (node: tree_sitter_node) => {
+  switch (node) {
+  | String({value}) =>
+    `Assoc([("type", `String("STRING")), ("value", `String(value))])
+  };
+};
+
+module StringMap =
+  Map.Make({
+    type t = string;
+    let compare = compare;
+  });
+
+let yojson_of_stringmap = (m: StringMap.t(tree_sitter_node)) => {
+  // `Assoc
+  let a =
+    StringMap.bindings(m)
+    |> List.map(((key, node)) => (key, yojson_of_tree_sitter_node(node)));
+  `Assoc(a);
+  // Yojson.Safe.write_assoc
+};
+
+[@deriving to_yojson]
+type grammar_json = {
+  name: string,
+  [@to_yojson yojson_of_stringmap]
+  rules: StringMap.t(tree_sitter_node),
+  // #[serde(default)]
+  // precedences: Vec<Vec<RuleJSON>>,
+  // #[serde(default)]
+  // conflicts: Vec<Vec<String>>,
+  // #[serde(default)]
+  // externals: Vec<RuleJSON>,
+  // #[serde(default)]
+  // extras: Vec<RuleJSON>,
+  // #[serde(default)]
+  // inline: Vec<String>,
+  // #[serde(default)]
+  // supertypes: Vec<String>,
+  // word: Option<String>,
+};
+
+let _ = {
+  // List.iter(
+  //   ((a, b, c)) => {
+  //     // hold
+  //     print_endline(Grammar.Nonterminal.name(a));
+  //     print_endline(Grammar.Nonterminal.name(Grammar.Production.lhs(b)));
+  //     Array.iter(
+  //       ((sym, id, attrs)) => {print_endline(id)},
+  //       Grammar.Production.rhs(b),
+  //     );
+  //   },
+  //   Grammar.Grammar.entry_points,
+  // );
+  // Grammar.Nonterminal.iter(nt => {
+  //   print_endline(Grammar.Nonterminal.name(nt))
+  // });
+
+  let grammar: grammar_json =
+    Grammar.Terminal.fold(
+      (t, acc) => {
+        switch (Grammar.Terminal.kind(t)) {
+        | `REGULAR =>
+          let rule = Grammar.Terminal.name(t);
+          let repr =
+            List.find_map(
+              attr => {
+                switch (Grammar.Attribute.label(attr)) {
+                | "pattern" =>
+                  let pattern = Grammar.Attribute.payload(attr);
+                  let pattern =
+                    Grain_utils.String_utils.slice(
+                      ~first=1,
+                      ~last=-1,
+                      pattern,
+                    );
+                  let pattern = Scanf.unescaped(pattern);
+                  Some(pattern);
+                | _ => None
+                }
+              },
+              Grammar.Terminal.attributes(t),
+            );
+          switch (repr) {
+          | Some(value) => {
+              ...acc,
+              rules: StringMap.add(rule, String({value: value}), acc.rules),
+            }
+          // TODO: Throw in the future
+          | None => acc
+          };
+        | `ERROR => acc
+        | `PSEUDO => acc
+        | `EOF => acc
+        }
+      },
+      {name: "grain", rules: StringMap.empty},
+    );
+  print_endline(
+    Yojson.Safe.pretty_to_string(grammar_json_to_yojson(grammar)),
+  );
+};


### PR DESCRIPTION
This is my initial experimentation to figure out if we can use `MenhirSdk` and the `cmly` file it can generate to automatically output a tree-sitter grammar.

It's a little annoying because you need to specify the RegExp pattern for each token in the parser, as that logic is actually done by sedlex_ppx in the lexer, but tree-sitter generates a combined lexer/parser given a JavaScript RegExp 😦.

If we can actually get this working, we could possibly throw away all our formatter code and just rely on [Topiary](https://github.com/tweag/topiary).