### PR TITLE
feat(stdlib)!: Replace `Int64` arithmatic functions with operators

### DIFF
--- a/compiler/test/stdlib/int64.test.gr
+++ b/compiler/test/stdlib/int64.test.gr
@@ -5,11 +5,14 @@ from Int64 use *
 
 // Suppress warnings about using `fromNumber` on constants, since that's what we want to test.
 let fromNumber = fromNumber
+from Pervasives use { (==) }
 assert fromNumber(5) == 5L
 assert fromNumber(0) == 0L
 
 assert toNumber(555L) == 555
 assert toNumber(0L) == 0
+
+from Int64 use { (==) }
 
 assert fromUint64(1uL) == 1L
 assert fromUint64(0xffffffffffffffffuL) == -1L
@@ -18,32 +21,32 @@ assert lnot(0xffffffffffffffffL) == 0L
 assert lnot(0L) == 0xffffffffffffffffL
 assert lnot(0xf0f0f0f0f0f0f0f0L) == 0x0f0f0f0f0f0f0f0fL
 
-assert land(0b1010L, 0b10L) == 0b10L
-assert land(0b1010L, 0L) == 0L
+assert (0b1010L & 0b10L) == 0b10L
+assert (0b1010L & 0L) == 0L
 
-assert lor(0b1010L, 0b0101L) == 0b1111L
-assert lor(0b1010L, 0L) == 0b1010L
+assert (0b1010L | 0b0101L) == 0b1111L
+assert (0b1010L | 0L) == 0b1010L
 
-assert lxor(0b1010L, 0b1101L) == 0b0111L
-assert lxor(0b1010L, 0L) == 0b1010L
+assert (0b1010L ^ 0b1101L) == 0b0111L
+assert (0b1010L ^ 0L) == 0b1010L
 
-assert shl(-1L, 1L) == -2L
-assert shl(-1L, 2L) == -4L
-assert shl(-1L, 3L) == -8L
-assert shl(-2L, 63L) == 0L
-assert shl(24L, 1L) == 48L
+assert -1L << 1L == -2L
+assert -1L << 2L == -4L
+assert -1L << 3L == -8L
+assert -2L << 63L == 0L
+assert 24L << 1L == 48L
 
-assert shr(-1L, 63L) == -1L
-assert shr(-24L, 1L) == -12L
+assert -1L >> 63L == -1L
+assert -24L >> 1L == -12L
 
-assert gt(5L, 4L)
-assert gte(5L, 5L)
-assert lt(5L, 17L)
-assert lte(5L, 5L)
-assert !gt(5L, 5L)
-assert !gte(5L, 22L)
-assert !lt(5L, -17L)
-assert !lte(5L, 4L)
+assert 5L > 4L
+assert 5L >= 5L
+assert 5L < 17L
+assert 5L <= 5L
+assert !(5L > 5L)
+assert !(5L >= 22L)
+assert !(5L < -17L)
+assert !(5L <= 4L)
 
 assert clz(0b11L) == 62L
 assert ctz(0b11000L) == 3L
@@ -51,13 +54,14 @@ assert popcnt(0b1100110011L) == 6L
 assert rotl(0b11L, 3L) == 0b11000L
 assert rotr(0b110000L, 3L) == 0b110L
 
-assert eq(5L, 5L)
-assert !eq(5L, 55L)
-assert ne(5L, 55L)
-assert !ne(5L, 5L)
+assert 5L == 5L
+assert !(5L == 55L)
+assert 5L != 55L
+assert !(5L != 5L)
 assert eqz(0L)
 assert !eqz(-42L)
 
+from Pervasives use { (==) }
 // Regression #1339
 let arr = [> 1, 2, 3]
 assert arr[toNumber(1L)] == 2

--- a/compiler/test/stdlib/sys.time.test.gr
+++ b/compiler/test/stdlib/sys.time.test.gr
@@ -1,7 +1,7 @@
 module TimeTest
 
 include "int64"
-from Int64 use { lt as (<), lte as (<=) }
+from Int64 use { (<), (<=) }
 include "sys/time"
 
 let mt1 = Time.monotonicTime()

--- a/stdlib/int64.gr
+++ b/stdlib/int64.gr
@@ -10,23 +10,7 @@ module Int64
 
 include "runtime/unsafe/wasmi32"
 include "runtime/unsafe/wasmi64"
-from WasmI64 use {
-  (==),
-  (!=),
-  (&),
-  (|),
-  (^),
-  (+),
-  (-),
-  (*),
-  (/),
-  (<<),
-  (>>),
-  (<),
-  (<=),
-  (>),
-  (>=),
-}
+from WasmI64 use { (==), (!=), (&), (|), (^), (<<), (>>), (<), (<=), (>), (>=) }
 include "runtime/exception"
 
 include "runtime/dataStructures"
@@ -65,6 +49,7 @@ provide let fromUint64 = (x: Uint64) => {
  */
 @unsafe
 provide let incr = (value: Int64) => {
+  from WasmI64 use { (+) }
   let value = WasmI32.fromGrain(value)
   let ptr = newInt64(WasmI64.load(value, 8n) + 1N)
   WasmI32.toGrain(ptr): Int64
@@ -80,6 +65,7 @@ provide let incr = (value: Int64) => {
  */
 @unsafe
 provide let decr = (value: Int64) => {
+  from WasmI64 use { (-) }
   let value = WasmI32.fromGrain(value)
   let ptr = newInt64(WasmI64.load(value, 8n) - 1N)
   WasmI32.toGrain(ptr): Int64
@@ -92,10 +78,12 @@ provide let decr = (value: Int64) => {
  * @param y: The second operand
  * @returns The sum of the two operands
  *
- * @since v0.2.0
+ * @since v0.6.0
+ * @history v0.2.0: Originally named `add`
  */
 @unsafe
-provide let add = (x: Int64, y: Int64) => {
+provide let (+) = (x: Int64, y: Int64) => {
+  from WasmI64 use { (+) }
   let xv = WasmI64.load(WasmI32.fromGrain(x), 8n)
   let yv = WasmI64.load(WasmI32.fromGrain(y), 8n)
   let ptr = newInt64(xv + yv)
@@ -109,10 +97,12 @@ provide let add = (x: Int64, y: Int64) => {
  * @param y: The second operand
  * @returns The difference of the two operands
  *
- * @since v0.2.0
+ * @since v0.6.0
+ * @history v0.2.0: Originally named `sub`
  */
 @unsafe
-provide let sub = (x: Int64, y: Int64) => {
+provide let (-) = (x: Int64, y: Int64) => {
+  from WasmI64 use { (-) }
   let xv = WasmI64.load(WasmI32.fromGrain(x), 8n)
   let yv = WasmI64.load(WasmI32.fromGrain(y), 8n)
   let ptr = newInt64(xv - yv)
@@ -126,10 +116,12 @@ provide let sub = (x: Int64, y: Int64) => {
  * @param y: The second operand
  * @returns The product of the two operands
  *
- * @since v0.2.0
+ * @since v0.6.0
+ * @history v0.2.0: Originally named `*`
  */
 @unsafe
-provide let mul = (x: Int64, y: Int64) => {
+provide let (*) = (x: Int64, y: Int64) => {
+  from WasmI64 use { (*) }
   let xv = WasmI64.load(WasmI32.fromGrain(x), 8n)
   let yv = WasmI64.load(WasmI32.fromGrain(y), 8n)
   let ptr = newInt64(xv * yv)
@@ -143,10 +135,12 @@ provide let mul = (x: Int64, y: Int64) => {
  * @param y: The second operand
  * @returns The quotient of its operands
  *
- * @since v0.2.0
+ * @since v0.6.0
+ * @history v0.2.0: Originally named `div`
  */
 @unsafe
-provide let div = (x: Int64, y: Int64) => {
+provide let (/) = (x: Int64, y: Int64) => {
+  from WasmI64 use { (/) }
   let xv = WasmI64.load(WasmI32.fromGrain(x), 8n)
   let yv = WasmI64.load(WasmI32.fromGrain(y), 8n)
   let ptr = newInt64(xv / yv)
@@ -172,6 +166,7 @@ provide let rem = (x: Int64, y: Int64) => {
 
 @unsafe
 let abs = n => {
+  from WasmI64 use { (-) }
   let mask = n >> 63N
   (n ^ mask) - mask
 }
@@ -186,10 +181,12 @@ let abs = n => {
  *
  * @throws ModuloByZero: When `y` is zero
  *
- * @since v0.2.0
+ * @since v0.6.0
+ * @history v0.2.0: Originally named `mod`
  */
 @unsafe
-provide let mod = (x: Int64, y: Int64) => {
+provide let (%) = (x: Int64, y: Int64) => {
+  from WasmI64 use { (-) }
   let xval = WasmI64.load(WasmI32.fromGrain(x), 8n)
   let yval = WasmI64.load(WasmI32.fromGrain(y), 8n)
 
@@ -250,10 +247,11 @@ provide let rotr = (value: Int64, amount: Int64) => {
  * @param amount: The number of bits to shift by
  * @returns The shifted value
  *
- * @since v0.2.0
+ * @since v0.6.0
+ * @history v0.2.0: Originally named `shl`
  */
 @unsafe
-provide let shl = (value: Int64, amount: Int64) => {
+provide let (<<) = (value: Int64, amount: Int64) => {
   let xv = WasmI64.load(WasmI32.fromGrain(value), 8n)
   let yv = WasmI64.load(WasmI32.fromGrain(amount), 8n)
   let ptr = newInt64(xv << yv)
@@ -267,10 +265,11 @@ provide let shl = (value: Int64, amount: Int64) => {
  * @param amount: The amount to shift by
  * @returns The shifted value
  *
- * @since v0.2.0
+ * @since v0.6.0
+ * @history v0.2.0: Originally named `shr`
  */
 @unsafe
-provide let shr = (value: Int64, amount: Int64) => {
+provide let (>>) = (value: Int64, amount: Int64) => {
   let xv = WasmI64.load(WasmI32.fromGrain(value), 8n)
   let yv = WasmI64.load(WasmI32.fromGrain(amount), 8n)
   let ptr = newInt64(xv >> yv)
@@ -284,10 +283,11 @@ provide let shr = (value: Int64, amount: Int64) => {
  * @param y: The second value
  * @returns `true` if the first value is equal to the second value or `false` otherwise
  *
- * @since v0.4.0
+ * @since v0.6.0
+ * @history v0.4.0: Originally named `eq`
  */
 @unsafe
-provide let eq = (x: Int64, y: Int64) => {
+provide let (==) = (x: Int64, y: Int64) => {
   let xv = WasmI64.load(WasmI32.fromGrain(x), 8n)
   let yv = WasmI64.load(WasmI32.fromGrain(y), 8n)
   xv == yv
@@ -300,10 +300,11 @@ provide let eq = (x: Int64, y: Int64) => {
  * @param y: The second value
  * @returns `true` if the first value is not equal to the second value or `false` otherwise
  *
- * @since v0.4.0
+ * @since v0.6.0
+ * @history v0.4.0: Originally named `ne`
  */
 @unsafe
-provide let ne = (x: Int64, y: Int64) => {
+provide let (!=) = (x: Int64, y: Int64) => {
   let xv = WasmI64.load(WasmI32.fromGrain(x), 8n)
   let yv = WasmI64.load(WasmI32.fromGrain(y), 8n)
   xv != yv
@@ -330,10 +331,11 @@ provide let eqz = (value: Int64) => {
  * @param y: The second value
  * @returns `true` if the first value is less than the second value or `false` otherwise
  *
- * @since v0.2.0
+ * @since v0.6.0
+ * @history v0.2.0: Originally named `lt`
  */
 @unsafe
-provide let lt = (x: Int64, y: Int64) => {
+provide let (<) = (x: Int64, y: Int64) => {
   let xv = WasmI64.load(WasmI32.fromGrain(x), 8n)
   let yv = WasmI64.load(WasmI32.fromGrain(y), 8n)
   xv < yv
@@ -346,10 +348,11 @@ provide let lt = (x: Int64, y: Int64) => {
  * @param y: The second value
  * @returns `true` if the first value is greater than the second value or `false` otherwise
  *
- * @since v0.2.0
+ * @since v0.6.0
+ * @history v0.2.0: Originally named `gt`
  */
 @unsafe
-provide let gt = (x: Int64, y: Int64) => {
+provide let (>) = (x: Int64, y: Int64) => {
   let xv = WasmI64.load(WasmI32.fromGrain(x), 8n)
   let yv = WasmI64.load(WasmI32.fromGrain(y), 8n)
   xv > yv
@@ -362,10 +365,11 @@ provide let gt = (x: Int64, y: Int64) => {
  * @param y: The second value
  * @returns `true` if the first value is less than or equal to the second value or `false` otherwise
  *
- * @since v0.2.0
+ * @since v0.6.0
+ * @history v0.2.0: Originally named `lte`
  */
 @unsafe
-provide let lte = (x: Int64, y: Int64) => {
+provide let (<=) = (x: Int64, y: Int64) => {
   let xv = WasmI64.load(WasmI32.fromGrain(x), 8n)
   let yv = WasmI64.load(WasmI32.fromGrain(y), 8n)
   xv <= yv
@@ -378,10 +382,11 @@ provide let lte = (x: Int64, y: Int64) => {
  * @param y: The second value
  * @returns `true` if the first value is greater than or equal to the second value or `false` otherwise
  *
- * @since v0.2.0
+ * @since v0.6.0
+ * @history v0.2.0: Originally named `gte`
  */
 @unsafe
-provide let gte = (x: Int64, y: Int64) => {
+provide let (>=) = (x: Int64, y: Int64) => {
   let xv = WasmI64.load(WasmI32.fromGrain(x), 8n)
   let yv = WasmI64.load(WasmI32.fromGrain(y), 8n)
   xv >= yv
@@ -409,10 +414,11 @@ provide let lnot = (value: Int64) => {
  * @param y: The second operand
  * @returns Containing a `1` in each bit position for which the corresponding bits of both operands are `1`
  *
- * @since v0.2.0
+ * @since v0.6.0
+ * @history v0.2.0: Originally named `land`
  */
 @unsafe
-provide let land = (x: Int64, y: Int64) => {
+provide let (&) = (x: Int64, y: Int64) => {
   let xv = WasmI64.load(WasmI32.fromGrain(x), 8n)
   let yv = WasmI64.load(WasmI32.fromGrain(y), 8n)
   let ptr = newInt64(xv & yv)
@@ -426,10 +432,11 @@ provide let land = (x: Int64, y: Int64) => {
  * @param y: The second operand
  * @returns Containing a `1` in each bit position for which the corresponding bits of either or both operands are `1`
  *
- * @since v0.2.0
+ * @since v0.6.0
+ * @history v0.2.0: Originally named `lor`
  */
 @unsafe
-provide let lor = (x: Int64, y: Int64) => {
+provide let (|) = (x: Int64, y: Int64) => {
   let xv = WasmI64.load(WasmI32.fromGrain(x), 8n)
   let yv = WasmI64.load(WasmI32.fromGrain(y), 8n)
   let ptr = newInt64(xv | yv)
@@ -443,10 +450,11 @@ provide let lor = (x: Int64, y: Int64) => {
  * @param y: The second operand
  * @returns Containing a `1` in each bit position for which the corresponding bits of either but not both operands are `1`
  *
- * @since v0.2.0
+ * @since v0.6.0
+ * @history v0.2.0: Originally named `lxor`
  */
 @unsafe
-provide let lxor = (x: Int64, y: Int64) => {
+provide let (^) = (x: Int64, y: Int64) => {
   let xv = WasmI64.load(WasmI32.fromGrain(x), 8n)
   let yv = WasmI64.load(WasmI32.fromGrain(y), 8n)
   let ptr = newInt64(xv ^ yv)

--- a/stdlib/int64.md
+++ b/stdlib/int64.md
@@ -142,15 +142,22 @@ Returns:
 |----|-----------|
 |`Int64`|The decremented value|
 
-### Int64.**add**
+### Int64.**(+)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.2.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally named `add`</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
-add : (x: Int64, y: Int64) => Int64
+(+) : (x: Int64, y: Int64) => Int64
 ```
 
 Computes the sum of its operands.
@@ -168,15 +175,22 @@ Returns:
 |----|-----------|
 |`Int64`|The sum of the two operands|
 
-### Int64.**sub**
+### Int64.**(-)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.2.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally named `sub`</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
-sub : (x: Int64, y: Int64) => Int64
+(-) : (x: Int64, y: Int64) => Int64
 ```
 
 Computes the difference of its operands.
@@ -194,15 +208,22 @@ Returns:
 |----|-----------|
 |`Int64`|The difference of the two operands|
 
-### Int64.**mul**
+### Int64.**(*)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.2.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally named `*`</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
-mul : (x: Int64, y: Int64) => Int64
+(*) : (x: Int64, y: Int64) => Int64
 ```
 
 Computes the product of its operands.
@@ -220,15 +241,22 @@ Returns:
 |----|-----------|
 |`Int64`|The product of the two operands|
 
-### Int64.**div**
+### Int64.**(/)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.2.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally named `div`</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
-div : (x: Int64, y: Int64) => Int64
+(/) : (x: Int64, y: Int64) => Int64
 ```
 
 Computes the quotient of its operands using signed division.
@@ -272,15 +300,22 @@ Returns:
 |----|-----------|
 |`Int64`|The remainder of its operands|
 
-### Int64.**mod**
+### Int64.**(%)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.2.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally named `mod`</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
-mod : (x: Int64, y: Int64) => Int64
+(%) : (x: Int64, y: Int64) => Int64
 ```
 
 Computes the remainder of the division of the first operand by the second.
@@ -357,15 +392,22 @@ Returns:
 |----|-----------|
 |`Int64`|The rotated value|
 
-### Int64.**shl**
+### Int64.**(<<)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.2.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally named `shl`</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
-shl : (value: Int64, amount: Int64) => Int64
+(<<) : (value: Int64, amount: Int64) => Int64
 ```
 
 Shifts the bits of the value left by the given number of bits.
@@ -383,15 +425,22 @@ Returns:
 |----|-----------|
 |`Int64`|The shifted value|
 
-### Int64.**shr**
+### Int64.**(>>)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.2.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally named `shr`</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
-shr : (value: Int64, amount: Int64) => Int64
+(>>) : (value: Int64, amount: Int64) => Int64
 ```
 
 Shifts the bits of the value right by the given number of bits, preserving the sign bit.
@@ -409,15 +458,22 @@ Returns:
 |----|-----------|
 |`Int64`|The shifted value|
 
-### Int64.**eq**
+### Int64.**(==)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.4.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.4.0</code></td><td>Originally named `eq`</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
-eq : (x: Int64, y: Int64) => Bool
+(==) : (x: Int64, y: Int64) => Bool
 ```
 
 Checks if the first value is equal to the second value.
@@ -435,15 +491,22 @@ Returns:
 |----|-----------|
 |`Bool`|`true` if the first value is equal to the second value or `false` otherwise|
 
-### Int64.**ne**
+### Int64.**(!=)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.4.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.4.0</code></td><td>Originally named `ne`</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
-ne : (x: Int64, y: Int64) => Bool
+(!=) : (x: Int64, y: Int64) => Bool
 ```
 
 Checks if the first value is not equal to the second value.
@@ -486,15 +549,22 @@ Returns:
 |----|-----------|
 |`Bool`|`true` if the first value is equal to zero or `false` otherwise|
 
-### Int64.**lt**
+### Int64.**(<)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.2.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally named `lt`</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
-lt : (x: Int64, y: Int64) => Bool
+(<) : (x: Int64, y: Int64) => Bool
 ```
 
 Checks if the first value is less than the second value.
@@ -512,15 +582,22 @@ Returns:
 |----|-----------|
 |`Bool`|`true` if the first value is less than the second value or `false` otherwise|
 
-### Int64.**gt**
+### Int64.**(>)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.2.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally named `gt`</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
-gt : (x: Int64, y: Int64) => Bool
+(>) : (x: Int64, y: Int64) => Bool
 ```
 
 Checks if the first value is greater than the second value.
@@ -538,15 +615,22 @@ Returns:
 |----|-----------|
 |`Bool`|`true` if the first value is greater than the second value or `false` otherwise|
 
-### Int64.**lte**
+### Int64.**(<=)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.2.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally named `lte`</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
-lte : (x: Int64, y: Int64) => Bool
+(<=) : (x: Int64, y: Int64) => Bool
 ```
 
 Checks if the first value is less than or equal to the second value.
@@ -564,15 +648,22 @@ Returns:
 |----|-----------|
 |`Bool`|`true` if the first value is less than or equal to the second value or `false` otherwise|
 
-### Int64.**gte**
+### Int64.**(>=)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.2.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally named `gte`</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
-gte : (x: Int64, y: Int64) => Bool
+(>=) : (x: Int64, y: Int64) => Bool
 ```
 
 Checks if the first value is greater than or equal to the second value.
@@ -615,15 +706,22 @@ Returns:
 |----|-----------|
 |`Int64`|Containing the inverted bits of the given value|
 
-### Int64.**land**
+### Int64.**(&)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.2.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally named `land`</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
-land : (x: Int64, y: Int64) => Int64
+(&) : (x: Int64, y: Int64) => Int64
 ```
 
 Computes the bitwise AND (`&`) on the given operands.
@@ -641,15 +739,22 @@ Returns:
 |----|-----------|
 |`Int64`|Containing a `1` in each bit position for which the corresponding bits of both operands are `1`|
 
-### Int64.**lor**
+### Int64.**(|)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.2.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally named `lor`</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
-lor : (x: Int64, y: Int64) => Int64
+(|) : (x: Int64, y: Int64) => Int64
 ```
 
 Computes the bitwise OR (`|`) on the given operands.
@@ -667,15 +772,22 @@ Returns:
 |----|-----------|
 |`Int64`|Containing a `1` in each bit position for which the corresponding bits of either or both operands are `1`|
 
-### Int64.**lxor**
+### Int64.**(^)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.2.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally named `lxor`</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
-lxor : (x: Int64, y: Int64) => Int64
+(^) : (x: Int64, y: Int64) => Int64
 ```
 
 Computes the bitwise XOR (`^`) on the given operands.


### PR DESCRIPTION
This pr brings the `Int64` library inline with the changes made in #1742 and #1734 


Marked as breaking beecause the external api changes.