### PR TITLE
feat(compiler): Allow arrays to do binary operation assignment

### DIFF
--- a/compiler/src/parsing/parser.messages
+++ b/compiler/src/parsing/parser.messages
@@ -5376,6 +5376,15 @@ program: MODULE UIDENT EOL LIDENT INFIX_ASSIGNMENT_10 WHEN
 ## The known suffix of the stack is as follows:
 ## id_expr assign_binop_op
 ##
+program: MODULE UIDENT EOL UIDENT LBRACK UIDENT RBRACK INFIX_ASSIGNMENT_10 YIELD
+##
+## Ends in an error in state: 478.
+##
+## array_set -> left_accessor_expr lbrack expr rbrack assign_binop_op . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## left_accessor_expr lbrack expr rbrack assign_binop_op
+##
 program: MODULE UIDENT EOL LIDENT EQUAL WHEN
 ##
 ## Ends in an error in state: 224.

--- a/compiler/src/parsing/parser.mly
+++ b/compiler/src/parsing/parser.mly
@@ -634,6 +634,7 @@ array_get:
 
 array_set:
   | left_accessor_expr lbrack expr rbrack equal expr { Expression.array_set ~loc:(to_loc $loc) $1 $3 $6 }
+  | left_accessor_expr lbrack expr rbrack assign_binop_op expr { Expression.array_set ~loc:(to_loc $loc) $1 $3 (Expression.apply ~loc:(to_loc $loc) (mkid_expr $loc($5) [$5]) [{paa_label=Unlabeled; paa_expr=Expression.array_get ~loc:(to_loc $loc) $1 $3; paa_loc=(to_loc $loc($6))}; {paa_label=Unlabeled; paa_expr=$6; paa_loc=(to_loc $loc($6))}]) }
 
 record_get:
   | left_accessor_expr dot lid { Expression.record_get ~loc:(to_loc $loc) $1 $3 }

--- a/compiler/test/suites/arrays.re
+++ b/compiler/test/suites/arrays.re
@@ -71,6 +71,11 @@ describe("arrays", ({test, testSkip}) => {
     "let x = [> 1, 2, 3]; x[-2] = 4; print(x)",
     "[> 1, 4, 3]\n",
   );
+  assertRun(
+    "array_set3",
+    "let x = [> 1, 2, 3]; x[0] += 1; print(x)",
+    "[> 2, 2, 3]\n",
+  );
   assertCompileError(
     "array_set_err",
     "let x = [> 1, 2, 3]; x[-2] = false",


### PR DESCRIPTION
Closes #1915

Following the same semantics as record set, array accesses should allow to make use of shorthand binary operation assignments like `+=`.

`arr[0] += 1` currently throws a syntax error, this should fix it.