### PR TITLE
chore(compiler): Remove unused `JSFunction` and `js_func`

### DIFF
--- a/compiler/src/codegen/transl_anf.re
+++ b/compiler/src/codegen/transl_anf.re
@@ -913,7 +913,6 @@ let lift_imports = (env, imports) => {
             Ident.add(imp_use_id, MGlobalBind(glob, Managed), env.ce_binds),
         },
       );
-    | JSFunction(_) => failwith("NYI: lift_imports JSFunction")
     };
   };
 

--- a/compiler/src/middle_end/analyze_inline_wasm.re
+++ b/compiler/src/middle_end/analyze_inline_wasm.re
@@ -67,8 +67,7 @@ let analyze = ({imports, body, analyses}) => {
       };
     | GrainValue(_)
     | WasmFunction(_)
-    | WasmValue(_)
-    | JSFunction(_) => ()
+    | WasmValue(_) => ()
     };
   };
   List.iter(process_import, imports.specs);

--- a/compiler/src/middle_end/analyze_manual_memory_management.re
+++ b/compiler/src/middle_end/analyze_manual_memory_management.re
@@ -24,8 +24,7 @@ let analyze = ({imports, body, analyses}) => {
       set_manual_call(imp_use_id);
     | GrainValue(_)
     | WasmFunction(_)
-    | WasmValue(_)
-    | JSFunction(_) => ()
+    | WasmValue(_) => ()
     };
   };
   let root_gc_disabled =

--- a/compiler/src/middle_end/anf_helper.re
+++ b/compiler/src/middle_end/anf_helper.re
@@ -274,6 +274,4 @@ module IncludeDeclaration = {
     mk(a, WasmFunction(md, name), s, global);
   let wasm_value = (~global=Nonglobal, a, md, name, s) =>
     mk(a, WasmValue(md, name), s, global);
-  let js_func = (~global=Nonglobal, a, md, name, s) =>
-    mk(a, JSFunction(md, name), s, global);
 };

--- a/compiler/src/middle_end/anf_helper.rei
+++ b/compiler/src/middle_end/anf_helper.rei
@@ -356,7 +356,4 @@ module IncludeDeclaration: {
   let wasm_value:
     (~global: global_flag=?, ident, string, string, import_shape) =>
     import_spec;
-  let js_func:
-    (~global: global_flag=?, ident, string, string, import_shape) =>
-    import_spec;
 };

--- a/compiler/src/middle_end/anftree.re
+++ b/compiler/src/middle_end/anftree.re
@@ -432,8 +432,7 @@ type import_shape =
 type import_desc =
   | GrainValue(string, string)
   | WasmFunction(string, string)
-  | WasmValue(string, string)
-  | JSFunction(string, string);
+  | WasmValue(string, string);
 
 [@deriving sexp]
 type import_spec = {

--- a/compiler/src/middle_end/anftree.rei
+++ b/compiler/src/middle_end/anftree.rei
@@ -411,8 +411,7 @@ type import_shape =
 type import_desc =
   | GrainValue(string, string)
   | WasmFunction(string, string)
-  | WasmValue(string, string)
-  | JSFunction(string, string);
+  | WasmValue(string, string);
 
 [@deriving sexp]
 type import_spec = {


### PR DESCRIPTION
This pr removes the unused `js_func` from the anftree. It looks to just be unused legacy code.