### PR TITLE
chore(compiler): Avoid round trip between string & bytes when reading cmi

### DIFF
--- a/compiler/src/typed/cmi_format.re
+++ b/compiler/src/typed/cmi_format.re
@@ -102,12 +102,21 @@ let input_cmi = ic =>
   | Result.Error(e) => raise(Invalid_argument(e))
   };
 
-let deserialize_cmi = bytes =>
+let deserialize_cmi = ic => size => {
+  let size = ref(size);
+  let lexbuf = Lexing.from_function (buf => n => {
+    let n = min (n, size^);
+    let read = input(ic, buf, 0, n);
+    size := size^ - read;
+    read
+   });
+  let state = Yojson.init_lexer ();
   switch (
-    cmi_infos_of_yojson @@ Yojson.Safe.from_string(Bytes.to_string(bytes))
+    cmi_infos_of_yojson @@ Yojson.Safe.from_lexbuf(state, lexbuf)
   ) {
   | Result.Ok(x) => x
   | Result.Error(e) => raise(Invalid_argument(e))
+  }
   };
 
 let serialize_cmi =

--- a/compiler/src/typed/cmi_format.re
+++ b/compiler/src/typed/cmi_format.re
@@ -102,22 +102,21 @@ let input_cmi = ic =>
   | Result.Error(e) => raise(Invalid_argument(e))
   };
 
-let deserialize_cmi = ic => size => {
+let deserialize_cmi = (ic, size) => {
   let size = ref(size);
-  let lexbuf = Lexing.from_function (buf => n => {
-    let n = min (n, size^);
-    let read = input(ic, buf, 0, n);
-    size := size^ - read;
-    read
-   });
-  let state = Yojson.init_lexer ();
-  switch (
-    cmi_infos_of_yojson @@ Yojson.Safe.from_lexbuf(state, lexbuf)
-  ) {
+  let lexbuf =
+    Lexing.from_function((buf, n) => {
+      let n = min(n, size^);
+      let read = input(ic, buf, 0, n);
+      size := size^ - read;
+      read;
+    });
+  let state = Yojson.init_lexer();
+  switch (cmi_infos_of_yojson @@ Yojson.Safe.from_lexbuf(state, lexbuf)) {
   | Result.Ok(x) => x
   | Result.Error(e) => raise(Invalid_argument(e))
-  }
   };
+};
 
 let serialize_cmi =
     (

--- a/compiler/src/utils/wasm_utils.re
+++ b/compiler/src/utils/wasm_utils.re
@@ -413,7 +413,7 @@ module type BinarySectionSpec = {
   type t;
 
   let name: string;
-  let deserialize: bytes => t;
+  let deserialize: in_channel => int => t;
   let accepts_version: abi_version => bool;
   let serialize: t => bytes;
 };
@@ -454,9 +454,7 @@ module BinarySection =
             when name == Spec.name && Spec.accepts_version(abi_version) =>
           /* Now we're at the start of the section. Time to read */
           let realsize = size - (pos_in(inchan) - offset);
-          let bytes = Bytes.create(realsize);
-          really_input(inchan, bytes, 0, realsize);
-          Some(Spec.deserialize(bytes));
+          Some(Spec.deserialize(inchan, realsize));
         | _ => process(tl)
         };
       };

--- a/compiler/src/utils/wasm_utils.re
+++ b/compiler/src/utils/wasm_utils.re
@@ -413,7 +413,7 @@ module type BinarySectionSpec = {
   type t;
 
   let name: string;
-  let deserialize: in_channel => int => t;
+  let deserialize: (in_channel, int) => t;
   let accepts_version: abi_version => bool;
   let serialize: t => bytes;
 };

--- a/compiler/src/utils/wasm_utils.rei
+++ b/compiler/src/utils/wasm_utils.rei
@@ -57,7 +57,7 @@ module type BinarySectionSpec = {
   type t;
 
   let name: string;
-  let deserialize: in_channel => int => t;
+  let deserialize: (in_channel, int) => t;
   let accepts_version: abi_version => bool;
   let serialize: t => bytes;
 };

--- a/compiler/src/utils/wasm_utils.rei
+++ b/compiler/src/utils/wasm_utils.rei
@@ -57,7 +57,7 @@ module type BinarySectionSpec = {
   type t;
 
   let name: string;
-  let deserialize: bytes => t;
+  let deserialize: in_channel => int => t;
   let accepts_version: abi_version => bool;
   let serialize: t => bytes;
 };


### PR DESCRIPTION
This pulls @hhugo's change that we included in #1909 into a separate commit so we can land the improvement without the JSOO upgrade while we figure out the performance degradation. 