### PR TITLE
chore(compiler): Make `locs` on `anf_helper` non optional

### DIFF
--- a/compiler/src/middle_end/anf_helper.re
+++ b/compiler/src/middle_end/anf_helper.re
@@ -9,223 +9,193 @@ type env = Env.t;
 type ident = Ident.t;
 type attributes = Typedtree.attributes;
 
-let default_loc = Location.dummy_loc;
 let default_env = Env.empty;
 let default_attributes = [];
 let default_allocation_type = Managed;
 
-let or_default_loc = Option.value(~default=default_loc);
 let or_default_env = Option.value(~default=default_env);
 let or_default_attributes = Option.value(~default=default_attributes);
 let or_default_allocation_type =
   Option.value(~default=default_allocation_type);
 
 module Imm = {
-  let mk = (~loc=?, ~env=?, d) => {
+  let mk = (~loc, ~env=?, d) => {
     imm_desc: d,
-    imm_loc: or_default_loc(loc),
+    imm_loc: loc,
     imm_env: or_default_env(env),
     imm_analyses: ref([]),
   };
-  let id = (~loc=?, ~env=?, id) => mk(~loc?, ~env?, ImmId(id));
-  let const = (~loc=?, ~env=?, const) => mk(~loc?, ~env?, ImmConst(const));
-  let trap = (~loc=?, ~env=?, ()) => mk(~loc?, ~env?, ImmTrap);
+  let id = (~loc, ~env=?, id) => mk(~loc, ~env?, ImmId(id));
+  let const = (~loc, ~env=?, const) => mk(~loc, ~env?, ImmConst(const));
+  let trap = (~loc, ~env=?, ()) => mk(~loc, ~env?, ImmTrap);
 };
 
 module Comp = {
-  let mk = (~loc=?, ~attributes=?, ~allocation_type=?, ~env=?, d) => {
+  let mk = (~loc, ~attributes=?, ~allocation_type=?, ~env=?, d) => {
     comp_desc: d,
-    comp_loc: or_default_loc(loc),
+    comp_loc: loc,
     comp_env: or_default_env(env),
     comp_attributes: or_default_attributes(attributes),
     comp_allocation_type: or_default_allocation_type(allocation_type),
     comp_analyses: ref([]),
   };
-  let imm = (~loc=?, ~attributes=?, ~allocation_type, ~env=?, imm) =>
-    mk(~loc?, ~attributes?, ~allocation_type, ~env?, CImmExpr(imm));
-  let number = (~loc=?, ~attributes=?, ~env=?, i) =>
-    mk(~loc?, ~attributes?, ~allocation_type=Managed, ~env?, CNumber(i));
-  let int32 = (~loc=?, ~attributes=?, ~env=?, i) =>
-    mk(~loc?, ~attributes?, ~allocation_type=Managed, ~env?, CInt32(i));
-  let int64 = (~loc=?, ~attributes=?, ~env=?, i) =>
-    mk(~loc?, ~attributes?, ~allocation_type=Managed, ~env?, CInt64(i));
-  let uint32 = (~loc=?, ~attributes=?, ~env=?, i) =>
-    mk(~loc?, ~attributes?, ~allocation_type=Managed, ~env?, CUint32(i));
-  let uint64 = (~loc=?, ~attributes=?, ~env=?, i) =>
-    mk(~loc?, ~attributes?, ~allocation_type=Managed, ~env?, CUint64(i));
-  let float32 = (~loc=?, ~attributes=?, ~env=?, i) =>
-    mk(~loc?, ~attributes?, ~allocation_type=Managed, ~env?, CFloat32(i));
-  let float64 = (~loc=?, ~attributes=?, ~env=?, i) =>
-    mk(~loc?, ~attributes?, ~allocation_type=Managed, ~env?, CFloat64(i));
-  let prim0 = (~loc=?, ~attributes=?, ~allocation_type, ~env=?, p0) =>
-    mk(~loc?, ~attributes?, ~allocation_type, ~env?, CPrim0(p0));
-  let prim1 = (~loc=?, ~attributes=?, ~allocation_type, ~env=?, p1, a) =>
-    mk(~loc?, ~attributes?, ~allocation_type, ~env?, CPrim1(p1, a));
-  let prim2 = (~loc=?, ~attributes=?, ~allocation_type, ~env=?, p2, a1, a2) =>
-    mk(~loc?, ~attributes?, ~allocation_type, ~env?, CPrim2(p2, a1, a2));
-  let primn = (~loc=?, ~attributes=?, ~allocation_type, ~env=?, p, args) =>
-    mk(~loc?, ~attributes?, ~allocation_type, ~env?, CPrimN(p, args));
-  let box_assign = (~loc=?, ~attributes=?, ~allocation_type, ~env=?, a1, a2) =>
-    mk(~loc?, ~attributes?, ~allocation_type, ~env?, CBoxAssign(a1, a2));
-  let local_assign = (~loc=?, ~attributes=?, ~allocation_type, ~env=?, a1, a2) =>
-    mk(~loc?, ~attributes?, ~allocation_type, ~env?, CLocalAssign(a1, a2));
-  let assign = (~loc=?, ~attributes=?, ~allocation_type, ~env=?, a1, a2) =>
-    mk(~loc?, ~attributes?, ~allocation_type, ~env?, CAssign(a1, a2));
-  let tuple = (~loc=?, ~attributes=?, ~env=?, elts) =>
-    mk(~loc?, ~attributes?, ~allocation_type=Managed, ~env?, CTuple(elts));
-  let array = (~loc=?, ~attributes=?, ~env=?, elts) =>
-    mk(~loc?, ~attributes?, ~allocation_type=Managed, ~env?, CArray(elts));
-  let array_get = (~loc=?, ~attributes=?, ~allocation_type, ~env=?, arr, i) =>
-    mk(~loc?, ~attributes?, ~allocation_type, ~env?, CArrayGet(arr, i));
-  let array_set = (~loc=?, ~attributes=?, ~allocation_type, ~env=?, arr, i, a) =>
-    mk(~loc?, ~attributes?, ~allocation_type, ~env?, CArraySet(arr, i, a));
-  let record = (~loc=?, ~attributes=?, ~env=?, type_hash, ttag, elts) =>
+  let imm = (~loc, ~attributes=?, ~allocation_type, ~env=?, imm) =>
+    mk(~loc, ~attributes?, ~allocation_type, ~env?, CImmExpr(imm));
+  let number = (~loc, ~attributes=?, ~env=?, i) =>
+    mk(~loc, ~attributes?, ~allocation_type=Managed, ~env?, CNumber(i));
+  let int32 = (~loc, ~attributes=?, ~env=?, i) =>
+    mk(~loc, ~attributes?, ~allocation_type=Managed, ~env?, CInt32(i));
+  let int64 = (~loc, ~attributes=?, ~env=?, i) =>
+    mk(~loc, ~attributes?, ~allocation_type=Managed, ~env?, CInt64(i));
+  let uint32 = (~loc, ~attributes=?, ~env=?, i) =>
+    mk(~loc, ~attributes?, ~allocation_type=Managed, ~env?, CUint32(i));
+  let uint64 = (~loc, ~attributes=?, ~env=?, i) =>
+    mk(~loc, ~attributes?, ~allocation_type=Managed, ~env?, CUint64(i));
+  let float32 = (~loc, ~attributes=?, ~env=?, i) =>
+    mk(~loc, ~attributes?, ~allocation_type=Managed, ~env?, CFloat32(i));
+  let float64 = (~loc, ~attributes=?, ~env=?, i) =>
+    mk(~loc, ~attributes?, ~allocation_type=Managed, ~env?, CFloat64(i));
+  let prim0 = (~loc, ~attributes=?, ~allocation_type, ~env=?, p0) =>
+    mk(~loc, ~attributes?, ~allocation_type, ~env?, CPrim0(p0));
+  let prim1 = (~loc, ~attributes=?, ~allocation_type, ~env=?, p1, a) =>
+    mk(~loc, ~attributes?, ~allocation_type, ~env?, CPrim1(p1, a));
+  let prim2 = (~loc, ~attributes=?, ~allocation_type, ~env=?, p2, a1, a2) =>
+    mk(~loc, ~attributes?, ~allocation_type, ~env?, CPrim2(p2, a1, a2));
+  let primn = (~loc, ~attributes=?, ~allocation_type, ~env=?, p, args) =>
+    mk(~loc, ~attributes?, ~allocation_type, ~env?, CPrimN(p, args));
+  let box_assign = (~loc, ~attributes=?, ~allocation_type, ~env=?, a1, a2) =>
+    mk(~loc, ~attributes?, ~allocation_type, ~env?, CBoxAssign(a1, a2));
+  let local_assign = (~loc, ~attributes=?, ~allocation_type, ~env=?, a1, a2) =>
+    mk(~loc, ~attributes?, ~allocation_type, ~env?, CLocalAssign(a1, a2));
+  let assign = (~loc, ~attributes=?, ~allocation_type, ~env=?, a1, a2) =>
+    mk(~loc, ~attributes?, ~allocation_type, ~env?, CAssign(a1, a2));
+  let tuple = (~loc, ~attributes=?, ~env=?, elts) =>
+    mk(~loc, ~attributes?, ~allocation_type=Managed, ~env?, CTuple(elts));
+  let array = (~loc, ~attributes=?, ~env=?, elts) =>
+    mk(~loc, ~attributes?, ~allocation_type=Managed, ~env?, CArray(elts));
+  let array_get = (~loc, ~attributes=?, ~allocation_type, ~env=?, arr, i) =>
+    mk(~loc, ~attributes?, ~allocation_type, ~env?, CArrayGet(arr, i));
+  let array_set = (~loc, ~attributes=?, ~allocation_type, ~env=?, arr, i, a) =>
+    mk(~loc, ~attributes?, ~allocation_type, ~env?, CArraySet(arr, i, a));
+  let record = (~loc, ~attributes=?, ~env=?, type_hash, ttag, elts) =>
     mk(
-      ~loc?,
+      ~loc,
       ~attributes?,
       ~allocation_type=Managed,
       ~env?,
       CRecord(type_hash, ttag, elts),
     );
-  let adt = (~loc=?, ~attributes=?, ~env=?, type_hash, ttag, vtag, elts) =>
+  let adt = (~loc, ~attributes=?, ~env=?, type_hash, ttag, vtag, elts) =>
     mk(
-      ~loc?,
+      ~loc,
       ~attributes?,
       ~allocation_type=Managed,
       ~env?,
       CAdt(type_hash, ttag, vtag, elts),
     );
-  let tuple_get = (~loc=?, ~attributes=?, ~allocation_type, ~env=?, idx, tup) =>
-    mk(
-      ~loc?,
-      ~attributes?,
-      ~allocation_type,
-      ~env?,
-      CGetTupleItem(idx, tup),
-    );
+  let tuple_get = (~loc, ~attributes=?, ~allocation_type, ~env=?, idx, tup) =>
+    mk(~loc, ~attributes?, ~allocation_type, ~env?, CGetTupleItem(idx, tup));
   let tuple_set =
-      (~loc=?, ~attributes=?, ~allocation_type, ~env=?, idx, tup, value) =>
+      (~loc, ~attributes=?, ~allocation_type, ~env=?, idx, tup, value) =>
     mk(
-      ~loc?,
+      ~loc,
       ~attributes?,
       ~allocation_type,
       ~env?,
       CSetTupleItem(idx, tup, value),
     );
-  let adt_get = (~loc=?, ~attributes=?, ~allocation_type, ~env=?, idx, value) =>
+  let adt_get = (~loc, ~attributes=?, ~allocation_type, ~env=?, idx, value) =>
+    mk(~loc, ~attributes?, ~allocation_type, ~env?, CGetAdtItem(idx, value));
+  let adt_get_tag = (~loc, ~attributes=?, ~env=?, value) =>
     mk(
-      ~loc?,
-      ~attributes?,
-      ~allocation_type,
-      ~env?,
-      CGetAdtItem(idx, value),
-    );
-  let adt_get_tag = (~loc=?, ~attributes=?, ~env=?, value) =>
-    mk(
-      ~loc?,
+      ~loc,
       ~attributes?,
       ~allocation_type=Unmanaged(WasmI32),
       ~env?,
       CGetAdtTag(value),
     );
   let record_get =
-      (~loc=?, ~attributes=?, ~allocation_type, ~env=?, idx, record) =>
+      (~loc, ~attributes=?, ~allocation_type, ~env=?, idx, record) =>
     mk(
-      ~loc?,
+      ~loc,
       ~attributes?,
       ~allocation_type,
       ~env?,
       CGetRecordItem(idx, record),
     );
   let record_set =
-      (~loc=?, ~attributes=?, ~allocation_type, ~env=?, idx, record, arg) =>
+      (~loc, ~attributes=?, ~allocation_type, ~env=?, idx, record, arg) =>
     mk(
-      ~loc?,
+      ~loc,
       ~attributes?,
       ~allocation_type,
       ~env?,
       CSetRecordItem(idx, record, arg),
     );
-  let if_ = (~loc=?, ~attributes=?, ~allocation_type, ~env=?, cond, tru, fals) =>
-    mk(~loc?, ~attributes?, ~allocation_type, ~env?, CIf(cond, tru, fals));
-  let for_ = (~loc=?, ~attributes=?, ~env=?, cond, inc, body) =>
+  let if_ = (~loc, ~attributes=?, ~allocation_type, ~env=?, cond, tru, fals) =>
+    mk(~loc, ~attributes?, ~allocation_type, ~env?, CIf(cond, tru, fals));
+  let for_ = (~loc, ~attributes=?, ~env=?, cond, inc, body) =>
     mk(
-      ~loc?,
+      ~loc,
       ~attributes?,
       ~allocation_type=Unmanaged(WasmI32),
       ~env?,
       CFor(cond, inc, body),
     );
-  let continue = (~loc=?, ~attributes=?, ~env=?, ()) =>
+  let continue = (~loc, ~attributes=?, ~env=?, ()) =>
     mk(
-      ~loc?,
+      ~loc,
       ~attributes?,
       ~allocation_type=Unmanaged(WasmI32),
       ~env?,
       CContinue,
     );
-  let break = (~loc=?, ~attributes=?, ~env=?, ()) =>
+  let break = (~loc, ~attributes=?, ~env=?, ()) =>
     mk(
-      ~loc?,
+      ~loc,
       ~attributes?,
       ~allocation_type=Unmanaged(WasmI32),
       ~env?,
       CBreak,
     );
-  let return = (~loc=?, ~attributes=?, ~env=?, ret) =>
+  let return = (~loc, ~attributes=?, ~env=?, ret) =>
     mk(
-      ~loc?,
+      ~loc,
       ~attributes?,
       ~allocation_type=Unmanaged(WasmI32),
       ~env?,
       CReturn(ret),
     );
   let switch_ =
-      (
-        ~loc=?,
-        ~attributes=?,
-        ~allocation_type,
-        ~env=?,
-        arg,
-        branches,
-        partial,
-      ) =>
+      (~loc, ~attributes=?, ~allocation_type, ~env=?, arg, branches, partial) =>
     mk(
-      ~loc?,
+      ~loc,
       ~attributes?,
       ~allocation_type,
       ~env?,
       CSwitch(arg, branches, partial),
     );
   let app =
-      (
-        ~loc=?,
-        ~attributes=?,
-        ~allocation_type,
-        ~env=?,
-        ~tail=false,
-        func,
-        args,
-      ) =>
-    mk(~loc?, ~attributes?, ~allocation_type, ~env?, CApp(func, args, tail));
-  let lambda = (~loc=?, ~attributes=?, ~env=?, ~name=?, args, body) =>
+      (~loc, ~attributes=?, ~allocation_type, ~env=?, ~tail=false, func, args) =>
+    mk(~loc, ~attributes?, ~allocation_type, ~env?, CApp(func, args, tail));
+  let lambda = (~loc, ~attributes=?, ~env=?, ~name=?, args, body) =>
     mk(
-      ~loc?,
+      ~loc,
       ~attributes?,
       ~allocation_type=Managed,
       ~env?,
       CLambda(name, args, body, Uncomputed),
     );
-  let bytes = (~loc=?, ~attributes=?, ~env=?, b) =>
-    mk(~loc?, ~attributes?, ~allocation_type=Managed, ~env?, CBytes(b));
-  let string = (~loc=?, ~attributes=?, ~env=?, s) =>
-    mk(~loc?, ~attributes?, ~allocation_type=Managed, ~env?, CString(s));
+  let bytes = (~loc, ~attributes=?, ~env=?, b) =>
+    mk(~loc, ~attributes?, ~allocation_type=Managed, ~env?, CBytes(b));
+  let string = (~loc, ~attributes=?, ~env=?, s) =>
+    mk(~loc, ~attributes?, ~allocation_type=Managed, ~env?, CString(s));
 };
 
 module AExp = {
-  let mk = (~loc=?, ~env=?, ~alloc_type, d) => {
+  let mk = (~loc, ~env=?, ~alloc_type, d) => {
     anf_desc: d,
-    anf_loc: or_default_loc(loc),
+    anf_loc: loc,
     anf_env: or_default_env(env),
     anf_analyses: ref([]),
     anf_allocation_type: alloc_type,
@@ -240,7 +210,7 @@ module AExp = {
 
   let let_ =
       (
-        ~loc=?,
+        ~loc,
         ~env=?,
         ~global=Nonglobal,
         ~mut_flag=Immutable,
@@ -249,15 +219,15 @@ module AExp = {
         body,
       ) =>
     mk(
-      ~loc?,
+      ~loc,
       ~env?,
       ~alloc_type=alloc_type(body),
       AELet(global, rec_flag, mut_flag, binds, body),
     );
-  let seq = (~loc=?, ~env=?, hd, tl) =>
-    mk(~loc?, ~env?, ~alloc_type=alloc_type(tl), AESeq(hd, tl));
-  let comp = (~loc=?, ~env=?, e) =>
-    mk(~loc?, ~env?, ~alloc_type=e.comp_allocation_type, AEComp(e));
+  let seq = (~loc, ~env=?, hd, tl) =>
+    mk(~loc, ~env?, ~alloc_type=alloc_type(tl), AESeq(hd, tl));
+  let comp = (~loc, ~env=?, e) =>
+    mk(~loc, ~env?, ~alloc_type=e.comp_allocation_type, AEComp(e));
 };
 
 module IncludeDeclaration = {

--- a/compiler/src/middle_end/anf_helper.rei
+++ b/compiler/src/middle_end/anf_helper.rei
@@ -10,16 +10,16 @@ type ident = Ident.t;
 type attributes = Typedtree.attributes;
 
 module Imm: {
-  let mk: (~loc: loc=?, ~env: env=?, imm_expression_desc) => imm_expression;
-  let id: (~loc: loc=?, ~env: env=?, ident) => imm_expression;
-  let const: (~loc: loc=?, ~env: env=?, constant) => imm_expression;
-  let trap: (~loc: loc=?, ~env: env=?, unit) => imm_expression;
+  let mk: (~loc: loc, ~env: env=?, imm_expression_desc) => imm_expression;
+  let id: (~loc: loc, ~env: env=?, ident) => imm_expression;
+  let const: (~loc: loc, ~env: env=?, constant) => imm_expression;
+  let trap: (~loc: loc, ~env: env=?, unit) => imm_expression;
 };
 
 module Comp: {
   let mk:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       ~allocation_type: allocation_type=?,
       ~env: env=?,
@@ -28,7 +28,7 @@ module Comp: {
     comp_expression;
   let imm:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       ~allocation_type: allocation_type,
       ~env: env=?,
@@ -37,33 +37,33 @@ module Comp: {
     comp_expression;
   let number:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       ~env: env=?,
       Asttypes.number_type
     ) =>
     comp_expression;
   let int32:
-    (~loc: loc=?, ~attributes: attributes=?, ~env: env=?, int32) =>
+    (~loc: loc, ~attributes: attributes=?, ~env: env=?, int32) =>
     comp_expression;
   let int64:
-    (~loc: loc=?, ~attributes: attributes=?, ~env: env=?, int64) =>
+    (~loc: loc, ~attributes: attributes=?, ~env: env=?, int64) =>
     comp_expression;
   let uint32:
-    (~loc: loc=?, ~attributes: attributes=?, ~env: env=?, int32) =>
+    (~loc: loc, ~attributes: attributes=?, ~env: env=?, int32) =>
     comp_expression;
   let uint64:
-    (~loc: loc=?, ~attributes: attributes=?, ~env: env=?, int64) =>
+    (~loc: loc, ~attributes: attributes=?, ~env: env=?, int64) =>
     comp_expression;
   let float32:
-    (~loc: loc=?, ~attributes: attributes=?, ~env: env=?, float) =>
+    (~loc: loc, ~attributes: attributes=?, ~env: env=?, float) =>
     comp_expression;
   let float64:
-    (~loc: loc=?, ~attributes: attributes=?, ~env: env=?, float) =>
+    (~loc: loc, ~attributes: attributes=?, ~env: env=?, float) =>
     comp_expression;
   let prim0:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       ~allocation_type: allocation_type,
       ~env: env=?,
@@ -72,7 +72,7 @@ module Comp: {
     comp_expression;
   let prim1:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       ~allocation_type: allocation_type,
       ~env: env=?,
@@ -82,7 +82,7 @@ module Comp: {
     comp_expression;
   let prim2:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       ~allocation_type: allocation_type,
       ~env: env=?,
@@ -93,7 +93,7 @@ module Comp: {
     comp_expression;
   let primn:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       ~allocation_type: allocation_type,
       ~env: env=?,
@@ -103,7 +103,7 @@ module Comp: {
     comp_expression;
   let box_assign:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       ~allocation_type: allocation_type,
       ~env: env=?,
@@ -113,7 +113,7 @@ module Comp: {
     comp_expression;
   let local_assign:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       ~allocation_type: allocation_type,
       ~env: env=?,
@@ -123,7 +123,7 @@ module Comp: {
     comp_expression;
   let assign:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       ~allocation_type: allocation_type,
       ~env: env=?,
@@ -133,7 +133,7 @@ module Comp: {
     comp_expression;
   let tuple:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       ~env: env=?,
       list(imm_expression)
@@ -141,7 +141,7 @@ module Comp: {
     comp_expression;
   let array:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       ~env: env=?,
       list(imm_expression)
@@ -149,7 +149,7 @@ module Comp: {
     comp_expression;
   let array_get:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       ~allocation_type: allocation_type,
       ~env: env=?,
@@ -159,7 +159,7 @@ module Comp: {
     comp_expression;
   let array_set:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       ~allocation_type: allocation_type,
       ~env: env=?,
@@ -170,7 +170,7 @@ module Comp: {
     comp_expression;
   let record:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       ~env: env=?,
       imm_expression,
@@ -180,7 +180,7 @@ module Comp: {
     comp_expression;
   let adt:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       ~env: env=?,
       imm_expression,
@@ -191,7 +191,7 @@ module Comp: {
     comp_expression;
   let tuple_get:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       ~allocation_type: allocation_type,
       ~env: env=?,
@@ -201,7 +201,7 @@ module Comp: {
     comp_expression;
   let tuple_set:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       ~allocation_type: allocation_type,
       ~env: env=?,
@@ -212,7 +212,7 @@ module Comp: {
     comp_expression;
   let adt_get:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       ~allocation_type: allocation_type,
       ~env: env=?,
@@ -221,11 +221,11 @@ module Comp: {
     ) =>
     comp_expression;
   let adt_get_tag:
-    (~loc: loc=?, ~attributes: attributes=?, ~env: env=?, imm_expression) =>
+    (~loc: loc, ~attributes: attributes=?, ~env: env=?, imm_expression) =>
     comp_expression;
   let record_get:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       ~allocation_type: allocation_type,
       ~env: env=?,
@@ -235,7 +235,7 @@ module Comp: {
     comp_expression;
   let record_set:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       ~allocation_type: allocation_type,
       ~env: env=?,
@@ -246,7 +246,7 @@ module Comp: {
     comp_expression;
   let if_:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       ~allocation_type: allocation_type,
       ~env: env=?,
@@ -257,7 +257,7 @@ module Comp: {
     comp_expression;
   let for_:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       ~env: env=?,
       option(anf_expression),
@@ -266,14 +266,14 @@ module Comp: {
     ) =>
     comp_expression;
   let continue:
-    (~loc: loc=?, ~attributes: attributes=?, ~env: env=?, unit) =>
+    (~loc: loc, ~attributes: attributes=?, ~env: env=?, unit) =>
     comp_expression;
   let break:
-    (~loc: loc=?, ~attributes: attributes=?, ~env: env=?, unit) =>
+    (~loc: loc, ~attributes: attributes=?, ~env: env=?, unit) =>
     comp_expression;
   let return:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       ~env: env=?,
       option(imm_expression)
@@ -281,7 +281,7 @@ module Comp: {
     comp_expression;
   let switch_:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       ~allocation_type: allocation_type,
       ~env: env=?,
@@ -292,7 +292,7 @@ module Comp: {
     comp_expression;
   let app:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       ~allocation_type: allocation_type,
       ~env: env=?,
@@ -303,7 +303,7 @@ module Comp: {
     comp_expression;
   let lambda:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~attributes: attributes=?,
       ~env: env=?,
       ~name: string=?,
@@ -312,17 +312,17 @@ module Comp: {
     ) =>
     comp_expression;
   let bytes:
-    (~loc: loc=?, ~attributes: attributes=?, ~env: env=?, bytes) =>
+    (~loc: loc, ~attributes: attributes=?, ~env: env=?, bytes) =>
     comp_expression;
   let string:
-    (~loc: loc=?, ~attributes: attributes=?, ~env: env=?, string) =>
+    (~loc: loc, ~attributes: attributes=?, ~env: env=?, string) =>
     comp_expression;
 };
 
 module AExp: {
   let mk:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~env: env=?,
       ~alloc_type: allocation_type,
       anf_expression_desc
@@ -330,7 +330,7 @@ module AExp: {
     anf_expression;
   let let_:
     (
-      ~loc: loc=?,
+      ~loc: loc,
       ~env: env=?,
       ~global: global_flag=?,
       ~mut_flag: mut_flag=?,
@@ -340,9 +340,8 @@ module AExp: {
     ) =>
     anf_expression;
   let seq:
-    (~loc: loc=?, ~env: env=?, comp_expression, anf_expression) =>
-    anf_expression;
-  let comp: (~loc: loc=?, ~env: env=?, comp_expression) => anf_expression;
+    (~loc: loc, ~env: env=?, comp_expression, anf_expression) => anf_expression;
+  let comp: (~loc: loc, ~env: env=?, comp_expression) => anf_expression;
 };
 
 module IncludeDeclaration: {
@@ -354,9 +353,6 @@ module IncludeDeclaration: {
     (~global: global_flag=?, ident, string, string, import_shape) =>
     import_spec;
   let wasm_value:
-    (~global: global_flag=?, ident, string, string, import_shape) =>
-    import_spec;
-  let js_func:
     (~global: global_flag=?, ident, string, string, import_shape) =>
     import_spec;
 };

--- a/compiler/src/middle_end/linearize.re
+++ b/compiler/src/middle_end/linearize.re
@@ -156,18 +156,12 @@ let lookup_symbol = (~env, ~allocation_type, ~repr, path) => {
 
 let convert_bind = (body, bind) =>
   switch (bind) {
-  | BSeq(exp) => AExp.seq(~loc=Location.dummy_loc, exp, body)
+  | BSeq(exp) => AExp.seq(~loc=exp.comp_loc, exp, body)
   | BLet(name, exp, global) =>
-    AExp.let_(
-      ~loc=Location.dummy_loc,
-      ~global,
-      Nonrecursive,
-      [(name, exp)],
-      body,
-    )
+    AExp.let_(~loc=exp.comp_loc, ~global, Nonrecursive, [(name, exp)], body)
   | BLetMut(name, exp, global) =>
     AExp.let_(
-      ~loc=Location.dummy_loc,
+      ~loc=exp.comp_loc,
       ~mut_flag=Mutable,
       ~global,
       Nonrecursive,
@@ -175,10 +169,16 @@ let convert_bind = (body, bind) =>
       body,
     )
   | BLetRec(names, global) =>
-    AExp.let_(~loc=Location.dummy_loc, ~global, Recursive, names, body)
+    AExp.let_(
+      ~loc=snd(List.hd(names)).comp_loc,
+      ~global,
+      Recursive,
+      names,
+      body,
+    )
   | BLetRecMut(names, global) =>
     AExp.let_(
-      ~loc=Location.dummy_loc,
+      ~loc=snd(List.hd(names)).comp_loc,
       ~mut_flag=Mutable,
       ~global,
       Recursive,
@@ -202,10 +202,10 @@ let convert_binds = anf_binds => {
     };
   let ans =
     switch (last_bind) {
-    | BSeq(exp) => AExp.comp(~loc=Location.dummy_loc, exp)
+    | BSeq(exp) => AExp.comp(~loc=exp.comp_loc, exp)
     | BLet(name, exp, global) =>
       AExp.let_(
-        ~loc=Location.dummy_loc,
+        ~loc=exp.comp_loc,
         ~global,
         Nonrecursive,
         [(name, exp)],
@@ -213,7 +213,7 @@ let convert_binds = anf_binds => {
       )
     | BLetMut(name, exp, global) =>
       AExp.let_(
-        ~loc=Location.dummy_loc,
+        ~loc=exp.comp_loc,
         ~mut_flag=Mutable,
         ~global,
         Nonrecursive,
@@ -221,10 +221,16 @@ let convert_binds = anf_binds => {
         void,
       )
     | BLetRec(names, global) =>
-      AExp.let_(~loc=Location.dummy_loc, ~global, Recursive, names, void)
+      AExp.let_(
+        ~loc=snd(List.hd(names)).comp_loc,
+        ~global,
+        Recursive,
+        names,
+        void,
+      )
     | BLetRecMut(names, global) =>
       AExp.let_(
-        ~loc=Location.dummy_loc,
+        ~loc=snd(List.hd(names)).comp_loc,
         ~mut_flag=Mutable,
         ~global,
         Recursive,

--- a/compiler/src/middle_end/matchcomp.re
+++ b/compiler/src/middle_end/matchcomp.re
@@ -730,7 +730,7 @@ module MatchTreeCompiler = {
         switch (bind) {
         | BLet(name, exp, global) =>
           AExp.let_(
-            ~loc=Location.dummy_loc,
+            ~loc=exp.comp_loc,
             ~global,
             Nonrecursive,
             [(name, exp)],
@@ -738,19 +738,19 @@ module MatchTreeCompiler = {
           )
         | BLetMut(name, exp, global) =>
           AExp.let_(
-            ~loc=Location.dummy_loc,
+            ~loc=exp.comp_loc,
             ~global,
             ~mut_flag=Mutable,
             Nonrecursive,
             [(name, exp)],
             body,
           )
-        | BSeq(exp) => AExp.seq(~loc=Location.dummy_loc, exp, body)
+        | BSeq(exp) => AExp.seq(~loc=exp.comp_loc, exp, body)
         | _ =>
           failwith("match_comp: compile_tree_help: unsupported binding type")
         },
       setup,
-      AExp.comp(~loc=Location.dummy_loc, ans),
+      AExp.comp(~loc=ans.comp_loc, ans),
     );
   };
 

--- a/compiler/src/middle_end/matchcomp.re
+++ b/compiler/src/middle_end/matchcomp.re
@@ -729,21 +729,28 @@ module MatchTreeCompiler = {
       (bind, body) =>
         switch (bind) {
         | BLet(name, exp, global) =>
-          AExp.let_(~global, Nonrecursive, [(name, exp)], body)
+          AExp.let_(
+            ~loc=Location.dummy_loc,
+            ~global,
+            Nonrecursive,
+            [(name, exp)],
+            body,
+          )
         | BLetMut(name, exp, global) =>
           AExp.let_(
+            ~loc=Location.dummy_loc,
             ~global,
             ~mut_flag=Mutable,
             Nonrecursive,
             [(name, exp)],
             body,
           )
-        | BSeq(exp) => AExp.seq(exp, body)
+        | BSeq(exp) => AExp.seq(~loc=Location.dummy_loc, exp, body)
         | _ =>
           failwith("match_comp: compile_tree_help: unsupported binding type")
         },
       setup,
-      AExp.comp(ans),
+      AExp.comp(~loc=Location.dummy_loc, ans),
     );
   };
 
@@ -753,19 +760,21 @@ module MatchTreeCompiler = {
         if (mut_boxing) {
           BSeq(
             Comp.assign(
+              ~loc=Location.dummy_loc,
               ~env,
               ~allocation_type=Managed,
-              Imm.id(name),
-              Imm.id(value),
+              Imm.id(~loc=Location.dummy_loc, name),
+              Imm.id(~loc=Location.dummy_loc, value),
             ),
           );
         } else {
           BSeq(
             Comp.local_assign(
+              ~loc=Location.dummy_loc,
               ~env,
               ~allocation_type=Managed,
               name,
-              Imm.id(value),
+              Imm.id(~loc=Location.dummy_loc, value),
             ),
           );
         },
@@ -780,14 +789,16 @@ module MatchTreeCompiler = {
           let assign = id =>
             if (mut_boxing) {
               Comp.assign(
+                ~loc=Location.dummy_loc,
                 ~env,
                 ~allocation_type=
                   get_allocation_type(pat.pat_env, pat.pat_type),
-                Imm.id(id),
+                Imm.id(~loc=Location.dummy_loc, id),
                 value,
               );
             } else {
               Comp.local_assign(
+                ~loc=Location.dummy_loc,
                 ~env,
                 ~allocation_type=
                   get_allocation_type(pat.pat_env, pat.pat_type),
@@ -833,8 +844,12 @@ module MatchTreeCompiler = {
       let env = expr.imm_env;
       (
         Comp.imm(
+          ~loc=Location.dummy_loc,
           ~allocation_type=Unmanaged(WasmI32),
-          Imm.const(Const_number(Const_number_int(Int64.of_int(i)))),
+          Imm.const(
+            ~loc=Location.dummy_loc,
+            Const_number(Const_number_int(Int64.of_int(i))),
+          ),
         ),
         get_bindings(~mut_boxing, env, patterns, values, aliases),
       );
@@ -880,6 +895,7 @@ module MatchTreeCompiler = {
         );
       (
         Comp.if_(
+          ~loc=Location.dummy_loc,
           ~allocation_type=true_comp.comp_allocation_type,
           cond,
           fold_tree(true_setup, true_comp),
@@ -919,10 +935,14 @@ module MatchTreeCompiler = {
       let (const, const_setup) =
         switch (helpConst(const)) {
         | Left(imm) => (imm, [])
-        | Right((name, binds)) => (Imm.id(name), binds)
+        | Right((name, binds)) => (
+            Imm.id(~loc=Location.dummy_loc, name),
+            binds,
+          )
         };
       let cond =
         Comp.prim2(
+          ~loc=Location.dummy_loc,
           ~allocation_type=Unmanaged(WasmI32),
           equality_op,
           cur_value,
@@ -957,21 +977,30 @@ module MatchTreeCompiler = {
       let alias_binding =
         BLet(
           alias,
-          Comp.imm(~allocation_type=Managed, cur_value),
+          Comp.imm(
+            ~loc=Location.dummy_loc,
+            ~allocation_type=Managed,
+            cur_value,
+          ),
           Nonglobal,
         );
 
       (
         Comp.if_(
+          ~loc=Location.dummy_loc,
           ~allocation_type=true_comp.comp_allocation_type,
-          Imm.id(cond_id),
+          Imm.id(~loc=Location.dummy_loc, cond_id),
           fold_tree(true_setup, true_comp),
           fold_tree(false_setup, false_comp),
         ),
         [alias_binding, ...cond_setup],
       );
     | Fail => (
-        Comp.imm(~allocation_type=Unmanaged(WasmI32), Imm.trap()),
+        Comp.imm(
+          ~loc=Location.dummy_loc,
+          ~allocation_type=Unmanaged(WasmI32),
+          Imm.trap(~loc=Location.dummy_loc, ()),
+        ),
         [],
       )
     | Explode(matrix_type, alias, rest) =>
@@ -992,6 +1021,7 @@ module MatchTreeCompiler = {
               BLet(
                 id,
                 Comp.adt_get(
+                  ~loc=Location.dummy_loc,
                   ~allocation_type=Managed,
                   Int32.of_int(idx),
                   cur_value,
@@ -1010,6 +1040,7 @@ module MatchTreeCompiler = {
               BLet(
                 id,
                 Comp.tuple_get(
+                  ~loc=Location.dummy_loc,
                   ~allocation_type=Managed,
                   Int32.of_int(idx),
                   cur_value,
@@ -1026,8 +1057,10 @@ module MatchTreeCompiler = {
               BLet(
                 id,
                 Comp.array_get(
+                  ~loc=Location.dummy_loc,
                   ~allocation_type=Managed,
                   Imm.const(
+                    ~loc=Location.dummy_loc,
                     Const_number(Const_number_int(Int64.of_int(idx))),
                   ),
                   cur_value,
@@ -1045,6 +1078,7 @@ module MatchTreeCompiler = {
               BLet(
                 id,
                 Comp.record_get(
+                  ~loc=Location.dummy_loc,
                   ~allocation_type=Managed,
                   Int32.of_int(label_pos),
                   cur_value,
@@ -1061,7 +1095,7 @@ module MatchTreeCompiler = {
       let new_values =
         List.map(
           fun
-          | BLet(id, _, _) => Imm.id(id)
+          | BLet(id, _, _) => Imm.id(~loc=Location.dummy_loc, id)
           | _ =>
             failwith(
               "Impossible: matchcomp: compile_tree_help: binding was not BLet",
@@ -1074,7 +1108,11 @@ module MatchTreeCompiler = {
       let bindings = [
         BLet(
           alias,
-          Comp.imm(~allocation_type=Managed, cur_value),
+          Comp.imm(
+            ~loc=Location.dummy_loc,
+            ~allocation_type=Managed,
+            cur_value,
+          ),
           Nonglobal,
         ),
         ...bindings,
@@ -1124,12 +1162,15 @@ module MatchTreeCompiler = {
           helpConst,
         );
       let value_constr_name = Ident.create("match_constructor");
-      let value_constr_id = Imm.id(value_constr_name);
+      let value_constr_id =
+        Imm.id(~loc=Location.dummy_loc, value_constr_name);
       let value_constr =
         switch (switch_type) {
-        | ConstructorSwitch => Comp.adt_get_tag(cur_value)
+        | ConstructorSwitch =>
+          Comp.adt_get_tag(~loc=Location.dummy_loc, cur_value)
         | ArraySwitch =>
           Comp.prim1(
+            ~loc=Location.dummy_loc,
             ~allocation_type=Unmanaged(WasmI32),
             ArrayLength,
             cur_value,
@@ -1141,17 +1182,19 @@ module MatchTreeCompiler = {
         List.fold_left(
           ((body_ans, body_setup), (tag, tree)) => {
             let cmp_id_name = Ident.create("match_cmp_constructors");
-            let cmp_id = Imm.id(cmp_id_name);
+            let cmp_id = Imm.id(~loc=Location.dummy_loc, cmp_id_name);
             /* If the constructor has the correct tag, execute this branch.
                Otherwise continue. */
             let setup = [
               BLet(
                 cmp_id_name,
                 Comp.prim2(
+                  ~loc=Location.dummy_loc,
                   ~allocation_type=Unmanaged(WasmI32),
                   Is,
                   value_constr_id,
                   Imm.const(
+                    ~loc=Location.dummy_loc,
                     Const_number(Const_number_int(Int64.of_int(tag))),
                   ),
                 ),
@@ -1171,6 +1214,7 @@ module MatchTreeCompiler = {
               );
             let ans =
               Comp.if_(
+                ~loc=Location.dummy_loc,
                 ~allocation_type=tree_ans.comp_allocation_type,
                 cmp_id,
                 fold_tree(tree_setup, tree_ans),
@@ -1199,19 +1243,32 @@ module MatchTreeCompiler = {
         let dummy_value =
           switch (allocation_type) {
           | Managed
-          | Unmanaged(WasmI32) => Imm.const(Const_wasmi32(0l))
-          | Unmanaged(WasmI64) => Imm.const(Const_wasmi64(0L))
-          | Unmanaged(WasmF32) => Imm.const(Const_wasmf32(0.))
-          | Unmanaged(WasmF64) => Imm.const(Const_wasmf64(0.))
+          | Unmanaged(WasmI32) =>
+            Imm.const(~loc=Location.dummy_loc, Const_wasmi32(0l))
+          | Unmanaged(WasmI64) =>
+            Imm.const(~loc=Location.dummy_loc, Const_wasmi64(0L))
+          | Unmanaged(WasmF32) =>
+            Imm.const(~loc=Location.dummy_loc, Const_wasmf32(0.))
+          | Unmanaged(WasmF64) =>
+            Imm.const(~loc=Location.dummy_loc, Const_wasmf64(0.))
           };
         if (mut_boxing) {
           BLetMut(
             id,
-            Comp.prim1(~allocation_type=Managed, BoxBind, dummy_value),
+            Comp.prim1(
+              ~loc=Location.dummy_loc,
+              ~allocation_type=Managed,
+              BoxBind,
+              dummy_value,
+            ),
             Nonglobal,
           );
         } else {
-          BLetMut(id, Comp.imm(~allocation_type, dummy_value), global);
+          BLetMut(
+            id,
+            Comp.imm(~loc=Location.dummy_loc, ~allocation_type, dummy_value),
+            global,
+          );
         };
       };
       switch (pat.pat_desc) {
@@ -1266,8 +1323,9 @@ module MatchTreeCompiler = {
       );
     (
       Comp.switch_(
+        ~loc=Location.dummy_loc,
         ~allocation_type,
-        Imm.id(jmp_name),
+        Imm.id(~loc=Location.dummy_loc, jmp_name),
         switch_branches,
         partial,
       ),

--- a/compiler/test/suites/optimizations.re
+++ b/compiler/test/suites/optimizations.re
@@ -3,6 +3,7 @@ open Grain_tests.Runner;
 open Grain_middle_end.Anftree;
 open Grain_middle_end.Anf_helper;
 open Grain_utils;
+open Grain_parsing;
 
 describe("optimizations", ({test, testSkip}) => {
   let test_or_skip =
@@ -75,9 +76,14 @@ describe("optimizations", ({test, testSkip}) => {
     "test_dead_branch_elimination_1",
     "{ if (true) {4} else {5} }",
     AExp.comp(
+      ~loc=Location.dummy_loc,
       Comp.imm(
+        ~loc=Location.dummy_loc,
         ~allocation_type=Managed,
-        Imm.const(Const_number(Const_number_int(4L))),
+        Imm.const(
+          ~loc=Location.dummy_loc,
+          Const_number(Const_number_int(4L)),
+        ),
       ),
     ),
   );
@@ -85,9 +91,14 @@ describe("optimizations", ({test, testSkip}) => {
     "test_dead_branch_elimination_2",
     "{ if (false) {4} else {5} }",
     AExp.comp(
+      ~loc=Location.dummy_loc,
       Comp.imm(
+        ~loc=Location.dummy_loc,
         ~allocation_type=Managed,
-        Imm.const(Const_number(Const_number_int(5L))),
+        Imm.const(
+          ~loc=Location.dummy_loc,
+          Const_number(Const_number_int(5L)),
+        ),
       ),
     ),
   );
@@ -95,9 +106,14 @@ describe("optimizations", ({test, testSkip}) => {
     "test_dead_branch_elimination_3",
     "{ let x = true; if (x) {4} else {5} }",
     AExp.comp(
+      ~loc=Location.dummy_loc,
       Comp.imm(
+        ~loc=Location.dummy_loc,
         ~allocation_type=Managed,
-        Imm.const(Const_number(Const_number_int(4L))),
+        Imm.const(
+          ~loc=Location.dummy_loc,
+          Const_number(Const_number_int(4L)),
+        ),
       ),
     ),
   );
@@ -105,9 +121,14 @@ describe("optimizations", ({test, testSkip}) => {
     "test_dead_branch_elimination_4",
     "{let x = if (true) {4} else {5}; x}",
     AExp.comp(
+      ~loc=Location.dummy_loc,
       Comp.imm(
+        ~loc=Location.dummy_loc,
         ~allocation_type=Managed,
-        Imm.const(Const_number(Const_number_int(4L))),
+        Imm.const(
+          ~loc=Location.dummy_loc,
+          Const_number(Const_number_int(4L)),
+        ),
       ),
     ),
   );
@@ -120,9 +141,14 @@ describe("optimizations", ({test, testSkip}) => {
     "test_const_propagation",
     "{\n    let x = 4;\n    let y = x;\n    x}",
     AExp.comp(
+      ~loc=Location.dummy_loc,
       Comp.imm(
+        ~loc=Location.dummy_loc,
         ~allocation_type=Managed,
-        Imm.const(Const_number(Const_number_int(4L))),
+        Imm.const(
+          ~loc=Location.dummy_loc,
+          Const_number(Const_number_int(4L)),
+        ),
       ),
     ),
   );
@@ -134,13 +160,20 @@ describe("optimizations", ({test, testSkip}) => {
       open Grain_typed;
       let x = Ident.create("lambda_arg");
       AExp.comp(
+        ~loc=Location.dummy_loc,
         Comp.lambda(
+          ~loc=Location.dummy_loc,
           [(x, Managed)],
           (
             AExp.comp(
+              ~loc=Location.dummy_loc,
               Comp.imm(
+                ~loc=Location.dummy_loc,
                 ~allocation_type=Managed,
-                Imm.const(Const_number(Const_number_int(4L))),
+                Imm.const(
+                  ~loc=Location.dummy_loc,
+                  Const_number(Const_number_int(4L)),
+                ),
               ),
             ),
             Managed,
@@ -155,13 +188,24 @@ describe("optimizations", ({test, testSkip}) => {
     "{\n  let x = 5;\n  let y = 12;\n  let z = y;\n  {\n    let y = x;\n    x\n  }\n  x + y}",
     Grain_typed.(
       AExp.comp(
+        ~loc=Location.dummy_loc,
         Comp.app(
+          ~loc=Location.dummy_loc,
           ~tail=true,
           ~allocation_type=Managed,
-          (Imm.id(Ident.create("+")), ([Managed, Managed], Managed)),
+          (
+            Imm.id(~loc=Location.dummy_loc, Ident.create("+")),
+            ([Managed, Managed], Managed),
+          ),
           [
-            Imm.const(Const_number(Const_number_int(5L))),
-            Imm.const(Const_number(Const_number_int(12L))),
+            Imm.const(
+              ~loc=Location.dummy_loc,
+              Const_number(Const_number_int(5L)),
+            ),
+            Imm.const(
+              ~loc=Location.dummy_loc,
+              Const_number(Const_number_int(12L)),
+            ),
           ],
         ),
       )
@@ -174,13 +218,22 @@ describe("optimizations", ({test, testSkip}) => {
       open Grain_typed;
       let arg = Ident.create("lambda_arg");
       AExp.comp(
-        Comp.lambda([(arg, Managed)]) @@
+        ~loc=Location.dummy_loc,
+        Comp.lambda(~loc=Location.dummy_loc, [(arg, Managed)]) @@
         (
-          AExp.comp @@
-          Comp.tuple([
-            Imm.id(arg),
-            Imm.const(Const_number(Const_number_int(1L))),
-          ]),
+          AExp.comp(
+            ~loc=Location.dummy_loc,
+            Comp.tuple(
+              ~loc=Location.dummy_loc,
+              [
+                Imm.id(~loc=Location.dummy_loc, arg),
+                Imm.const(
+                  ~loc=Location.dummy_loc,
+                  Const_number(Const_number_int(1L)),
+                ),
+              ],
+            ),
+          ),
           Managed,
         ),
       );
@@ -193,13 +246,20 @@ describe("optimizations", ({test, testSkip}) => {
       open Grain_typed;
       let x = Ident.create("lambda_arg");
       AExp.comp(
+        ~loc=Location.dummy_loc,
         Comp.lambda(
+          ~loc=Location.dummy_loc,
           [(x, Managed)],
           (
             AExp.comp(
+              ~loc=Location.dummy_loc,
               Comp.imm(
+                ~loc=Location.dummy_loc,
                 ~allocation_type=Managed,
-                Imm.const(Const_number(Const_number_int(1L))),
+                Imm.const(
+                  ~loc=Location.dummy_loc,
+                  Const_number(Const_number_int(1L)),
+                ),
               ),
             ),
             Managed,
@@ -216,33 +276,45 @@ describe("optimizations", ({test, testSkip}) => {
       let foo = Ident.create("foo");
       let x = Ident.create("x");
       AExp.let_(
+        ~loc=Location.dummy_loc,
         Nonrecursive,
         ~global=Global,
         [
           (
             foo,
             Comp.lambda(
+              ~loc=Location.dummy_loc,
               ~name="foo",
               [],
               (
                 AExp.let_(
+                  ~loc=Location.dummy_loc,
                   Nonrecursive,
                   ~mut_flag=Mutable,
                   [
                     (
                       x,
                       Comp.imm(
+                        ~loc=Location.dummy_loc,
                         ~allocation_type=Managed,
-                        Imm.const(Const_number(Const_number_int(5L))),
+                        Imm.const(
+                          ~loc=Location.dummy_loc,
+                          Const_number(Const_number_int(5L)),
+                        ),
                       ),
                     ),
                   ],
                 ) @@
                 AExp.comp(
+                  ~loc=Location.dummy_loc,
                   Comp.local_assign(
+                    ~loc=Location.dummy_loc,
                     ~allocation_type=Unmanaged(WasmI32),
                     x,
-                    Imm.const(Const_number(Const_number_int(6L))),
+                    Imm.const(
+                      ~loc=Location.dummy_loc,
+                      Const_number(Const_number_int(6L)),
+                    ),
                   ),
                 ),
                 Unmanaged(WasmI32),
@@ -251,9 +323,11 @@ describe("optimizations", ({test, testSkip}) => {
           ),
         ],
         AExp.comp(
+          ~loc=Location.dummy_loc,
           Comp.imm(
+            ~loc=Location.dummy_loc,
             ~allocation_type=Unmanaged(WasmI32),
-            Imm.const(Const_void),
+            Imm.const(~loc=Location.dummy_loc, Const_void),
           ),
         ),
       );
@@ -268,41 +342,52 @@ describe("optimizations", ({test, testSkip}) => {
       let bar = Ident.create("bar");
       let foo = Ident.create("foo");
       AExp.let_(
+        ~loc=Location.dummy_loc,
         Nonrecursive,
         ~global=Global,
         [
           (
             bar,
             Comp.lambda(
+              ~loc=Location.dummy_loc,
               ~name="bar",
               [],
               (
                 AExp.let_(
+                  ~loc=Location.dummy_loc,
                   Nonrecursive,
                   [
                     (
                       x,
                       Comp.prim1(
+                        ~loc=Location.dummy_loc,
                         ~allocation_type=Managed,
                         BoxBind,
-                        Imm.const(Const_number(Const_number_int(5L))),
+                        Imm.const(
+                          ~loc=Location.dummy_loc,
+                          Const_number(Const_number_int(5L)),
+                        ),
                       ),
                     ),
                   ],
                 ) @@
                 AExp.let_(
+                  ~loc=Location.dummy_loc,
                   Nonrecursive,
                   [
                     (
                       foo,
                       Comp.lambda(
+                        ~loc=Location.dummy_loc,
                         [],
                         (
                           AExp.comp(
+                            ~loc=Location.dummy_loc,
                             Comp.prim1(
+                              ~loc=Location.dummy_loc,
                               ~allocation_type=Managed,
                               UnboxBind,
-                              Imm.id(x),
+                              Imm.id(~loc=Location.dummy_loc, x),
                             ),
                           ),
                           Managed,
@@ -312,10 +397,12 @@ describe("optimizations", ({test, testSkip}) => {
                   ],
                 ) @@
                 AExp.comp(
+                  ~loc=Location.dummy_loc,
                   Comp.app(
+                    ~loc=Location.dummy_loc,
                     ~tail=true,
                     ~allocation_type=Managed,
-                    (Imm.id(foo), ([], Managed)),
+                    (Imm.id(~loc=Location.dummy_loc, foo), ([], Managed)),
                     [],
                   ),
                 ),
@@ -325,9 +412,11 @@ describe("optimizations", ({test, testSkip}) => {
           ),
         ],
         AExp.comp(
+          ~loc=Location.dummy_loc,
           Comp.imm(
+            ~loc=Location.dummy_loc,
             ~allocation_type=Unmanaged(WasmI32),
-            Imm.const(Const_void),
+            Imm.const(~loc=Location.dummy_loc, Const_void),
           ),
         ),
       );
@@ -344,37 +433,57 @@ describe("optimizations", ({test, testSkip}) => {
       let arg = Ident.create("lambda_arg");
       let app = Ident.create("app");
       AExp.let_(
+        ~loc=Location.dummy_loc,
         Nonrecursive,
         [
           (
             foo,
-            Comp.lambda([(arg, Managed)]) @@
+            Comp.lambda(~loc=Location.dummy_loc, [(arg, Managed)]) @@
             (
-              AExp.comp @@ Comp.imm(~allocation_type=Managed) @@ Imm.id(arg),
+              AExp.comp(~loc=Location.dummy_loc) @@
+              Comp.imm(~loc=Location.dummy_loc, ~allocation_type=Managed) @@
+              Imm.id(~loc=Location.dummy_loc, arg),
               Managed,
             ),
           ),
         ],
       ) @@
       AExp.let_(
+        ~loc=Location.dummy_loc,
         Nonrecursive,
         [
           (
             app,
             Comp.app(
+              ~loc=Location.dummy_loc,
               ~allocation_type=Managed,
-              (Imm.id(foo), ([Managed], Managed)),
-              [Imm.const(Const_number(Const_number_int(3L)))],
+              (Imm.id(~loc=Location.dummy_loc, foo), ([Managed], Managed)),
+              [
+                Imm.const(
+                  ~loc=Location.dummy_loc,
+                  Const_number(Const_number_int(3L)),
+                ),
+              ],
             ),
           ),
         ],
       ) @@
-      AExp.comp @@
+      AExp.comp(~loc=Location.dummy_loc) @@
       Comp.app(
+        ~loc=Location.dummy_loc,
         ~allocation_type=Managed,
         ~tail=true,
-        (Imm.id(plus), ([Managed, Managed], Managed)),
-        [Imm.id(app), Imm.const(Const_number(Const_number_int(5L)))],
+        (
+          Imm.id(~loc=Location.dummy_loc, plus),
+          ([Managed, Managed], Managed),
+        ),
+        [
+          Imm.id(~loc=Location.dummy_loc, app),
+          Imm.const(
+            ~loc=Location.dummy_loc,
+            Const_number(Const_number_int(5L)),
+          ),
+        ],
       );
     },
   );
@@ -433,12 +542,14 @@ describe("optimizations", ({test, testSkip}) => {
       let arg = Ident.create("lambda_arg");
       let app = Ident.create("app");
       AExp.let_(
+        ~loc=Location.dummy_loc,
         ~global=Global,
         Nonrecursive,
         [
           (
             foo,
             Comp.lambda(
+              ~loc=Location.dummy_loc,
               ~name=Ident.name(foo),
               ~attributes=[
                 Grain_parsing.Location.mknoloc(Typedtree.Disable_gc),
@@ -446,23 +557,39 @@ describe("optimizations", ({test, testSkip}) => {
               [(arg, Managed), (arg, Managed), (arg, Managed)],
               (
                 AExp.let_(
+                  ~loc=Location.dummy_loc,
                   Nonrecursive,
                   [
                     (
                       app,
                       Comp.app(
+                        ~loc=Location.dummy_loc,
                         ~allocation_type=Managed,
-                        (Imm.id(plus), ([Managed, Managed], Managed)),
-                        [Imm.id(arg), Imm.id(arg)],
+                        (
+                          Imm.id(~loc=Location.dummy_loc, plus),
+                          ([Managed, Managed], Managed),
+                        ),
+                        [
+                          Imm.id(~loc=Location.dummy_loc, arg),
+                          Imm.id(~loc=Location.dummy_loc, arg),
+                        ],
                       ),
                     ),
                   ],
                   AExp.comp(
+                    ~loc=Location.dummy_loc,
                     Comp.app(
+                      ~loc=Location.dummy_loc,
                       ~allocation_type=Managed,
                       ~tail=true,
-                      (Imm.id(plus), ([Managed, Managed], Managed)),
-                      [Imm.id(app), Imm.id(arg)],
+                      (
+                        Imm.id(~loc=Location.dummy_loc, plus),
+                        ([Managed, Managed], Managed),
+                      ),
+                      [
+                        Imm.id(~loc=Location.dummy_loc, app),
+                        Imm.id(~loc=Location.dummy_loc, arg),
+                      ],
                     ),
                   ),
                 ),
@@ -473,9 +600,11 @@ describe("optimizations", ({test, testSkip}) => {
         ],
       ) @@
       AExp.comp(
+        ~loc=Location.dummy_loc,
         Comp.imm(
+          ~loc=Location.dummy_loc,
           ~allocation_type=Unmanaged(WasmI32),
-          Imm.const(Const_void),
+          Imm.const(~loc=Location.dummy_loc, Const_void),
         ),
       );
     },
@@ -499,12 +628,14 @@ describe("optimizations", ({test, testSkip}) => {
       let fill = Ident.create("fill");
       let copy = Ident.create("copy");
       AExp.let_(
+        ~loc=Location.dummy_loc,
         ~global=Global,
         Nonrecursive,
         [
           (
             foo,
             Comp.lambda(
+              ~loc=Location.dummy_loc,
               ~name=Ident.name(foo),
               ~attributes=[
                 Grain_parsing.Location.mknoloc(Typedtree.Disable_gc),
@@ -512,10 +643,12 @@ describe("optimizations", ({test, testSkip}) => {
               [],
               (
                 AExp.seq(
+                  ~loc=Location.dummy_loc,
                   Comp.app(
+                    ~loc=Location.dummy_loc,
                     ~allocation_type=Unmanaged(WasmI32),
                     (
-                      Imm.id(fill),
+                      Imm.id(~loc=Location.dummy_loc, fill),
                       (
                         [
                           Unmanaged(WasmI32),
@@ -526,17 +659,19 @@ describe("optimizations", ({test, testSkip}) => {
                       ),
                     ),
                     [
-                      Imm.const(Const_wasmi32(0l)),
-                      Imm.const(Const_wasmi32(0l)),
-                      Imm.const(Const_wasmi32(0l)),
+                      Imm.const(~loc=Location.dummy_loc, Const_wasmi32(0l)),
+                      Imm.const(~loc=Location.dummy_loc, Const_wasmi32(0l)),
+                      Imm.const(~loc=Location.dummy_loc, Const_wasmi32(0l)),
                     ],
                   ),
                   AExp.comp(
+                    ~loc=Location.dummy_loc,
                     Comp.app(
+                      ~loc=Location.dummy_loc,
                       ~tail=true,
                       ~allocation_type=Unmanaged(WasmI32),
                       (
-                        Imm.id(copy),
+                        Imm.id(~loc=Location.dummy_loc, copy),
                         (
                           [
                             Unmanaged(WasmI32),
@@ -547,9 +682,15 @@ describe("optimizations", ({test, testSkip}) => {
                         ),
                       ),
                       [
-                        Imm.const(Const_wasmi32(0l)),
-                        Imm.const(Const_wasmi32(0l)),
-                        Imm.const(Const_wasmi32(0l)),
+                        Imm.const(~loc=Location.dummy_loc, Const_wasmi32(0l)),
+                        Imm.const(
+                          ~loc=Location.dummy_loc,
+                          Const_wasmi32(0l),
+                        ),
+                        Imm.const(
+                          ~loc=Location.dummy_loc,
+                          Const_wasmi32(0l),
+                        ),
                       ],
                     ),
                   ),
@@ -561,9 +702,11 @@ describe("optimizations", ({test, testSkip}) => {
         ],
       ) @@
       AExp.comp(
+        ~loc=Location.dummy_loc,
         Comp.imm(
+          ~loc=Location.dummy_loc,
           ~allocation_type=Unmanaged(WasmI32),
-          Imm.const(Const_void),
+          Imm.const(~loc=Location.dummy_loc, Const_void),
         ),
       );
     },
@@ -583,12 +726,14 @@ describe("optimizations", ({test, testSkip}) => {
       open Grain_typed;
       let foo = Ident.create("foo");
       AExp.let_(
+        ~loc=Location.dummy_loc,
         ~global=Global,
         Nonrecursive,
         [
           (
             foo,
             Comp.lambda(
+              ~loc=Location.dummy_loc,
               ~name=Ident.name(foo),
               ~attributes=[
                 Grain_parsing.Location.mknoloc(Typedtree.Disable_gc),
@@ -596,23 +741,33 @@ describe("optimizations", ({test, testSkip}) => {
               [],
               (
                 AExp.seq(
+                  ~loc=Location.dummy_loc,
                   Comp.primn(
+                    ~loc=Location.dummy_loc,
                     ~allocation_type=Unmanaged(WasmI32),
                     WasmMemoryFill,
                     [
-                      Imm.const(Const_wasmi32(0l)),
-                      Imm.const(Const_wasmi32(0l)),
-                      Imm.const(Const_wasmi32(0l)),
+                      Imm.const(~loc=Location.dummy_loc, Const_wasmi32(0l)),
+                      Imm.const(~loc=Location.dummy_loc, Const_wasmi32(0l)),
+                      Imm.const(~loc=Location.dummy_loc, Const_wasmi32(0l)),
                     ],
                   ),
                   AExp.comp(
+                    ~loc=Location.dummy_loc,
                     Comp.primn(
+                      ~loc=Location.dummy_loc,
                       ~allocation_type=Unmanaged(WasmI32),
                       WasmMemoryCopy,
                       [
-                        Imm.const(Const_wasmi32(0l)),
-                        Imm.const(Const_wasmi32(0l)),
-                        Imm.const(Const_wasmi32(0l)),
+                        Imm.const(~loc=Location.dummy_loc, Const_wasmi32(0l)),
+                        Imm.const(
+                          ~loc=Location.dummy_loc,
+                          Const_wasmi32(0l),
+                        ),
+                        Imm.const(
+                          ~loc=Location.dummy_loc,
+                          Const_wasmi32(0l),
+                        ),
                       ],
                     ),
                   ),
@@ -624,9 +779,11 @@ describe("optimizations", ({test, testSkip}) => {
         ],
       ) @@
       AExp.comp(
+        ~loc=Location.dummy_loc,
         Comp.imm(
+          ~loc=Location.dummy_loc,
           ~allocation_type=Unmanaged(WasmI32),
-          Imm.const(Const_void),
+          Imm.const(~loc=Location.dummy_loc, Const_void),
         ),
       );
     },


### PR DESCRIPTION
This pr makes locations non optional on `anf_helper`.


I think after this is merged we might want to open an issue to go through and evaluate the use of `Location.dummy_loc` throughout the compiler.