### PR TITLE
chore(stdlib): Optimize `Buffer.addChar`

### DIFF
--- a/stdlib/buffer.gr
+++ b/stdlib/buffer.gr
@@ -13,7 +13,7 @@ include "runtime/unsafe/memory"
 include "runtime/unsafe/wasmi32"
 include "runtime/unsafe/conv"
 include "runtime/exception"
-include "runtime/datastructures"
+include "runtime/dataStructures"
 from DataStructures use { untagChar }
 include "int32"
 include "bytes"

--- a/stdlib/buffer.gr
+++ b/stdlib/buffer.gr
@@ -13,6 +13,8 @@ include "runtime/unsafe/memory"
 include "runtime/unsafe/wasmi32"
 include "runtime/unsafe/conv"
 include "runtime/exception"
+include "runtime/datastructures"
+from DataStructures use { untagChar }
 include "int32"
 include "bytes"
 include "string"
@@ -318,8 +320,59 @@ provide let addString = (string, buffer) => {
  *
  * @since v0.4.0
  */
+@unsafe
 provide let addChar = (char, buffer) => {
-  addString(Char.toString(char), buffer)
+  from WasmI32 use {
+    (-),
+    (*),
+    (&),
+    (|),
+    (>>>),
+    ltU as (<),
+    gtU as (>),
+    leU as (<=),
+  }
+  let usv = untagChar(char)
+
+  let bytelen = if (usv < 0x80n) {
+    autogrow(1, buffer)
+    from WasmI32 use { (+) }
+    let off = coerceNumberToWasmI32(buffer.len)
+    let dst = WasmI32.fromGrain(buffer.data) + _VALUE_OFFSET
+    WasmI32.store8(dst, usv, off)
+    1
+  } else {
+    let mut count = 0n
+    let mut bytelen = 0
+    let mut offset = 0n
+    if (usv <= 0x07FFn) {
+      count = 1n
+      bytelen = 2
+      offset = 0xC0n
+    } else if (usv <= 0xFFFFn) {
+      count = 2n
+      bytelen = 3
+      offset = 0xE0n
+    } else {
+      count = 3n
+      bytelen = 4
+      offset = 0xF0n
+    }
+    from WasmI32 use { (+) }
+    autogrow(bytelen, buffer)
+    let off = coerceNumberToWasmI32(buffer.len)
+    let dst = WasmI32.fromGrain(buffer.data) + _VALUE_OFFSET
+    WasmI32.store8(dst, (usv >>> 6n * count) + offset, off)
+    let mut n = 0n
+    while (count > 0n) {
+      n += 1n
+      let temp = usv >>> 6n * (count - 1n)
+      WasmI32.store8(dst + n, 0x80n | temp & 0x3Fn, off)
+      count -= 1n
+    }
+    bytelen
+  }
+  buffer.len += bytelen
 }
 
 /**


### PR DESCRIPTION
This optimizes `Buffer.addChar` which previously relied on `Char.toString`. This new method eliminates the need for a needless string allocation on the heap.


Closes: #1879 