### PR TITLE
chore(compiler): Make Ast_helper locs non optional

### DIFF
--- a/compiler/src/formatting/format.re
+++ b/compiler/src/formatting/format.re
@@ -3799,7 +3799,7 @@ and print_expression_inner =
         ~expressions,
         ~original_source,
         ~comments=comments_in_expression,
-        Ast_helper.Expression.ident(constr),
+        Ast_helper.Expression.ident(~loc=constr.loc, constr),
       );
     | PExpConstruct(id, PExpConstrRecord(record)) =>
       Doc.concat([

--- a/compiler/src/parsing/ast_helper.re
+++ b/compiler/src/parsing/ast_helper.re
@@ -237,20 +237,18 @@ module Pattern = {
 };
 
 module Expression = {
-  let mk = (~loc=?, ~attributes=?, d) => {
-    let loc = Option.value(~default=Location.dummy_loc, loc);
+  let mk = (~loc, ~attributes=?, d) => {
     let attributes = Option.value(~default=[], attributes);
     {pexp_desc: d, pexp_attributes: attributes, pexp_loc: loc};
   };
-  let ident = (~loc=?, ~attributes=?, a) =>
-    mk(~loc?, ~attributes?, PExpId(a));
-  let constant = (~loc=?, ~attributes=?, a) =>
-    mk(~loc?, ~attributes?, PExpConstant(a));
-  let tuple = (~loc=?, ~attributes=?, a) =>
-    mk(~loc?, ~attributes?, PExpTuple(a));
-  let record = (~loc=?, ~attributes=?, a, b) =>
-    mk(~loc?, ~attributes?, PExpRecord(a, b));
-  let record_fields = (~loc=?, ~attributes=?, a) =>
+  let ident = (~loc, ~attributes=?, a) => mk(~loc, ~attributes?, PExpId(a));
+  let constant = (~loc, ~attributes=?, a) =>
+    mk(~loc, ~attributes?, PExpConstant(a));
+  let tuple = (~loc, ~attributes=?, a) =>
+    mk(~loc, ~attributes?, PExpTuple(a));
+  let record = (~loc, ~attributes=?, a, b) =>
+    mk(~loc, ~attributes?, PExpRecord(a, b));
+  let record_fields = (~loc, ~attributes=?, a) =>
     switch (a) {
     | [] => failwith("Impossible: empty record field list")
     | [base, ...rest] =>
@@ -287,54 +285,53 @@ module Expression = {
           rest,
         );
       let record_items = List.rev(record_items);
-      record(~loc?, ~attributes?, spread_base, record_items);
+      record(~loc, ~attributes?, spread_base, record_items);
     };
-  let record_get = (~loc=?, ~attributes=?, a, b) =>
-    mk(~loc?, ~attributes?, PExpRecordGet(a, b));
-  let record_set = (~loc=?, ~attributes=?, a, b, c) =>
-    mk(~loc?, ~attributes?, PExpRecordSet(a, b, c));
-  let array = (~loc=?, ~attributes=?, a) =>
-    mk(~loc?, ~attributes?, PExpArray(a));
-  let array_get = (~loc=?, ~attributes=?, a, b) =>
-    mk(~loc?, ~attributes?, PExpArrayGet(a, b));
-  let array_set = (~loc=?, ~attributes=?, a, b, c) =>
-    mk(~loc?, ~attributes?, PExpArraySet(a, b, c));
-  let let_ = (~loc=?, ~attributes=?, a, b, c) =>
-    mk(~loc?, ~attributes?, PExpLet(a, b, c));
-  let match = (~loc=?, ~attributes=?, a, b) =>
-    mk(~loc?, ~attributes?, PExpMatch(a, b));
-  let prim0 = (~loc=?, ~attributes=?, a) =>
-    mk(~loc?, ~attributes?, PExpPrim0(a));
-  let prim1 = (~loc=?, ~attributes=?, a, b) =>
-    mk(~loc?, ~attributes?, PExpPrim1(a, b));
-  let prim2 = (~loc=?, ~attributes=?, a, b, c) =>
-    mk(~loc?, ~attributes?, PExpPrim2(a, b, c));
-  let primn = (~loc=?, ~attributes=?, a, b) =>
-    mk(~loc?, ~attributes?, PExpPrimN(a, b));
-  let if_ = (~loc=?, ~attributes=?, a, b, c) =>
-    mk(~loc?, ~attributes?, PExpIf(a, b, c));
-  let while_ = (~loc=?, ~attributes=?, a, b) =>
-    mk(~loc?, ~attributes?, PExpWhile(a, b));
-  let for_ = (~loc=?, ~attributes=?, a, b, c, d) =>
-    mk(~loc?, ~attributes?, PExpFor(a, b, c, d));
-  let continue = (~loc=?, ~attributes=?, ()) =>
-    mk(~loc?, ~attributes?, PExpContinue);
-  let break = (~loc=?, ~attributes=?, ()) =>
-    mk(~loc?, ~attributes?, PExpBreak);
-  let return = (~loc=?, ~attributes=?, a) =>
-    mk(~loc?, ~attributes?, PExpReturn(a));
-  let constraint_ = (~loc=?, ~attributes=?, a, b) =>
-    mk(~loc?, ~attributes?, PExpConstraint(a, b));
+  let record_get = (~loc, ~attributes=?, a, b) =>
+    mk(~loc, ~attributes?, PExpRecordGet(a, b));
+  let record_set = (~loc, ~attributes=?, a, b, c) =>
+    mk(~loc, ~attributes?, PExpRecordSet(a, b, c));
+  let array = (~loc, ~attributes=?, a) =>
+    mk(~loc, ~attributes?, PExpArray(a));
+  let array_get = (~loc, ~attributes=?, a, b) =>
+    mk(~loc, ~attributes?, PExpArrayGet(a, b));
+  let array_set = (~loc, ~attributes=?, a, b, c) =>
+    mk(~loc, ~attributes?, PExpArraySet(a, b, c));
+  let let_ = (~loc, ~attributes=?, a, b, c) =>
+    mk(~loc, ~attributes?, PExpLet(a, b, c));
+  let match = (~loc, ~attributes=?, a, b) =>
+    mk(~loc, ~attributes?, PExpMatch(a, b));
+  let prim0 = (~loc, ~attributes=?, a) =>
+    mk(~loc, ~attributes?, PExpPrim0(a));
+  let prim1 = (~loc, ~attributes=?, a, b) =>
+    mk(~loc, ~attributes?, PExpPrim1(a, b));
+  let prim2 = (~loc, ~attributes=?, a, b, c) =>
+    mk(~loc, ~attributes?, PExpPrim2(a, b, c));
+  let primn = (~loc, ~attributes=?, a, b) =>
+    mk(~loc, ~attributes?, PExpPrimN(a, b));
+  let if_ = (~loc, ~attributes=?, a, b, c) =>
+    mk(~loc, ~attributes?, PExpIf(a, b, c));
+  let while_ = (~loc, ~attributes=?, a, b) =>
+    mk(~loc, ~attributes?, PExpWhile(a, b));
+  let for_ = (~loc, ~attributes=?, a, b, c, d) =>
+    mk(~loc, ~attributes?, PExpFor(a, b, c, d));
+  let continue = (~loc, ~attributes=?, ()) =>
+    mk(~loc, ~attributes?, PExpContinue);
+  let break = (~loc, ~attributes=?, ()) => mk(~loc, ~attributes?, PExpBreak);
+  let return = (~loc, ~attributes=?, a) =>
+    mk(~loc, ~attributes?, PExpReturn(a));
+  let constraint_ = (~loc, ~attributes=?, a, b) =>
+    mk(~loc, ~attributes?, PExpConstraint(a, b));
   let use = (~loc, ~attributes=?, a, b) =>
     mk(~loc, ~attributes?, PExpUse(a, b));
-  let box_assign = (~loc=?, ~attributes=?, a, b) =>
-    mk(~loc?, ~attributes?, PExpBoxAssign(a, b));
-  let assign = (~loc=?, ~attributes=?, a, b) =>
-    mk(~loc?, ~attributes?, PExpAssign(a, b));
-  let lambda = (~loc=?, ~attributes=?, a, b) =>
-    mk(~loc?, ~attributes?, PExpLambda(a, b));
-  let apply = (~loc=?, ~attributes=?, a, b) =>
-    mk(~loc?, ~attributes?, PExpApp(a, b));
+  let box_assign = (~loc, ~attributes=?, a, b) =>
+    mk(~loc, ~attributes?, PExpBoxAssign(a, b));
+  let assign = (~loc, ~attributes=?, a, b) =>
+    mk(~loc, ~attributes?, PExpAssign(a, b));
+  let lambda = (~loc, ~attributes=?, a, b) =>
+    mk(~loc, ~attributes?, PExpLambda(a, b));
+  let apply = (~loc, ~attributes=?, a, b) =>
+    mk(~loc, ~attributes?, PExpApp(a, b));
   let construct = (~loc, ~attributes=?, a, b) =>
     mk(~loc, ~attributes?, PExpConstruct(a, b));
   let singleton_construct = (~loc, ~attributes=?, a) =>
@@ -367,22 +364,18 @@ module Expression = {
   // and if you choose to shift then 1 / foo would always be a syntax error
   // because the parser would expect a number). It's easier to just parse it
   // as division and have this action decide that it's actually a rational.
-  let binop = (~loc=?, ~attributes=?, f, a, b) => {
+  let binop = (~loc, ~attributes=?, f, a, b) => {
     // Locations of nested binops are difficult to compute in the parser so we
     // just set the location manually here
     let loc =
       Location.(
-        Option.map(
-          loc =>
-            switch (a, b) {
-            | ({pexp_loc: {loc_start}}, {pexp_loc: {loc_end}}) => {
-                ...loc,
-                loc_start,
-                loc_end,
-              }
-            },
-          loc,
-        )
+        switch (a, b) {
+        | ({pexp_loc: {loc_start}}, {pexp_loc: {loc_end}}) => {
+            ...loc,
+            loc_start,
+            loc_end,
+          }
+        }
       );
     switch (f, a, b) {
     | (
@@ -390,14 +383,10 @@ module Expression = {
         {pexp_desc: PExpConstant(PConstNumber(PConstNumberInt(x)))},
         {pexp_desc: PExpConstant(PConstNumber(PConstNumberInt(y)))},
       ) =>
-      constant(
-        ~loc?,
-        ~attributes?,
-        PConstNumber(PConstNumberRational(x, y)),
-      )
+      constant(~loc, ~attributes?, PConstNumber(PConstNumberRational(x, y)))
     | _ =>
       mk(
-        ~loc?,
+        ~loc,
         ~attributes?,
         PExpApp(
           f,
@@ -409,8 +398,8 @@ module Expression = {
       )
     };
   };
-  let block = (~loc=?, ~attributes=?, a) =>
-    mk(~loc?, ~attributes?, PExpBlock(a));
+  let block = (~loc, ~attributes=?, a) =>
+    mk(~loc, ~attributes?, PExpBlock(a));
   let list = (~loc, ~attributes=?, a) => {
     let empty = tuple_construct(~loc, ident_empty, []);
     let list =

--- a/compiler/src/parsing/ast_helper.re
+++ b/compiler/src/parsing/ast_helper.re
@@ -91,16 +91,15 @@ module Constant = {
 };
 
 module Type = {
-  let mk = (~loc=?, d) => {
-    let loc = Option.value(~default=Location.dummy_loc, loc);
+  let mk = (~loc, d) => {
     {ptyp_desc: d, ptyp_loc: loc};
   };
-  let any = (~loc=?, ()) => mk(~loc?, PTyAny);
-  let var = (~loc=?, a) => mk(~loc?, PTyVar(a));
-  let arrow = (~loc=?, a, b) => mk(~loc?, PTyArrow(a, b));
-  let tuple = (~loc=?, a) => mk(~loc?, PTyTuple(a));
-  let constr = (~loc=?, a, b) => mk(~loc?, PTyConstr(a, b));
-  let poly = (~loc=?, a, b) => mk(~loc?, PTyPoly(a, b));
+  let any = (~loc, ()) => mk(~loc, PTyAny);
+  let var = (~loc, a) => mk(~loc, PTyVar(a));
+  let arrow = (~loc, a, b) => mk(~loc, PTyArrow(a, b));
+  let tuple = (~loc, a) => mk(~loc, PTyTuple(a));
+  let constr = (~loc, a, b) => mk(~loc, PTyConstr(a, b));
+  let poly = (~loc, a, b) => mk(~loc, PTyPoly(a, b));
 
   let force_poly = t =>
     switch (t.ptyp_desc) {

--- a/compiler/src/parsing/ast_helper.re
+++ b/compiler/src/parsing/ast_helper.re
@@ -484,8 +484,7 @@ module PrimitiveDescription = {
 };
 
 module ValueDescription = {
-  let mk = (~loc=?, ~mod_, ~name, ~alias, ~typ, ()) => {
-    let loc = Option.value(~default=Location.dummy_loc, loc);
+  let mk = (~loc, ~mod_, ~name, ~alias, ~typ, ()) => {
     {
       pval_mod: mod_,
       pval_name: name,
@@ -497,15 +496,13 @@ module ValueDescription = {
 };
 
 module ValueBinding = {
-  let mk = (~loc=?, p, e) => {
-    let loc = Option.value(~default=Location.dummy_loc, loc);
+  let mk = (~loc, p, e) => {
     {pvb_pat: p, pvb_expr: e, pvb_loc: loc};
   };
 };
 
 module MatchBranch = {
-  let mk = (~loc=?, p, e, g) => {
-    let loc = Option.value(~default=Location.dummy_loc, loc);
+  let mk = (~loc, p, e, g) => {
     {pmb_pat: p, pmb_body: e, pmb_guard: g, pmb_loc: loc};
   };
 };

--- a/compiler/src/parsing/ast_helper.re
+++ b/compiler/src/parsing/ast_helper.re
@@ -181,20 +181,19 @@ module Exception = {
 };
 
 module Pattern = {
-  let mk = (~loc=?, d) => {
-    let loc = Option.value(~default=Location.dummy_loc, loc);
+  let mk = (~loc, d) => {
     {ppat_desc: d, ppat_loc: loc};
   };
-  let any = (~loc=?, ()) => mk(~loc?, PPatAny);
-  let var = (~loc=?, a) => mk(~loc?, PPatVar(a));
-  let tuple = (~loc=?, a) => mk(~loc?, PPatTuple(a));
-  let array = (~loc=?, a) => mk(~loc?, PPatArray(a));
-  let record = (~loc=?, a) => {
+  let any = (~loc, ()) => mk(~loc, PPatAny);
+  let var = (~loc, a) => mk(~loc, PPatVar(a));
+  let tuple = (~loc, a) => mk(~loc, PPatTuple(a));
+  let array = (~loc, a) => mk(~loc, PPatArray(a));
+  let record = (~loc, a) => {
     let (patterns, closed) = record_pattern_info(a);
-    mk(~loc?, PPatRecord(patterns, closed));
+    mk(~loc, PPatRecord(patterns, closed));
   };
-  let constant = (~loc=?, a) => mk(~loc?, PPatConstant(a));
-  let constraint_ = (~loc=?, a, b) => mk(~loc?, PPatConstraint(a, b));
+  let constant = (~loc, a) => mk(~loc, PPatConstant(a));
+  let constraint_ = (~loc, a, b) => mk(~loc, PPatConstraint(a, b));
   let construct = (~loc, a, b) => mk(~loc, PPatConstruct(a, b));
   let singleton_construct = (~loc, a) =>
     construct(~loc, a, PPatConstrSingleton);
@@ -233,8 +232,8 @@ module Pattern = {
       );
     };
   };
-  let or_ = (~loc=?, a, b) => mk(~loc?, PPatOr(a, b));
-  let alias = (~loc=?, a, b) => mk(~loc?, PPatAlias(a, b));
+  let or_ = (~loc, a, b) => mk(~loc, PPatOr(a, b));
+  let alias = (~loc, a, b) => mk(~loc, PPatAlias(a, b));
 };
 
 module Expression = {

--- a/compiler/src/parsing/ast_helper.re
+++ b/compiler/src/parsing/ast_helper.re
@@ -109,13 +109,12 @@ module Type = {
 };
 
 module ConstructorDeclaration = {
-  let mk = (~loc=?, n, a) => {
-    let loc = Option.value(~default=Location.dummy_loc, loc);
+  let mk = (~loc, n, a) => {
     {pcd_name: n, pcd_args: a, pcd_loc: loc};
   };
-  let singleton = (~loc=?, n) => mk(~loc?, n, PConstrSingleton);
-  let tuple = (~loc=?, n, a) => mk(~loc?, n, PConstrTuple(a));
-  let record = (~loc=?, n, a) => {
+  let singleton = (~loc, n) => mk(~loc, n, PConstrSingleton);
+  let tuple = (~loc, n, a) => mk(~loc, n, PConstrTuple(a));
+  let record = (~loc, n, a) => {
     List.iter(
       ld =>
         if (ld.pld_mutable == Mutable) {
@@ -128,7 +127,7 @@ module ConstructorDeclaration = {
         },
       a.txt,
     );
-    mk(~loc?, n, PConstrRecord(a));
+    mk(~loc, n, PConstrRecord(a));
   };
 };
 

--- a/compiler/src/parsing/ast_helper.re
+++ b/compiler/src/parsing/ast_helper.re
@@ -452,27 +452,26 @@ module Expression = {
 };
 
 module Toplevel = {
-  let mk = (~loc=?, ~attributes=?, d) => {
-    let loc = Option.value(~default=Location.dummy_loc, loc);
+  let mk = (~loc, ~attributes=?, d) => {
     let attributes = Option.value(~default=[], attributes);
     {ptop_desc: d, ptop_attributes: attributes, ptop_loc: loc};
   };
   let include_ = (~loc, ~attributes=?, i) =>
     mk(~loc, ~attributes?, PTopInclude(i));
-  let foreign = (~loc=?, ~attributes=?, e, d) =>
-    mk(~loc?, ~attributes?, PTopForeign(e, d));
+  let foreign = (~loc, ~attributes=?, e, d) =>
+    mk(~loc, ~attributes?, PTopForeign(e, d));
   let module_ = (~loc, ~attributes=?, e, m) =>
     mk(~loc, ~attributes?, PTopModule(e, m));
-  let primitive = (~loc=?, ~attributes=?, e, d) =>
-    mk(~loc?, ~attributes?, PTopPrimitive(e, d));
-  let data = (~loc=?, ~attributes=?, elts) =>
-    mk(~loc?, ~attributes?, PTopData(elts));
-  let let_ = (~loc=?, ~attributes=?, e, r, m, vb) =>
-    mk(~loc?, ~attributes?, PTopLet(e, r, m, vb));
-  let expr = (~loc=?, ~attributes=?, e) =>
-    mk(~loc?, ~attributes?, PTopExpr(e));
-  let grain_exception = (~loc=?, ~attributes=?, e, ext) =>
-    mk(~loc?, ~attributes?, PTopException(e, ext));
+  let primitive = (~loc, ~attributes=?, e, d) =>
+    mk(~loc, ~attributes?, PTopPrimitive(e, d));
+  let data = (~loc, ~attributes=?, elts) =>
+    mk(~loc, ~attributes?, PTopData(elts));
+  let let_ = (~loc, ~attributes=?, e, r, m, vb) =>
+    mk(~loc, ~attributes?, PTopLet(e, r, m, vb));
+  let expr = (~loc, ~attributes=?, e) =>
+    mk(~loc, ~attributes?, PTopExpr(e));
+  let grain_exception = (~loc, ~attributes=?, e, ext) =>
+    mk(~loc, ~attributes?, PTopException(e, ext));
   let provide = (~loc, ~attributes=?, e) =>
     mk(~loc, ~attributes?, PTopProvide(e));
 };

--- a/compiler/src/parsing/ast_helper.re
+++ b/compiler/src/parsing/ast_helper.re
@@ -132,15 +132,13 @@ module ConstructorDeclaration = {
 };
 
 module LabelDeclaration = {
-  let mk = (~loc=?, n, t, m) => {
-    let loc = Option.value(~default=Location.dummy_loc, loc);
+  let mk = (~loc, n, t, m) => {
     {pld_name: n, pld_type: t, pld_mutable: m, pld_loc: loc};
   };
 };
 
 module DataDeclaration = {
-  let mk = (~loc=?, ~rec_flag=Nonrecursive, n, t, k, m) => {
-    let loc = Option.value(~default=Location.dummy_loc, loc);
+  let mk = (~loc, ~rec_flag=Nonrecursive, n, t, k, m) => {
     {
       pdata_rec: rec_flag,
       pdata_name: n,
@@ -150,23 +148,22 @@ module DataDeclaration = {
       pdata_loc: loc,
     };
   };
-  let abstract = (~loc=?, ~rec_flag=?, n, t, m) =>
-    mk(~loc?, ~rec_flag?, n, t, PDataAbstract, m);
-  let variant = (~loc=?, ~rec_flag=?, n, t, cdl) =>
-    mk(~loc?, ~rec_flag?, n, t, PDataVariant(cdl), None);
-  let record = (~loc=?, ~rec_flag=?, n, t, ldl) =>
-    mk(~loc?, ~rec_flag?, n, t, PDataRecord(ldl), None);
+  let abstract = (~loc, ~rec_flag=?, n, t, m) =>
+    mk(~loc, ~rec_flag?, n, t, PDataAbstract, m);
+  let variant = (~loc, ~rec_flag=?, n, t, cdl) =>
+    mk(~loc, ~rec_flag?, n, t, PDataVariant(cdl), None);
+  let record = (~loc, ~rec_flag=?, n, t, ldl) =>
+    mk(~loc, ~rec_flag?, n, t, PDataRecord(ldl), None);
 };
 
 module Exception = {
-  let mk = (~loc=?, n, t) => {
-    let loc = Option.value(~default=Location.dummy_loc, loc);
+  let mk = (~loc, n, t) => {
     let ext = {pext_name: n, pext_kind: PExtDecl(t), pext_loc: loc};
     {ptyexn_constructor: ext, ptyexn_loc: loc};
   };
-  let singleton = (~loc=?, n) => mk(~loc?, n, PConstrSingleton);
-  let tuple = (~loc=?, n, args) => mk(~loc?, n, PConstrTuple(args));
-  let record = (~loc=?, n, args) => {
+  let singleton = (~loc, n) => mk(~loc, n, PConstrSingleton);
+  let tuple = (~loc, n, args) => mk(~loc, n, PConstrTuple(args));
+  let record = (~loc, n, args) => {
     List.iter(
       ld =>
         if (ld.pld_mutable == Mutable) {
@@ -179,7 +176,7 @@ module Exception = {
         },
       args.txt,
     );
-    mk(~loc?, n, PConstrRecord(args));
+    mk(~loc, n, PConstrRecord(args));
   };
 };
 

--- a/compiler/src/parsing/ast_helper.rei
+++ b/compiler/src/parsing/ast_helper.rei
@@ -157,38 +157,37 @@ module Pattern: {
 
 module Expression: {
   let mk:
-    (~loc: loc=?, ~attributes: attributes=?, expression_desc) => expression;
-  let ident: (~loc: loc=?, ~attributes: attributes=?, id) => expression;
-  let constant:
-    (~loc: loc=?, ~attributes: attributes=?, constant) => expression;
+    (~loc: loc, ~attributes: attributes=?, expression_desc) => expression;
+  let ident: (~loc: loc, ~attributes: attributes=?, id) => expression;
+  let constant: (~loc: loc, ~attributes: attributes=?, constant) => expression;
   let tuple:
-    (~loc: loc=?, ~attributes: attributes=?, list(expression)) => expression;
+    (~loc: loc, ~attributes: attributes=?, list(expression)) => expression;
   let record:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       option(expression),
       list((id, expression))
     ) =>
     expression;
   let record_fields:
-    (~loc: loc=?, ~attributes: attributes=?, list(recorditem)) => expression;
+    (~loc: loc, ~attributes: attributes=?, list(recorditem)) => expression;
   let record_get:
-    (~loc: loc=?, ~attributes: attributes=?, expression, id) => expression;
+    (~loc: loc, ~attributes: attributes=?, expression, id) => expression;
   let record_set:
-    (~loc: loc=?, ~attributes: attributes=?, expression, id, expression) =>
+    (~loc: loc, ~attributes: attributes=?, expression, id, expression) =>
     expression;
   let list:
     (~loc: loc, ~attributes: attributes=?, list(listitem(expression))) =>
     expression;
   let array:
-    (~loc: loc=?, ~attributes: attributes=?, list(expression)) => expression;
+    (~loc: loc, ~attributes: attributes=?, list(expression)) => expression;
   let array_get:
-    (~loc: loc=?, ~attributes: attributes=?, expression, expression) =>
+    (~loc: loc, ~attributes: attributes=?, expression, expression) =>
     expression;
   let array_set:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       expression,
       expression,
@@ -197,7 +196,7 @@ module Expression: {
     expression;
   let let_:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       rec_flag,
       mut_flag,
@@ -205,25 +204,20 @@ module Expression: {
     ) =>
     expression;
   let match:
-    (
-      ~loc: loc=?,
-      ~attributes: attributes=?,
-      expression,
-      list(match_branch)
-    ) =>
+    (~loc: loc, ~attributes: attributes=?, expression, list(match_branch)) =>
     expression;
-  let prim0: (~loc: loc=?, ~attributes: attributes=?, prim0) => expression;
+  let prim0: (~loc: loc, ~attributes: attributes=?, prim0) => expression;
   let prim1:
-    (~loc: loc=?, ~attributes: attributes=?, prim1, expression) => expression;
+    (~loc: loc, ~attributes: attributes=?, prim1, expression) => expression;
   let prim2:
-    (~loc: loc=?, ~attributes: attributes=?, prim2, expression, expression) =>
+    (~loc: loc, ~attributes: attributes=?, prim2, expression, expression) =>
     expression;
   let primn:
-    (~loc: loc=?, ~attributes: attributes=?, primn, list(expression)) =>
+    (~loc: loc, ~attributes: attributes=?, primn, list(expression)) =>
     expression;
   let if_:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       expression,
       expression,
@@ -231,11 +225,11 @@ module Expression: {
     ) =>
     expression;
   let while_:
-    (~loc: loc=?, ~attributes: attributes=?, expression, expression) =>
+    (~loc: loc, ~attributes: attributes=?, expression, expression) =>
     expression;
   let for_:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       option(expression),
       option(expression),
@@ -243,23 +237,23 @@ module Expression: {
       expression
     ) =>
     expression;
-  let continue: (~loc: loc=?, ~attributes: attributes=?, unit) => expression;
-  let break: (~loc: loc=?, ~attributes: attributes=?, unit) => expression;
+  let continue: (~loc: loc, ~attributes: attributes=?, unit) => expression;
+  let break: (~loc: loc, ~attributes: attributes=?, unit) => expression;
   let return:
-    (~loc: loc=?, ~attributes: attributes=?, option(expression)) => expression;
+    (~loc: loc, ~attributes: attributes=?, option(expression)) => expression;
   let constraint_:
-    (~loc: loc=?, ~attributes: attributes=?, expression, parsed_type) =>
+    (~loc: loc, ~attributes: attributes=?, expression, parsed_type) =>
     expression;
   let use: (~loc: loc, ~attributes: attributes=?, id, use_items) => expression;
   let box_assign:
-    (~loc: loc=?, ~attributes: attributes=?, expression, expression) =>
+    (~loc: loc, ~attributes: attributes=?, expression, expression) =>
     expression;
   let assign:
-    (~loc: loc=?, ~attributes: attributes=?, expression, expression) =>
+    (~loc: loc, ~attributes: attributes=?, expression, expression) =>
     expression;
   let lambda:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       list(lambda_argument),
       expression
@@ -267,7 +261,7 @@ module Expression: {
     expression;
   let apply:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       expression,
       list(application_argument)
@@ -285,7 +279,7 @@ module Expression: {
     (~loc: loc, ~attributes: attributes=?, id, list(recorditem)) => expression;
   let binop:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       expression,
       expression,
@@ -293,7 +287,7 @@ module Expression: {
     ) =>
     expression;
   let block:
-    (~loc: loc=?, ~attributes: attributes=?, list(expression)) => expression;
+    (~loc: loc, ~attributes: attributes=?, list(expression)) => expression;
   let ignore: expression => expression;
 };
 

--- a/compiler/src/parsing/ast_helper.rei
+++ b/compiler/src/parsing/ast_helper.rei
@@ -72,13 +72,12 @@ module Type: {
 };
 
 module ConstructorDeclaration: {
-  let mk: (~loc: loc=?, str, constructor_arguments) => constructor_declaration;
-  let singleton: (~loc: loc=?, str) => constructor_declaration;
+  let mk: (~loc: loc, str, constructor_arguments) => constructor_declaration;
+  let singleton: (~loc: loc, str) => constructor_declaration;
   let tuple:
-    (~loc: loc=?, str, location(list(parsed_type))) =>
-    constructor_declaration;
+    (~loc: loc, str, location(list(parsed_type))) => constructor_declaration;
   let record:
-    (~loc: loc=?, str, location(list(label_declaration))) =>
+    (~loc: loc, str, location(list(label_declaration))) =>
     constructor_declaration;
 };
 

--- a/compiler/src/parsing/ast_helper.rei
+++ b/compiler/src/parsing/ast_helper.rei
@@ -134,25 +134,25 @@ module Exception: {
 };
 
 module Pattern: {
-  let mk: (~loc: loc=?, pattern_desc) => pattern;
-  let any: (~loc: loc=?, unit) => pattern;
-  let var: (~loc: loc=?, str) => pattern;
-  let tuple: (~loc: loc=?, list(pattern)) => pattern;
-  let array: (~loc: loc=?, list(pattern)) => pattern;
+  let mk: (~loc: loc, pattern_desc) => pattern;
+  let any: (~loc: loc, unit) => pattern;
+  let var: (~loc: loc, str) => pattern;
+  let tuple: (~loc: loc, list(pattern)) => pattern;
+  let array: (~loc: loc, list(pattern)) => pattern;
   let record:
-    (~loc: loc=?, list((option((id, pattern)), Asttypes.closed_flag))) =>
+    (~loc: loc, list((option((id, pattern)), Asttypes.closed_flag))) =>
     pattern;
   let list: (~loc: loc, list(listitem(pattern))) => pattern;
-  let constant: (~loc: loc=?, constant) => pattern;
-  let constraint_: (~loc: loc=?, pattern, parsed_type) => pattern;
+  let constant: (~loc: loc, constant) => pattern;
+  let constraint_: (~loc: loc, pattern, parsed_type) => pattern;
   let construct: (~loc: loc, id, constructor_pattern) => pattern;
   let singleton_construct: (~loc: loc, id) => pattern;
   let tuple_construct: (~loc: loc, id, list(pattern)) => pattern;
   let record_construct:
     (~loc: loc, id, list((option((id, pattern)), Asttypes.closed_flag))) =>
     pattern;
-  let or_: (~loc: loc=?, pattern, pattern) => pattern;
-  let alias: (~loc: loc=?, pattern, str) => pattern;
+  let or_: (~loc: loc, pattern, pattern) => pattern;
+  let alias: (~loc: loc, pattern, str) => pattern;
 };
 
 module Expression: {

--- a/compiler/src/parsing/ast_helper.rei
+++ b/compiler/src/parsing/ast_helper.rei
@@ -357,7 +357,7 @@ module PrimitiveDescription: {
 module ValueDescription: {
   let mk:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~mod_: str,
       ~name: str,
       ~alias: option(str),
@@ -368,12 +368,12 @@ module ValueDescription: {
 };
 
 module ValueBinding: {
-  let mk: (~loc: loc=?, pattern, expression) => value_binding;
+  let mk: (~loc: loc, pattern, expression) => value_binding;
 };
 
 module MatchBranch: {
   let mk:
-    (~loc: loc=?, pattern, expression, option(expression)) => match_branch;
+    (~loc: loc, pattern, expression, option(expression)) => match_branch;
 };
 
 module IncludeDeclaration: {

--- a/compiler/src/parsing/ast_helper.rei
+++ b/compiler/src/parsing/ast_helper.rei
@@ -60,14 +60,14 @@ module Constant: {
 };
 
 module Type: {
-  let mk: (~loc: loc=?, parsed_type_desc) => parsed_type;
-  let any: (~loc: loc=?, unit) => parsed_type;
-  let var: (~loc: loc=?, string) => parsed_type;
+  let mk: (~loc: loc, parsed_type_desc) => parsed_type;
+  let any: (~loc: loc, unit) => parsed_type;
+  let var: (~loc: loc, string) => parsed_type;
   let arrow:
-    (~loc: loc=?, list(parsed_type_argument), parsed_type) => parsed_type;
-  let tuple: (~loc: loc=?, list(parsed_type)) => parsed_type;
-  let constr: (~loc: loc=?, id, list(parsed_type)) => parsed_type;
-  let poly: (~loc: loc=?, list(str), parsed_type) => parsed_type;
+    (~loc: loc, list(parsed_type_argument), parsed_type) => parsed_type;
+  let tuple: (~loc: loc, list(parsed_type)) => parsed_type;
+  let constr: (~loc: loc, id, list(parsed_type)) => parsed_type;
+  let poly: (~loc: loc, list(str), parsed_type) => parsed_type;
   let force_poly: parsed_type => parsed_type;
 };
 

--- a/compiler/src/parsing/ast_helper.rei
+++ b/compiler/src/parsing/ast_helper.rei
@@ -299,25 +299,19 @@ module Expression: {
 
 module Toplevel: {
   let mk:
-    (~loc: loc=?, ~attributes: attributes=?, toplevel_stmt_desc) =>
-    toplevel_stmt;
+    (~loc: loc, ~attributes: attributes=?, toplevel_stmt_desc) => toplevel_stmt;
   let include_:
     (~loc: loc, ~attributes: attributes=?, include_declaration) =>
     toplevel_stmt;
   let foreign:
-    (
-      ~loc: loc=?,
-      ~attributes: attributes=?,
-      provide_flag,
-      value_description
-    ) =>
+    (~loc: loc, ~attributes: attributes=?, provide_flag, value_description) =>
     toplevel_stmt;
   let module_:
     (~loc: loc, ~attributes: attributes=?, provide_flag, module_declaration) =>
     toplevel_stmt;
   let primitive:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       provide_flag,
       primitive_description
@@ -325,14 +319,14 @@ module Toplevel: {
     toplevel_stmt;
   let data:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       list((provide_flag, data_declaration))
     ) =>
     toplevel_stmt;
   let let_:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       provide_flag,
       rec_flag,
@@ -341,9 +335,9 @@ module Toplevel: {
     ) =>
     toplevel_stmt;
   let expr:
-    (~loc: loc=?, ~attributes: attributes=?, expression) => toplevel_stmt;
+    (~loc: loc, ~attributes: attributes=?, expression) => toplevel_stmt;
   let grain_exception:
-    (~loc: loc=?, ~attributes: attributes=?, provide_flag, type_exception) =>
+    (~loc: loc, ~attributes: attributes=?, provide_flag, type_exception) =>
     toplevel_stmt;
   let provide:
     (~loc: loc, ~attributes: attributes=?, list(provide_item)) =>

--- a/compiler/src/parsing/ast_helper.rei
+++ b/compiler/src/parsing/ast_helper.rei
@@ -82,13 +82,13 @@ module ConstructorDeclaration: {
 };
 
 module LabelDeclaration: {
-  let mk: (~loc: loc=?, id, parsed_type, mut_flag) => label_declaration;
+  let mk: (~loc: loc, id, parsed_type, mut_flag) => label_declaration;
 };
 
 module DataDeclaration: {
   let mk:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~rec_flag: rec_flag=?,
       str,
       list(parsed_type),
@@ -98,7 +98,7 @@ module DataDeclaration: {
     data_declaration;
   let abstract:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~rec_flag: rec_flag=?,
       str,
       list(parsed_type),
@@ -107,7 +107,7 @@ module DataDeclaration: {
     data_declaration;
   let variant:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~rec_flag: rec_flag=?,
       str,
       list(parsed_type),
@@ -116,7 +116,7 @@ module DataDeclaration: {
     data_declaration;
   let record:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~rec_flag: rec_flag=?,
       str,
       list(parsed_type),
@@ -126,12 +126,11 @@ module DataDeclaration: {
 };
 
 module Exception: {
-  let mk: (~loc: loc=?, str, constructor_arguments) => type_exception;
-  let singleton: (~loc: loc=?, str) => type_exception;
-  let tuple:
-    (~loc: loc=?, str, location(list(parsed_type))) => type_exception;
+  let mk: (~loc: loc, str, constructor_arguments) => type_exception;
+  let singleton: (~loc: loc, str) => type_exception;
+  let tuple: (~loc: loc, str, location(list(parsed_type))) => type_exception;
   let record:
-    (~loc: loc=?, str, location(list(label_declaration))) => type_exception;
+    (~loc: loc, str, location(list(label_declaration))) => type_exception;
 };
 
 module Pattern: {

--- a/compiler/src/parsing/parser.mly
+++ b/compiler/src/parsing/parser.mly
@@ -304,7 +304,7 @@ data_typ:
 
 typ:
   | FUN data_typ either_arrow typ { Type.arrow ~loc:(to_loc $loc) [TypeArgument.mk ~loc:(to_loc $loc($2)) Unlabeled $2] $4 }
-  | FUN LIDENT either_arrow typ { Type.arrow ~loc:(to_loc $loc) [TypeArgument.mk ~loc:(to_loc $loc($2)) Unlabeled (Type.var $2)] $4 }
+  | FUN LIDENT either_arrow typ { Type.arrow ~loc:(to_loc $loc) [TypeArgument.mk ~loc:(to_loc $loc($2)) Unlabeled (Type.var ~loc:(to_loc $loc($2)) $2)] $4 }
   | FUN lparen arg_typs? rparen either_arrow typ { Type.arrow ~loc:(to_loc $loc) (Option.value ~default:[] $3) $6 }
   | lparen tuple_typs rparen { Type.tuple ~loc:(to_loc $loc) $2 }
   | lparen typ rparen { $2 }

--- a/compiler/src/typed/translprim.re
+++ b/compiler/src/typed/translprim.re
@@ -25,6 +25,7 @@ let default_loc = Location.dummy_loc;
 
 let mkident = name =>
   Expression.ident(
+    ~loc=Location.dummy_loc,
     Location.mkloc(
       Identifier.IdentName(Location.mkloc(name, default_loc)),
       default_loc,
@@ -1512,7 +1513,7 @@ let transl_prim = (env, desc) => {
       );
     | Primitive1(BuiltinId as p) =>
       // This primitive must always be inlined, so we do not generate a lambda
-      (Expression.constant(PConstVoid), Typecore.prim1_type(p))
+      (Expression.constant(~loc, PConstVoid), Typecore.prim1_type(p))
     | Primitive1(p) =>
       let attributes =
         switch (p) {

--- a/compiler/src/typed/typecore.re
+++ b/compiler/src/typed/typecore.re
@@ -1093,7 +1093,7 @@ and type_expect_ =
           Location.mknoloc(Identifier.IdentName(Location.mknoloc("()"))),
           [],
         )
-      | args => Pattern.tuple(args)
+      | args => Pattern.tuple(~loc=Location.dummy_loc, args)
       };
     let body =
       switch (prelude) {

--- a/compiler/src/typed/typecore.re
+++ b/compiler/src/typed/typecore.re
@@ -1024,6 +1024,7 @@ and type_expect_ =
             let default_loc = default.pexp_loc;
             let scases = [
               MatchBranch.mk(
+                ~loc=default_loc,
                 Pattern.construct(
                   ~loc=default_loc,
                   mknoloc(Identifier.IdentName(mknoloc("Some"))),
@@ -1038,6 +1039,7 @@ and type_expect_ =
                 None,
               ),
               MatchBranch.mk(
+                ~loc=default_loc,
                 Pattern.construct(
                   ~loc=default_loc,
                   mknoloc(Identifier.IdentName(mknoloc("None"))),
@@ -1068,7 +1070,7 @@ and type_expect_ =
                 ~loc=sloc,
                 Nonrecursive,
                 Immutable,
-                [ValueBinding.mk(arg.pla_pattern, smatch)],
+                [ValueBinding.mk(~loc=arg.pla_loc, arg.pla_pattern, smatch)],
               );
             (
               [pat, ...args],
@@ -1107,7 +1109,7 @@ and type_expect_ =
       env,
       ty_expected_explained,
       labels,
-      [MatchBranch.mk(pat, body, None)],
+      [MatchBranch.mk(~loc, pat, body, None)],
     );
   | PExpApp(func, args) =>
     begin_def(); /* one more level for non-returning functions */

--- a/compiler/test/suites/arrays.re
+++ b/compiler/test/suites/arrays.re
@@ -126,6 +126,7 @@ describe("arrays", ({test, testSkip}) => {
           module_name: Location.mknoloc("Test"),
           statements: [
             Toplevel.expr(
+              ~loc=Location.dummy_loc,
               Expression.array_set(
                 Expression.ident(
                   Location.mknoloc(

--- a/compiler/test/suites/arrays.re
+++ b/compiler/test/suites/arrays.re
@@ -128,13 +128,21 @@ describe("arrays", ({test, testSkip}) => {
             Toplevel.expr(
               ~loc=Location.dummy_loc,
               Expression.array_set(
+                ~loc=Location.dummy_loc,
                 Expression.ident(
+                  ~loc=Location.dummy_loc,
                   Location.mknoloc(
                     Identifier.IdentName(Location.mknoloc("state")),
                   ),
                 ),
-                Expression.constant(Constant.number(PConstNumberInt("0"))),
-                Expression.constant(Constant.number(PConstNumberInt("5"))),
+                Expression.constant(
+                  ~loc=Location.dummy_loc,
+                  Constant.number(PConstNumberInt("0")),
+                ),
+                Expression.constant(
+                  ~loc=Location.dummy_loc,
+                  Constant.number(PConstNumberInt("5")),
+                ),
               ),
             ),
           ],

--- a/compiler/test/suites/basic_functionality.re
+++ b/compiler/test/suites/basic_functionality.re
@@ -283,7 +283,10 @@ describe("basic functionality", ({test, testSkip}) => {
               Asttypes.Immutable,
               [
                 ValueBinding.mk(
-                  Pattern.var(Location.mknoloc("pokémon")),
+                  Pattern.var(
+                    ~loc=Location.dummy_loc,
+                    Location.mknoloc("pokémon"),
+                  ),
                   Expression.constant(Constant.string("pikachu")),
                 ),
               ],

--- a/compiler/test/suites/basic_functionality.re
+++ b/compiler/test/suites/basic_functionality.re
@@ -261,12 +261,15 @@ describe("basic functionality", ({test, testSkip}) => {
                   [],
                   [
                     ConstructorDeclaration.singleton(
+                      ~loc=Location.dummy_loc,
                       Location.mknoloc("Cachaça"),
                     ),
                     ConstructorDeclaration.singleton(
+                      ~loc=Location.dummy_loc,
                       Location.mknoloc("Sugar"),
                     ),
                     ConstructorDeclaration.singleton(
+                      ~loc=Location.dummy_loc,
                       Location.mknoloc("Lime"),
                     ),
                   ],

--- a/compiler/test/suites/basic_functionality.re
+++ b/compiler/test/suites/basic_functionality.re
@@ -292,6 +292,7 @@ describe("basic functionality", ({test, testSkip}) => {
                   [],
                   Some(
                     Type.constr(
+                      ~loc=Location.dummy_loc,
                       Location.mknoloc(
                         Identifier.IdentName(Location.mknoloc("Number")),
                       ),

--- a/compiler/test/suites/basic_functionality.re
+++ b/compiler/test/suites/basic_functionality.re
@@ -257,6 +257,7 @@ describe("basic functionality", ({test, testSkip}) => {
               (
                 Asttypes.NotProvided,
                 DataDeclaration.variant(
+                  ~loc=Location.dummy_loc,
                   Location.mknoloc("Caipirinha"),
                   [],
                   [
@@ -291,6 +292,7 @@ describe("basic functionality", ({test, testSkip}) => {
               (
                 Asttypes.NotProvided,
                 DataDeclaration.abstract(
+                  ~loc=Location.dummy_loc,
                   Location.mknoloc("Über"),
                   [],
                   Some(

--- a/compiler/test/suites/basic_functionality.re
+++ b/compiler/test/suites/basic_functionality.re
@@ -283,6 +283,7 @@ describe("basic functionality", ({test, testSkip}) => {
               Asttypes.Immutable,
               [
                 ValueBinding.mk(
+                  ~loc=Location.dummy_loc,
                   Pattern.var(
                     ~loc=Location.dummy_loc,
                     Location.mknoloc("pokémon"),

--- a/compiler/test/suites/basic_functionality.re
+++ b/compiler/test/suites/basic_functionality.re
@@ -292,7 +292,10 @@ describe("basic functionality", ({test, testSkip}) => {
                     ~loc=Location.dummy_loc,
                     Location.mknoloc("pokémon"),
                   ),
-                  Expression.constant(Constant.string("pikachu")),
+                  Expression.constant(
+                    ~loc=Location.dummy_loc,
+                    Constant.string("pikachu"),
+                  ),
                 ),
               ],
             ),

--- a/compiler/test/suites/basic_functionality.re
+++ b/compiler/test/suites/basic_functionality.re
@@ -253,31 +253,35 @@ describe("basic functionality", ({test, testSkip}) => {
         {
           module_name: Location.mknoloc("Test"),
           statements: [
-            Toplevel.data([
-              (
-                Asttypes.NotProvided,
-                DataDeclaration.variant(
-                  ~loc=Location.dummy_loc,
-                  Location.mknoloc("Caipirinha"),
-                  [],
-                  [
-                    ConstructorDeclaration.singleton(
-                      ~loc=Location.dummy_loc,
-                      Location.mknoloc("Cachaça"),
-                    ),
-                    ConstructorDeclaration.singleton(
-                      ~loc=Location.dummy_loc,
-                      Location.mknoloc("Sugar"),
-                    ),
-                    ConstructorDeclaration.singleton(
-                      ~loc=Location.dummy_loc,
-                      Location.mknoloc("Lime"),
-                    ),
-                  ],
+            Toplevel.data(
+              ~loc=Location.dummy_loc,
+              [
+                (
+                  Asttypes.NotProvided,
+                  DataDeclaration.variant(
+                    ~loc=Location.dummy_loc,
+                    Location.mknoloc("Caipirinha"),
+                    [],
+                    [
+                      ConstructorDeclaration.singleton(
+                        ~loc=Location.dummy_loc,
+                        Location.mknoloc("Cachaça"),
+                      ),
+                      ConstructorDeclaration.singleton(
+                        ~loc=Location.dummy_loc,
+                        Location.mknoloc("Sugar"),
+                      ),
+                      ConstructorDeclaration.singleton(
+                        ~loc=Location.dummy_loc,
+                        Location.mknoloc("Lime"),
+                      ),
+                    ],
+                  ),
                 ),
-              ),
-            ]),
+              ],
+            ),
             Toplevel.let_(
+              ~loc=Location.dummy_loc,
               Asttypes.NotProvided,
               Asttypes.Nonrecursive,
               Asttypes.Immutable,
@@ -292,25 +296,28 @@ describe("basic functionality", ({test, testSkip}) => {
                 ),
               ],
             ),
-            Toplevel.data([
-              (
-                Asttypes.NotProvided,
-                DataDeclaration.abstract(
-                  ~loc=Location.dummy_loc,
-                  Location.mknoloc("Über"),
-                  [],
-                  Some(
-                    Type.constr(
-                      ~loc=Location.dummy_loc,
-                      Location.mknoloc(
-                        Identifier.IdentName(Location.mknoloc("Number")),
+            Toplevel.data(
+              ~loc=Location.dummy_loc,
+              [
+                (
+                  Asttypes.NotProvided,
+                  DataDeclaration.abstract(
+                    ~loc=Location.dummy_loc,
+                    Location.mknoloc("Über"),
+                    [],
+                    Some(
+                      Type.constr(
+                        ~loc=Location.dummy_loc,
+                        Location.mknoloc(
+                          Identifier.IdentName(Location.mknoloc("Number")),
+                        ),
+                        [],
                       ),
-                      [],
                     ),
                   ),
                 ),
-              ),
-            ]),
+              ],
+            ),
           ],
           comments: [],
           prog_loc: Location.dummy_loc,

--- a/compiler/test/suites/blocks.re
+++ b/compiler/test/suites/blocks.re
@@ -16,14 +16,17 @@ describe("blocks", ({test}) => {
           statements: [
             Toplevel.expr(
               ~loc=Location.dummy_loc,
-              Expression.block([
-                Expression.singleton_construct(
-                  ~loc=Location.dummy_loc,
-                  Location.mknoloc(
-                    Identifier.IdentName(Location.mknoloc("Foo")),
+              Expression.block(
+                ~loc=Location.dummy_loc,
+                [
+                  Expression.singleton_construct(
+                    ~loc=Location.dummy_loc,
+                    Location.mknoloc(
+                      Identifier.IdentName(Location.mknoloc("Foo")),
+                    ),
                   ),
-                ),
-              ]),
+                ],
+              ),
             ),
           ],
           comments: [],

--- a/compiler/test/suites/blocks.re
+++ b/compiler/test/suites/blocks.re
@@ -15,6 +15,7 @@ describe("blocks", ({test}) => {
           module_name: Location.mknoloc("Test"),
           statements: [
             Toplevel.expr(
+              ~loc=Location.dummy_loc,
               Expression.block([
                 Expression.singleton_construct(
                   ~loc=Location.dummy_loc,

--- a/compiler/test/suites/chars.re
+++ b/compiler/test/suites/chars.re
@@ -33,8 +33,10 @@ describe("chars", ({test, testSkip}) => {
     },
     loc_ghost: false,
   };
-  let char = (~loc=?, s) =>
-    Toplevel.expr(~loc?) @@ Expression.constant(~loc?, Constant.char(s));
+  let char = (~loc=?, s) => {
+    let loc = Option.value(~default=Location.dummy_loc, loc);
+    Toplevel.expr(~loc) @@ Expression.constant(~loc, Constant.char(s));
+  };
 
   assertRun("char1", "print('A')", "A\n");
   assertSnapshot("char2", "'\\x41'");

--- a/compiler/test/suites/parsing.re
+++ b/compiler/test/suites/parsing.re
@@ -42,6 +42,7 @@ describe("parsing", ({test, testSkip}) => {
         module_name: Location.mknoloc("Test"),
         statements: [
           Toplevel.expr(
+            ~loc=Location.dummy_loc,
             Expression.apply(
               Expression.ident(
                 Location.mknoloc(
@@ -111,6 +112,7 @@ describe("parsing", ({test, testSkip}) => {
       module_name: Location.mknoloc("Test"),
       statements: [
         Toplevel.expr(
+          ~loc=Location.dummy_loc,
           Expression.apply(
             Expression.ident(
               Location.mknoloc(
@@ -144,6 +146,7 @@ describe("parsing", ({test, testSkip}) => {
       module_name: Location.mknoloc("Test"),
       statements: [
         Toplevel.expr(
+          ~loc=Location.dummy_loc,
           Expression.apply(
             Expression.ident(
               Location.mknoloc(
@@ -177,6 +180,7 @@ describe("parsing", ({test, testSkip}) => {
       module_name: Location.mknoloc("Test"),
       statements: [
         Toplevel.expr(
+          ~loc=Location.dummy_loc,
           Expression.apply(
             Expression.ident(
               Location.mknoloc(
@@ -210,6 +214,7 @@ describe("parsing", ({test, testSkip}) => {
       module_name: Location.mknoloc("Test"),
       statements: [
         Toplevel.expr(
+          ~loc=Location.dummy_loc,
           Expression.apply(
             Expression.ident(
               Location.mknoloc(
@@ -243,6 +248,7 @@ describe("parsing", ({test, testSkip}) => {
       module_name: Location.mknoloc("Test"),
       statements: [
         Toplevel.expr(
+          ~loc=Location.dummy_loc,
           Expression.return(
             Some(Expression.constant(PConstNumber(PConstNumberInt("-1")))),
           ),
@@ -320,7 +326,10 @@ describe("parsing", ({test, testSkip}) => {
     "module Test; a\x0ab",
     {
       module_name: Location.mknoloc("Test"),
-      statements: [Toplevel.expr(a), Toplevel.expr(b)],
+      statements: [
+        Toplevel.expr(~loc=Location.dummy_loc, a),
+        Toplevel.expr(~loc=Location.dummy_loc, b),
+      ],
       comments: [],
       prog_loc: Location.dummy_loc,
     },
@@ -330,7 +339,10 @@ describe("parsing", ({test, testSkip}) => {
     "module Test; a\x0cb",
     {
       module_name: Location.mknoloc("Test"),
-      statements: [Toplevel.expr(a), Toplevel.expr(b)],
+      statements: [
+        Toplevel.expr(~loc=Location.dummy_loc, a),
+        Toplevel.expr(~loc=Location.dummy_loc, b),
+      ],
       comments: [],
       prog_loc: Location.dummy_loc,
     },
@@ -340,7 +352,10 @@ describe("parsing", ({test, testSkip}) => {
     "module Test; a\x0db",
     {
       module_name: Location.mknoloc("Test"),
-      statements: [Toplevel.expr(a), Toplevel.expr(b)],
+      statements: [
+        Toplevel.expr(~loc=Location.dummy_loc, a),
+        Toplevel.expr(~loc=Location.dummy_loc, b),
+      ],
       comments: [],
       prog_loc: Location.dummy_loc,
     },
@@ -350,7 +365,10 @@ describe("parsing", ({test, testSkip}) => {
     "module Test; a\x0d\x0ab",
     {
       module_name: Location.mknoloc("Test"),
-      statements: [Toplevel.expr(a), Toplevel.expr(b)],
+      statements: [
+        Toplevel.expr(~loc=Location.dummy_loc, a),
+        Toplevel.expr(~loc=Location.dummy_loc, b),
+      ],
       comments: [],
       prog_loc: Location.dummy_loc,
     },
@@ -360,7 +378,10 @@ describe("parsing", ({test, testSkip}) => {
     "module Test; a\xc2\x85b",
     {
       module_name: Location.mknoloc("Test"),
-      statements: [Toplevel.expr(a), Toplevel.expr(b)],
+      statements: [
+        Toplevel.expr(~loc=Location.dummy_loc, a),
+        Toplevel.expr(~loc=Location.dummy_loc, b),
+      ],
       comments: [],
       prog_loc: Location.dummy_loc,
     },
@@ -370,7 +391,10 @@ describe("parsing", ({test, testSkip}) => {
     "module Test; a\xe2\x80\xa8b",
     {
       module_name: Location.mknoloc("Test"),
-      statements: [Toplevel.expr(a), Toplevel.expr(b)],
+      statements: [
+        Toplevel.expr(~loc=Location.dummy_loc, a),
+        Toplevel.expr(~loc=Location.dummy_loc, b),
+      ],
       comments: [],
       prog_loc: Location.dummy_loc,
     },
@@ -380,7 +404,10 @@ describe("parsing", ({test, testSkip}) => {
     "module Test; a\xe2\x80\xa9b",
     {
       module_name: Location.mknoloc("Test"),
-      statements: [Toplevel.expr(a), Toplevel.expr(b)],
+      statements: [
+        Toplevel.expr(~loc=Location.dummy_loc, a),
+        Toplevel.expr(~loc=Location.dummy_loc, b),
+      ],
       comments: [],
       prog_loc: Location.dummy_loc,
     },

--- a/compiler/test/suites/parsing.re
+++ b/compiler/test/suites/parsing.re
@@ -19,14 +19,17 @@ describe("parsing", ({test, testSkip}) => {
   );
   let a =
     Expression.ident(
+      ~loc=Location.dummy_loc,
       Location.mknoloc(Identifier.IdentName(Location.mknoloc("a"))),
     );
   let b =
     Expression.ident(
+      ~loc=Location.dummy_loc,
       Location.mknoloc(Identifier.IdentName(Location.mknoloc("b"))),
     );
   let c =
     Expression.ident(
+      ~loc=Location.dummy_loc,
       Location.mknoloc(Identifier.IdentName(Location.mknoloc("c"))),
     );
   let unlabled_expr = expr => {
@@ -44,7 +47,9 @@ describe("parsing", ({test, testSkip}) => {
           Toplevel.expr(
             ~loc=Location.dummy_loc,
             Expression.apply(
+              ~loc=Location.dummy_loc,
               Expression.ident(
+                ~loc=Location.dummy_loc,
                 Location.mknoloc(
                   Identifier.IdentName(Location.mknoloc(op)),
                 ),
@@ -114,7 +119,9 @@ describe("parsing", ({test, testSkip}) => {
         Toplevel.expr(
           ~loc=Location.dummy_loc,
           Expression.apply(
+            ~loc=Location.dummy_loc,
             Expression.ident(
+              ~loc=Location.dummy_loc,
               Location.mknoloc(
                 Identifier.IdentName(Location.mknoloc("+++")),
               ),
@@ -123,7 +130,9 @@ describe("parsing", ({test, testSkip}) => {
               unlabled_expr(a),
               unlabled_expr(
                 Expression.apply(
+                  ~loc=Location.dummy_loc,
                   Expression.ident(
+                    ~loc=Location.dummy_loc,
                     Location.mknoloc(
                       Identifier.IdentName(Location.mknoloc("***")),
                     ),
@@ -148,7 +157,9 @@ describe("parsing", ({test, testSkip}) => {
         Toplevel.expr(
           ~loc=Location.dummy_loc,
           Expression.apply(
+            ~loc=Location.dummy_loc,
             Expression.ident(
+              ~loc=Location.dummy_loc,
               Location.mknoloc(
                 Identifier.IdentName(Location.mknoloc("&&--")),
               ),
@@ -157,7 +168,9 @@ describe("parsing", ({test, testSkip}) => {
               unlabled_expr(a),
               unlabled_expr(
                 Expression.apply(
+                  ~loc=Location.dummy_loc,
                   Expression.ident(
+                    ~loc=Location.dummy_loc,
                     Location.mknoloc(
                       Identifier.IdentName(Location.mknoloc("&--")),
                     ),
@@ -182,7 +195,9 @@ describe("parsing", ({test, testSkip}) => {
         Toplevel.expr(
           ~loc=Location.dummy_loc,
           Expression.apply(
+            ~loc=Location.dummy_loc,
             Expression.ident(
+              ~loc=Location.dummy_loc,
               Location.mknoloc(
                 Identifier.IdentName(Location.mknoloc("||--")),
               ),
@@ -191,7 +206,9 @@ describe("parsing", ({test, testSkip}) => {
               unlabled_expr(a),
               unlabled_expr(
                 Expression.apply(
+                  ~loc=Location.dummy_loc,
                   Expression.ident(
+                    ~loc=Location.dummy_loc,
                     Location.mknoloc(
                       Identifier.IdentName(Location.mknoloc("|--")),
                     ),
@@ -216,7 +233,9 @@ describe("parsing", ({test, testSkip}) => {
         Toplevel.expr(
           ~loc=Location.dummy_loc,
           Expression.apply(
+            ~loc=Location.dummy_loc,
             Expression.ident(
+              ~loc=Location.dummy_loc,
               Location.mknoloc(
                 Identifier.IdentName(Location.mknoloc(">>")),
               ),
@@ -224,7 +243,9 @@ describe("parsing", ({test, testSkip}) => {
             [
               unlabled_expr(
                 Expression.apply(
+                  ~loc=Location.dummy_loc,
                   Expression.ident(
+                    ~loc=Location.dummy_loc,
                     Location.mknoloc(
                       Identifier.IdentName(Location.mknoloc("<<")),
                     ),
@@ -250,7 +271,13 @@ describe("parsing", ({test, testSkip}) => {
         Toplevel.expr(
           ~loc=Location.dummy_loc,
           Expression.return(
-            Some(Expression.constant(PConstNumber(PConstNumberInt("-1")))),
+            ~loc=Location.dummy_loc,
+            Some(
+              Expression.constant(
+                ~loc=Location.dummy_loc,
+                PConstNumber(PConstNumberInt("-1")),
+              ),
+            ),
           ),
         ),
       ],

--- a/compiler/test/suites/strings.re
+++ b/compiler/test/suites/strings.re
@@ -35,8 +35,10 @@ describe("strings", ({test, testSkip}) => {
     },
     loc_ghost: false,
   };
-  let str = (~loc=?, s) =>
-    Toplevel.expr(~loc?) @@ Expression.constant(~loc?, Constant.string(s));
+  let str = (~loc=?, s) => {
+    let loc = Option.value(~default=Location.dummy_loc, loc);
+    Toplevel.expr(~loc) @@ Expression.constant(~loc, Constant.string(s));
+  };
   assertParse(
     "string_parse_dqs1",
     "module Test; \"foo\"",


### PR DESCRIPTION
This pr makes locatons on ast nodes not optional.

Question should we also refactor the anf_helper nodes to have non optional locs in this pr or should we do that in a seperate pr.

Closes: #1106 