### PR TITLE
feat(stdlib)!: Replace `Int32` arithmatic functions with operators

### DIFF
--- a/compiler/test/stdlib/int32.test.gr
+++ b/compiler/test/stdlib/int32.test.gr
@@ -3,6 +3,7 @@ module Int32Test
 include "int32"
 from Int32 use *
 
+from Pervasives use { (==) }
 // Suppress warnings about using `fromNumber` on constants, since that's what we want to test.
 let fromNumber = fromNumber
 assert fromNumber(5) == 5l
@@ -16,36 +17,38 @@ assert toNumber(0l) == 0
 assert fromUint32(1ul) == 1l
 assert fromUint32(0xfffffffful) == -1l
 
+from Int32 use { (==) }
+
 assert lnot(0xffffffffl) == 0l
 assert lnot(0l) == 0xffffffffl
 assert lnot(0xf0f0f0f0l) == 0x0f0f0f0fl
 
-assert land(0b1010l, 0b10l) == 0b10l
-assert land(0b1010l, 0l) == 0l
+assert (0b1010l & 0b10l) == 0b10l
+assert (0b1010l & 0l) == 0l
 
-assert lor(0b1010l, 0b0101l) == 0b1111l
-assert lor(0b1010l, 0l) == 0b1010l
+assert (0b1010l | 0b0101l) == 0b1111l
+assert (0b1010l | 0l) == 0b1010l
 
-assert lxor(0b1010l, 0b1101l) == 0b0111l
-assert lxor(0b1010l, 0l) == 0b1010l
+assert (0b1010l ^ 0b1101l) == 0b0111l
+assert (0b1010l ^ 0l) == 0b1010l
 
-assert shl(-1l, 1l) == -2l
-assert shl(-1l, 2l) == -4l
-assert shl(-1l, 3l) == -8l
-assert shl(-2l, 63l) == 0l
-assert shl(24l, 1l) == 48l
+assert -1l << 1l == -2l
+assert -1l << 2l == -4l
+assert -1l << 3l == -8l
+assert -2l << 63l == 0l
+assert 24l << 1l == 48l
 
-assert shr(-1l, 63l) == -1l
-assert shr(-24l, 1l) == -12l
+assert -1l >> 63l == -1l
+assert -24l >> 1l == -12l
 
-assert gt(5l, 4l)
-assert gte(5l, 5l)
-assert lt(5l, 17l)
-assert lte(5l, 5l)
-assert !gt(5l, 5l)
-assert !gte(5l, 22l)
-assert !lt(5l, -17l)
-assert !lte(5l, 4l)
+assert 5l > 4l
+assert 5l >= 5l
+assert 5l < 17l
+assert 5l <= 5l
+assert !(5l > 5l)
+assert !(5l >= 22l)
+assert !(5l < -17l)
+assert !(5l <= 4l)
 
 assert clz(0b11l) == 30l
 assert ctz(0b11000l) == 3l
@@ -53,13 +56,14 @@ assert popcnt(0b1100110011l) == 6l
 assert rotl(0b11l, 3l) == 0b11000l
 assert rotr(0b110000l, 3l) == 0b110l
 
-assert eq(5l, 5l)
-assert !eq(5l, 55l)
-assert ne(5l, 55l)
-assert !ne(5l, 5l)
+assert 5l == 5l
+assert !(5l == 55l)
+assert 5l != 55l
+assert !(5l != 5l)
 assert eqz(0l)
 assert !eqz(-42l)
 
+from Pervasives use { (==) }
 // Regression #1339
 let arr = [> 1, 2, 3]
 assert arr[toNumber(1l)] == 2

--- a/stdlib/int32.gr
+++ b/stdlib/int32.gr
@@ -95,10 +95,11 @@ provide let decr = (value: Int32) => {
  * @param y: The second operand
  * @returns The sum of the two operands
  *
- * @since v0.2.0
+ * @since v0.6.0
+ * @history v0.2.0: Originally named `add`
  */
 @unsafe
-provide let add = (x: Int32, y: Int32) => {
+provide let (+) = (x: Int32, y: Int32) => {
   let xv = WasmI32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
   let yv = WasmI32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   let ptr = newInt32(xv + yv)
@@ -112,10 +113,11 @@ provide let add = (x: Int32, y: Int32) => {
  * @param y: The second operand
  * @returns The difference of the two operands
  *
- * @since v0.2.0
+ * @since v0.6.0
+ * @history v0.2.0: Originally named `sub`
  */
 @unsafe
-provide let sub = (x: Int32, y: Int32) => {
+provide let (-) = (x: Int32, y: Int32) => {
   let xv = WasmI32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
   let yv = WasmI32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   let ptr = newInt32(xv - yv)
@@ -129,10 +131,11 @@ provide let sub = (x: Int32, y: Int32) => {
  * @param y: The second operand
  * @returns The product of the two operands
  *
- * @since v0.2.0
+ * @since v0.6.0
+ * @history v0.2.0: Originally named `mul`
  */
 @unsafe
-provide let mul = (x: Int32, y: Int32) => {
+provide let (*) = (x: Int32, y: Int32) => {
   let xv = WasmI32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
   let yv = WasmI32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   let ptr = newInt32(xv * yv)
@@ -146,10 +149,11 @@ provide let mul = (x: Int32, y: Int32) => {
  * @param y: The second operand
  * @returns The quotient of its operands
  *
- * @since v0.2.0
+ * @since v0.6.0
+ * @history v0.2.0: Originally named `div`
  */
 @unsafe
-provide let div = (x: Int32, y: Int32) => {
+provide let (/) = (x: Int32, y: Int32) => {
   let xv = WasmI32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
   let yv = WasmI32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   let ptr = newInt32(xv / yv)
@@ -175,6 +179,7 @@ provide let rem = (x: Int32, y: Int32) => {
 
 @unsafe
 let abs = n => {
+  from WasmI32 use { (-) }
   let mask = n >> 31n
   (n ^ mask) - mask
 }
@@ -189,10 +194,12 @@ let abs = n => {
  *
  * @throws ModuloByZero: When `y` is zero
  *
- * @since v0.2.0
+ * @since v0.6.0
+ * @history v0.2.0: Originally named `mod`
  */
 @unsafe
-provide let mod = (x: Int32, y: Int32) => {
+provide let (%) = (x: Int32, y: Int32) => {
+  from WasmI32 use { (-) }
   let xval = WasmI32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
   let yval = WasmI32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
 
@@ -253,10 +260,11 @@ provide let rotr = (value: Int32, amount: Int32) => {
  * @param amount: The number of bits to shift by
  * @returns The shifted value
  *
- * @since v0.2.0
+ * @since v0.6.0
+ * @history v0.2.0: Originally named `shl`
  */
 @unsafe
-provide let shl = (value: Int32, amount: Int32) => {
+provide let (<<) = (value: Int32, amount: Int32) => {
   let xv = WasmI32.load(WasmI32.fromGrain(value), _VALUE_OFFSET)
   let yv = WasmI32.load(WasmI32.fromGrain(amount), _VALUE_OFFSET)
   let ptr = newInt32(xv << yv)
@@ -270,10 +278,11 @@ provide let shl = (value: Int32, amount: Int32) => {
  * @param amount: The amount to shift by
  * @returns The shifted value
  *
- * @since v0.2.0
+ * @since v0.6.0
+ * @history v0.2.0: Originally named `shr`
  */
 @unsafe
-provide let shr = (value: Int32, amount: Int32) => {
+provide let (>>) = (value: Int32, amount: Int32) => {
   let xv = WasmI32.load(WasmI32.fromGrain(value), _VALUE_OFFSET)
   let yv = WasmI32.load(WasmI32.fromGrain(amount), _VALUE_OFFSET)
   let ptr = newInt32(xv >> yv)
@@ -287,10 +296,11 @@ provide let shr = (value: Int32, amount: Int32) => {
  * @param y: The second value
  * @returns `true` if the first value is equal to the second value or `false` otherwise
  *
- * @since v0.4.0
+ * @since v0.6.0
+ * @history v0.4.0: Originally named `eq`
  */
 @unsafe
-provide let eq = (x: Int32, y: Int32) => {
+provide let (==) = (x: Int32, y: Int32) => {
   let xv = WasmI32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
   let yv = WasmI32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   xv == yv
@@ -303,10 +313,11 @@ provide let eq = (x: Int32, y: Int32) => {
  * @param y: The second value
  * @returns `true` if the first value is not equal to the second value or `false` otherwise
  *
- * @since v0.4.0
+ * @since v0.6.0
+ * @history v0.4.0: Originally named `ne`
  */
 @unsafe
-provide let ne = (x: Int32, y: Int32) => {
+provide let (!=) = (x: Int32, y: Int32) => {
   let xv = WasmI32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
   let yv = WasmI32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   xv != yv
@@ -333,10 +344,11 @@ provide let eqz = (value: Int32) => {
  * @param y: The second value
  * @returns `true` if the first value is less than the second value or `false` otherwise
  *
- * @since v0.2.0
+ * @since v0.6.0
+ * @history v0.2.0: Originally named `lt`
  */
 @unsafe
-provide let lt = (x: Int32, y: Int32) => {
+provide let (<) = (x: Int32, y: Int32) => {
   let xv = WasmI32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
   let yv = WasmI32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   xv < yv
@@ -349,10 +361,11 @@ provide let lt = (x: Int32, y: Int32) => {
  * @param y: The second value
  * @returns `true` if the first value is greater than the second value or `false` otherwise
  *
- * @since v0.2.0
+ * @since v0.6.0
+ * @history v0.2.0: Originally named `gt`
  */
 @unsafe
-provide let gt = (x: Int32, y: Int32) => {
+provide let (>) = (x: Int32, y: Int32) => {
   let xv = WasmI32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
   let yv = WasmI32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   xv > yv
@@ -365,10 +378,11 @@ provide let gt = (x: Int32, y: Int32) => {
  * @param y: The second value
  * @returns `true` if the first value is less than or equal to the second value or `false` otherwise
  *
- * @since v0.2.0
+ * @since v0.6.0
+ * @history v0.2.0: Originally named `lte`
  */
 @unsafe
-provide let lte = (x: Int32, y: Int32) => {
+provide let (<=) = (x: Int32, y: Int32) => {
   let xv = WasmI32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
   let yv = WasmI32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   xv <= yv
@@ -381,10 +395,11 @@ provide let lte = (x: Int32, y: Int32) => {
  * @param y: The second value
  * @returns `true` if the first value is greater than or equal to the second value or `false` otherwise
  *
- * @since v0.2.0
+ * @since v0.6.0
+ * @history v0.2.0: Originally named `gte`
  */
 @unsafe
-provide let gte = (x: Int32, y: Int32) => {
+provide let (>=) = (x: Int32, y: Int32) => {
   let xv = WasmI32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
   let yv = WasmI32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   xv >= yv
@@ -412,10 +427,11 @@ provide let lnot = (value: Int32) => {
  * @param y: The second operand
  * @returns Containing a `1` in each bit position for which the corresponding bits of both operands are `1`
  *
- * @since v0.2.0
+ * @since v0.6.0
+ * @history v0.2.0: Originally named `land`
  */
 @unsafe
-provide let land = (x: Int32, y: Int32) => {
+provide let (&) = (x: Int32, y: Int32) => {
   let xv = WasmI32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
   let yv = WasmI32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   let ptr = newInt32(xv & yv)
@@ -429,10 +445,11 @@ provide let land = (x: Int32, y: Int32) => {
  * @param y: The second operand
  * @returns Containing a `1` in each bit position for which the corresponding bits of either or both operands are `1`
  *
- * @since v0.2.0
+ * @since v0.6.0
+ * @history v0.2.0: Originally named `lor`
  */
 @unsafe
-provide let lor = (x: Int32, y: Int32) => {
+provide let (|) = (x: Int32, y: Int32) => {
   let xv = WasmI32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
   let yv = WasmI32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   let ptr = newInt32(xv | yv)
@@ -446,10 +463,11 @@ provide let lor = (x: Int32, y: Int32) => {
  * @param y: The second operand
  * @returns Containing a `1` in each bit position for which the corresponding bits of either but not both operands are `1`
  *
- * @since v0.2.0
+ * @since v0.6.0
+ * @history v0.2.0: Originally named `lxor`
  */
 @unsafe
-provide let lxor = (x: Int32, y: Int32) => {
+provide let (^) = (x: Int32, y: Int32) => {
   let xv = WasmI32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
   let yv = WasmI32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   let ptr = newInt32(xv ^ yv)

--- a/stdlib/int32.md
+++ b/stdlib/int32.md
@@ -142,15 +142,22 @@ Returns:
 |----|-----------|
 |`Int32`|The decremented value|
 
-### Int32.**add**
+### Int32.**(+)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.2.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally named `add`</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
-add : (x: Int32, y: Int32) => Int32
+(+) : (x: Int32, y: Int32) => Int32
 ```
 
 Computes the sum of its operands.
@@ -168,15 +175,22 @@ Returns:
 |----|-----------|
 |`Int32`|The sum of the two operands|
 
-### Int32.**sub**
+### Int32.**(-)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.2.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally named `sub`</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
-sub : (x: Int32, y: Int32) => Int32
+(-) : (x: Int32, y: Int32) => Int32
 ```
 
 Computes the difference of its operands.
@@ -194,15 +208,22 @@ Returns:
 |----|-----------|
 |`Int32`|The difference of the two operands|
 
-### Int32.**mul**
+### Int32.**(*)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.2.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally named `mul`</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
-mul : (x: Int32, y: Int32) => Int32
+(*) : (x: Int32, y: Int32) => Int32
 ```
 
 Computes the product of its operands.
@@ -220,15 +241,22 @@ Returns:
 |----|-----------|
 |`Int32`|The product of the two operands|
 
-### Int32.**div**
+### Int32.**(/)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.2.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally named `div`</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
-div : (x: Int32, y: Int32) => Int32
+(/) : (x: Int32, y: Int32) => Int32
 ```
 
 Computes the quotient of its operands using signed division.
@@ -272,15 +300,22 @@ Returns:
 |----|-----------|
 |`Int32`|The remainder of its operands|
 
-### Int32.**mod**
+### Int32.**(%)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.2.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally named `mod`</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
-mod : (x: Int32, y: Int32) => Int32
+(%) : (x: Int32, y: Int32) => Int32
 ```
 
 Computes the remainder of the division of the first operand by the second.
@@ -357,15 +392,22 @@ Returns:
 |----|-----------|
 |`Int32`|The rotated value|
 
-### Int32.**shl**
+### Int32.**(<<)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.2.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally named `shl`</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
-shl : (value: Int32, amount: Int32) => Int32
+(<<) : (value: Int32, amount: Int32) => Int32
 ```
 
 Shifts the bits of the value left by the given number of bits.
@@ -383,15 +425,22 @@ Returns:
 |----|-----------|
 |`Int32`|The shifted value|
 
-### Int32.**shr**
+### Int32.**(>>)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.2.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally named `shr`</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
-shr : (value: Int32, amount: Int32) => Int32
+(>>) : (value: Int32, amount: Int32) => Int32
 ```
 
 Shifts the bits of the value right by the given number of bits, preserving the sign bit.
@@ -409,15 +458,22 @@ Returns:
 |----|-----------|
 |`Int32`|The shifted value|
 
-### Int32.**eq**
+### Int32.**(==)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.4.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.4.0</code></td><td>Originally named `eq`</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
-eq : (x: Int32, y: Int32) => Bool
+(==) : (x: Int32, y: Int32) => Bool
 ```
 
 Checks if the first value is equal to the second value.
@@ -435,15 +491,22 @@ Returns:
 |----|-----------|
 |`Bool`|`true` if the first value is equal to the second value or `false` otherwise|
 
-### Int32.**ne**
+### Int32.**(!=)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.4.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.4.0</code></td><td>Originally named `ne`</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
-ne : (x: Int32, y: Int32) => Bool
+(!=) : (x: Int32, y: Int32) => Bool
 ```
 
 Checks if the first value is not equal to the second value.
@@ -486,15 +549,22 @@ Returns:
 |----|-----------|
 |`Bool`|`true` if the first value is equal to zero or `false` otherwise|
 
-### Int32.**lt**
+### Int32.**(<)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.2.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally named `lt`</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
-lt : (x: Int32, y: Int32) => Bool
+(<) : (x: Int32, y: Int32) => Bool
 ```
 
 Checks if the first value is less than the second value.
@@ -512,15 +582,22 @@ Returns:
 |----|-----------|
 |`Bool`|`true` if the first value is less than the second value or `false` otherwise|
 
-### Int32.**gt**
+### Int32.**(>)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.2.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally named `gt`</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
-gt : (x: Int32, y: Int32) => Bool
+(>) : (x: Int32, y: Int32) => Bool
 ```
 
 Checks if the first value is greater than the second value.
@@ -538,15 +615,22 @@ Returns:
 |----|-----------|
 |`Bool`|`true` if the first value is greater than the second value or `false` otherwise|
 
-### Int32.**lte**
+### Int32.**(<=)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.2.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally named `lte`</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
-lte : (x: Int32, y: Int32) => Bool
+(<=) : (x: Int32, y: Int32) => Bool
 ```
 
 Checks if the first value is less than or equal to the second value.
@@ -564,15 +648,22 @@ Returns:
 |----|-----------|
 |`Bool`|`true` if the first value is less than or equal to the second value or `false` otherwise|
 
-### Int32.**gte**
+### Int32.**(>=)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.2.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally named `gte`</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
-gte : (x: Int32, y: Int32) => Bool
+(>=) : (x: Int32, y: Int32) => Bool
 ```
 
 Checks if the first value is greater than or equal to the second value.
@@ -615,15 +706,22 @@ Returns:
 |----|-----------|
 |`Int32`|Containing the inverted bits of the given value|
 
-### Int32.**land**
+### Int32.**(&)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.2.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally named `land`</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
-land : (x: Int32, y: Int32) => Int32
+(&) : (x: Int32, y: Int32) => Int32
 ```
 
 Computes the bitwise AND (`&`) on the given operands.
@@ -641,15 +739,22 @@ Returns:
 |----|-----------|
 |`Int32`|Containing a `1` in each bit position for which the corresponding bits of both operands are `1`|
 
-### Int32.**lor**
+### Int32.**(|)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.2.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally named `lor`</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
-lor : (x: Int32, y: Int32) => Int32
+(|) : (x: Int32, y: Int32) => Int32
 ```
 
 Computes the bitwise OR (`|`) on the given operands.
@@ -667,15 +772,22 @@ Returns:
 |----|-----------|
 |`Int32`|Containing a `1` in each bit position for which the corresponding bits of either or both operands are `1`|
 
-### Int32.**lxor**
+### Int32.**(^)**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.2.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>next</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.2.0</code></td><td>Originally named `lxor`</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain
-lxor : (x: Int32, y: Int32) => Int32
+(^) : (x: Int32, y: Int32) => Int32
 ```
 
 Computes the bitwise XOR (`^`) on the given operands.


### PR DESCRIPTION
This pr brings the `Int32` library inline with the changes made in #1742 and #1734 


Marked as breaking beecause the external api changes.