### PR TITLE
chore(stdlib): Improve examples in `Array` module

### DIFF
--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -4,7 +4,7 @@
  * An immutable array implementation is available in the `Immutable` submodule.
  *
  * @example include "array"
- * @example [> 1, 2, 3 ]
+ * @example [> 1, 2, 3]
  *
  * @since v0.2.0
  * @history v0.1.0: Originally named `arrays`
@@ -152,7 +152,7 @@ provide let init: (Number, Number => a) => Array<a> =
  * @throws IndexOutOfBounds: When `index` is not an integer
  * @throws IndexOutOfBounds: When `index` is out of bounds
  *
- * @example Array.get(1,[> 1, 2, 3, 4, 5]) == 2
+ * @example Array.get(1, [> 1, 2, 3, 4, 5]) == 2
  *
  * @since v0.1.0
  * @history v0.2.0: Argument order changed to data-last
@@ -174,7 +174,10 @@ provide let get = (index, array) => {
  * @throws IndexOutOfBounds: When `index` is not an integer
  * @throws IndexOutOfBounds: When `index` is out of bounds
  *
- * @example Array.set(1, 9, [> 1, 2, 3, 4, 5]) == [> 1, 9, 3, 4, 5]
+ * @example
+ * let array = [> 1, 2, 3, 4, 5]
+ * Array.set(1, 9, array)
+ * assert array == [> 1, 9, 3, 4, 5]
  *
  * @since v0.1.0
  * @history v0.2.0: Argument order changed to data-last
@@ -263,7 +266,7 @@ provide let concat = arrays => {
  * @param array: The array to copy
  * @returns The new array containing the elements from the input
  *
- * @example Array.copy([> 1, 2, 3 ]) == [> 1, 2, 3 ]
+ * @example Array.copy([> 1, 2, 3]) == [> 1, 2, 3]
  *
  * @since v0.1.0
  */
@@ -345,7 +348,7 @@ provide let forEachi = (fn, array) => {
  * @param array: The array to iterate
  * @returns The new array with mapped values
  *
- * @example Array.map(x => x * 2, [> 1, 2, 3]) == [> 2, 4, 6 ]
+ * @example Array.map(x => x * 2, [> 1, 2, 3]) == [> 2, 4, 6]
  *
  * @since v0.1.0
  * @history v0.2.0: Argument order changed to data-last
@@ -365,7 +368,7 @@ provide let map = (fn, array) => {
  * @param array: The array to iterate
  * @returns The new array with mapped values
  *
- * @example Array.mapi((x, i) => (x * 2, i), [> 1, 2, 3]) == [> (2, 0), (4, 1), (6, 2) ]
+ * @example Array.mapi((x, i) => (x * 2, i), [> 1, 2, 3]) == [> (2, 0), (4, 1), (6, 2)]
  *
  * @since v0.1.0
  */
@@ -415,7 +418,7 @@ provide let reduce = (fn, initial, array) => {
  * @param array: The array to iterate
  * @returns The final accumulator returned from `fn`
  *
- * @example Array.reduceRight((el, acc) => acc ++ el, "", [> "baz", "bar", "foo"]) == "bazbarfoo"
+ * @example Array.reduceRight((el, acc) => acc ++ el, "", [> "baz", "bar", "foo"]) == "foobarbaz"
  *
  * @since v0.5.3
  */
@@ -469,7 +472,7 @@ provide let reducei = (fn, initial, array) => {
  *
  * @throws InvalidArgument(String): When the combined length of all arrays is not an integer
  *
- * @example Array.flatMap(e => [> 1], [> 1, 2, 3]) == [> 1, 1, 1 ]
+ * @example Array.flatMap(e => [> 1, e], [> 1, 2, 3]) == [> 1, 1, 1, 2, 1, 3]
  *
  * @since v0.3.0
  */
@@ -497,8 +500,8 @@ provide let flatMap = (fn, array) => {
  * @param array: The array to check
  * @returns `true` if all elements satisfy the condition or `false` otherwise
  *
- * @example Array.every(e => e % 2 == 0, [> 2, 4, 6 ]) == true
- * @example Array.every(e => e % 2 == 0, [> 2, 4, 7 ]) == false
+ * @example Array.every(e => e % 2 == 0, [> 2, 4, 6]) == true
+ * @example Array.every(e => e % 2 == 0, [> 2, 4, 7]) == false
  *
  * @since v0.3.0
  */
@@ -519,9 +522,9 @@ provide let every = (fn, array) => {
  * @param array: The array to iterate
  * @returns `true` if one or more elements satisfy the condition or `false` otherwise
  *
- * @example Array.some(e => e % 2 == 0, [> 2, 4, 6 ]) == true
- * @example Array.some(e => e % 2 == 0, [> 2, 4, 7 ]) == true
- * @example Array.some(e => e % 2 == 0, [> 3, 5, 7 ]) == false
+ * @example Array.some(e => e % 2 == 0, [> 2, 4, 6]) == true
+ * @example Array.some(e => e % 2 == 0, [> 2, 4, 7]) == true
+ * @example Array.some(e => e % 2 == 0, [> 3, 5, 7]) == false
  *
  * @since v0.3.0
  */
@@ -541,9 +544,9 @@ provide let some = (fn, array) => {
  * @param array: The array to update
  *
  * @example
- * let arr = [> 2, 4, 6 ]
+ * let arr = [> 2, 4, 6]
  * Array.fill(0, arr)
- * assert arr == [> 0, 0, 0 ]
+ * assert arr == [> 0, 0, 0]
  *
  * @since v0.2.0
  */
@@ -568,9 +571,9 @@ provide let fill = (value, array) => {
  * @throws IndexOutOfBounds: When the start index is greater then the stop index
  *
  * @example
- * let arr = [> 2, 4, 6, 8 ]
+ * let arr = [> 2, 4, 6, 8]
  * Array.fillRange(0, 1, 3, arr)
- * assert arr == [> 2, 0, 0, 8 ]
+ * assert arr == [> 2, 0, 0, 8]
  *
  * @since v0.2.0
  */
@@ -601,7 +604,7 @@ provide let fillRange = (value, start, stop, array) => {
  * @param array: The array to reverse
  * @returns The new array
  *
- * @example Array.reverse([> 1, 2, 3 ]) == [> 3, 2, 1 ]
+ * @example Array.reverse([> 1, 2, 3]) == [> 3, 2, 1]
  *
  * @since v0.4.0
  */
@@ -619,7 +622,7 @@ provide let reverse = array => {
  * @param array: The array to convert
  * @returns The list containing all elements from the array
  *
- * @example Array.toList([> 1, 2, 3 ]) == [ 1, 2, 3 ]
+ * @example Array.toList([> 1, 2, 3]) == [1, 2, 3]
  *
  * @since v0.1.0
  */
@@ -641,7 +644,7 @@ provide let toList = array => {
  * @param list: The list to convert
  * @returns The array containing all elements from the list
  *
- * @example Array.fromList([ 1, 2, 3 ]) == [> 1, 2, 3 ]
+ * @example Array.fromList([1, 2, 3]) == [> 1, 2, 3]
  *
  * @since v0.1.0
  */
@@ -674,8 +677,8 @@ provide let fromList = list => {
  * @param array: The array to inspect
  * @returns `true` if the value exists in the array or `false` otherwise
  *
- * @example Array.contains(1, [> 1, 2, 3 ]) == true
- * @example Array.contains(0, [> 1, 2, 3 ]) == false
+ * @example Array.contains(1, [> 1, 2, 3]) == true
+ * @example Array.contains(0, [> 1, 2, 3]) == false
  *
  * @since v0.2.0
  */
@@ -695,9 +698,9 @@ provide let contains = (search, array) => {
  * @param array: The array to search
  * @returns `Some(element)` containing the first value found or `None` otherwise
  *
- * @example Array.find((e) => e % 2 == 0, [> 1, 4, 3 ]) == Some(4)
- * @example Array.find((e) => e % 2 == 0, [> 1, 2, 3, 4 ]) == Some(2)
- * @example Array.find((e) => e % 2 == 0, [> 1, 3, 5 ]) == None
+ * @example Array.find(e => e % 2 == 0, [> 1, 4, 3]) == Some(4)
+ * @example Array.find(e => e % 2 == 0, [> 1, 2, 3, 4]) == Some(2)
+ * @example Array.find(e => e % 2 == 0, [> 1, 3, 5]) == None
  *
  * @since v0.2.0
  */
@@ -718,9 +721,9 @@ provide let find = (fn, array) => {
  * @param array: The array to search
  * @returns `Some(index)` containing the index of the first element found or `None` otherwise
  *
- * @example Array.findIndex((e) => e % 2 == 0, [> 1, 4, 3 ]) == Some(1)
- * @example Array.findIndex((e) => e % 2 == 0, [> 1, 2, 3, 4 ]) == Some(1)
- * @example Array.findIndex((e) => e % 2 == 0, [> 1, 3, 5 ]) == None
+ * @example Array.findIndex(e => e % 2 == 0, [> 1, 4, 3]) == Some(1)
+ * @example Array.findIndex(e => e % 2 == 0, [> 1, 2, 3, 4]) == Some(1)
+ * @example Array.findIndex(e => e % 2 == 0, [> 1, 3, 5]) == None
  *
  * @since v0.2.0
  */
@@ -766,7 +769,7 @@ provide let product = (array1: Array<a>, array2: Array<b>) => {
  * @param array: The array to iterate
  * @returns The total number of elements that satisfy the condition
  *
- * @example Array.count(e => e % 2 == 0, [> 1, 2, 3, 4 ]) == 2
+ * @example Array.count(e => e % 2 == 0, [> 1, 2, 3, 4]) == 2
  *
  * @since v0.2.0
  */
@@ -789,8 +792,8 @@ provide let count = (fn, array) => {
  * @param array: The array to iterate
  * @returns The total number of elements that satisfy the condition
  *
- * @example Array.counti((e, i) => e % 2 == 0 && i % 2 == 0, [> 1, 2, 3, 4, 5 ]) == 0
- * @example Array.counti((e, i) => e % 2 == 0 && i % 2 == 0, [> 0, 1, 2, 3, 5 ]) == 1
+ * @example Array.counti((e, i) => e % 2 == 0 && i % 2 == 0, [> 1, 2, 3, 4, 5]) == 0
+ * @example Array.counti((e, i) => e % 2 == 0 && i % 2 == 0, [> 0, 1, 2, 3, 5]) == 2
  *
  * @since v0.3.0
  */
@@ -814,7 +817,7 @@ provide let counti = (fn, array) => {
  * @param array: The array to iterate
  * @returns The new array containing elements where `fn` returned `true`
  *
- * @example Array.filter(e => e % 2 == 0, [> 1, 2, 3, 4 ]) == [> 2, 4 ]
+ * @example Array.filter(e => e % 2 == 0, [> 1, 2, 3, 4]) == [> 2, 4]
  *
  * @since v0.3.0
  */
@@ -841,8 +844,8 @@ provide let filter = (fn, array) => {
  * @param array: The array to iterate
  * @returns The new array containing elements where `fn` returned `true`
  *
- * @example Array.filteri((e, i) => e % 2 == 0, [> 1, 2, 3, 4 ]) == [> 2, 4 ]
- * @example Array.filteri((e, i) => e % 2 == 1 && i % 2 == 0, [> 1, 2, 3, 4, 5 ]) == [> 1, 3, 5 ]
+ * @example Array.filteri((e, i) => e % 2 == 0, [> 1, 2, 3, 4]) == [> 2, 4]
+ * @example Array.filteri((e, i) => e % 2 == 1 && i % 2 == 0, [> 1, 2, 3, 4, 5]) == [> 1, 3, 5]
  *
  * @since v0.3.0
  */
@@ -867,7 +870,7 @@ provide let filteri = (fn, array) => {
  * @param array: The array to filter
  * @returns The new array with only unique values
  *
- * @example Array.unique([> 1, 2, 1, 2, 3, 1 ]) == [> 1, 2, 3 ]
+ * @example Array.unique([> 1, 2, 1, 2, 3, 1]) == [> 1, 2, 3]
  *
  * @since v0.3.0
  */
@@ -888,7 +891,7 @@ provide let unique = array => {
  *
  * @throws IndexOutOfBounds: When the arrays have different sizes
  *
- * @example Array.zip([> 1, 2, 3], [> 4, 5, 6]) // [> (1, 4), (2, 5), (3, 6)]
+ * @example Array.zip([> 1, 2, 3], [> 4, 5, 6]) == [> (1, 4), (2, 5), (3, 6)]
  *
  * @since v0.4.0
  * @history v0.6.0: Support zipping arrays of different sizes
@@ -919,8 +922,8 @@ provide let zip = (array1: Array<a>, array2: Array<b>) => {
  *
  * @throws IndexOutOfBounds: When the arrays have different sizes
  *
- * @example Array.zipWith((a, b) => a + b, [> 1, 2, 3], [> 4, 5, 6]) // [> 5, 7, 9]
- * @example Array.zipWith((a, b) => a * b, [> 1, 2, 3], [> 4, 5]) // [> 4, 10]
+ * @example Array.zipWith((a, b) => a + b, [> 1, 2, 3], [> 4, 5, 6]) == [> 5, 7, 9]
+ * @example Array.zipWith((a, b) => a * b, [> 1, 2, 3], [> 4, 5]) == [> 4, 10]
  *
  * @since v0.5.3
  */
@@ -995,8 +998,8 @@ provide let join = (separator: String, items: Array<String>) => {
  * @param array: The array to be sliced
  * @returns The subset of the array that was sliced
  *
- * @example Array.slice(1, end=3, [> 1, 2, 3, 4 ]) == [> 2, 3 ]
- * @example Array.slice(1, [> 1, 2, 3,4 ]) == [> 2, 3, 4 ]
+ * @example Array.slice(1, end=3, [> 1, 2, 3, 4]) == [> 2, 3]
+ * @example Array.slice(1, [> 1, 2, 3, 4]) == [> 2, 3, 4]
  *
  * @since v0.4.0
  * @history v0.6.0: Default `end` to the Array length
@@ -1030,9 +1033,9 @@ provide let slice = (start, end=length(array), array) => {
  * @param array: The array to be sorted
  *
  * @example
- * let arr = [> 3, 2, 4, 1 ]
+ * let arr = [> 3, 2, 4, 1]
  * Array.sort((a, b) => a - b, arr)
- * assert arr == [> 1, 2, 3, 4 ]
+ * assert arr == [> 1, 2, 3, 4]
  *
  * @since v0.4.5
  */
@@ -1076,12 +1079,12 @@ provide let sort = (comp, array) => {
  *
  * @example
  * let array = [> 1, 2, 3, 4, 5]
- * Array.rotate(2, arr)
- * assert arr == [> 3, 4, 5, 1, 2]
+ * Array.rotate(2, array)
+ * assert array == [> 3, 4, 5, 1, 2]
  * @example
  * let array = [> 1, 2, 3, 4, 5]
- * Array.rotate(-1, arr)
- * assert arr == [> 5, 1, 2, 3, 4]
+ * Array.rotate(-1, array)
+ * assert array == [> 5, 1, 2, 3, 4]
  *
  * @since v0.4.5
  * @history v0.6.0: Behavior changed from right-rotation to left-rotation
@@ -1149,8 +1152,8 @@ let rec chunkHelp = (chunkSize, arr, arrLen, chunkStartIndex) => {
  * @throws InvalidArgument(String): When `chunkSize` is not an integer
  * @throws InvalidArgument(String): When `chunkSize` is less than one
  *
- * @example Array.chunk(2, [> 1, 2, 3, 4, 5]) == [> [> 1, 2], [> 3, 4], [> 5] ]
- * @example Array.chunk(2, [> 1, 2, 3, 4]) == [> [> 1, 2], [> 3, 4] ]
+ * @example Array.chunk(2, [> 1, 2, 3, 4, 5]) == [> [> 1, 2], [> 3, 4], [> 5]]
+ * @example Array.chunk(2, [> 1, 2, 3, 4]) == [> [> 1, 2], [> 3, 4]]
  *
  * @since v0.6.0
  */
@@ -1169,7 +1172,7 @@ provide let chunk = (chunkSize, arr) => {
  * An immutable array implementation.
  *
  * @example from Array use { module Immutable }
- * @example Array.Immutable.empty()
+ * @example Array.Immutable.empty
  * @example Immutable.fromList([1, 2, 3, 4, 5])
  *
  * @since v0.6.0
@@ -1259,7 +1262,7 @@ provide module Immutable {
   /**
    * An empty array.
    *
-   * @example Array.Immutable.empty()
+   * @example Array.Immutable.empty == Array.Immutable.fromList([])
    *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
@@ -1278,10 +1281,10 @@ provide module Immutable {
    *
    * @example
    * from Array use { module Immutable }
-   * Immutable.isEmpty(Immutable.fromList([1, 2, 3])) == false
+   * assert Immutable.isEmpty(Immutable.fromList([1, 2, 3])) == false
    * @example
    * from Array use { module Immutable }
-   * Immutable.isEmpty(Immutable.fromList([])) == true
+   * assert Immutable.isEmpty(Immutable.fromList([])) == true
    *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
@@ -1297,7 +1300,7 @@ provide module Immutable {
    *
    * @example
    * from Array use { module Immutable }
-   * Immutable.length(Immutable.fromList([1, 2, 3, 4, 5])) == 5
+   * assert Immutable.length(Immutable.fromList([1, 2, 3, 4, 5])) == 5
    *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
@@ -1402,9 +1405,10 @@ provide module Immutable {
    *
    * @example
    * from Array use { module Immutable }
-   * let mut arr = fromList([1, 2, 3, 4, 5])
-   * arr = Immutable.set(1, 9, arr)
-   * assert arr == Immutable.fromList([1, 9, 3, 4, 5])
+   * let arr = Immutable.fromList([1, 2, 3, 4, 5])
+   * let array = Immutable.set(1, 9, arr)
+   * assert arr == Immutable.fromList([1, 2, 3, 4, 5])
+   * assert array == Immutable.fromList([1, 9, 3, 4, 5])
    *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
@@ -1581,6 +1585,8 @@ provide module Immutable {
    * let arr1 = Immutable.fromList([1, 2])
    * let arr2 = Immutable.fromList([3, 4, 5])
    * assert Immutable.append(arr1, arr2) == Immutable.fromList([1, 2, 3, 4, 5])
+   * assert arr1 == Immutable.fromList([1, 2])
+   * assert arr2 == Immutable.fromList([3, 4, 5])
    *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
@@ -1620,9 +1626,9 @@ provide module Immutable {
    *
    * @example
    * from Array use { module Immutable }
-   * let arr1 = Immutable.fromList([1,2])
-   * let arr2 = Immutable.fromList([3,4])
-   * let arr3 = Immutable.fromList([5,6])
+   * let arr1 = Immutable.fromList([1, 2])
+   * let arr2 = Immutable.fromList([3, 4])
+   * let arr3 = Immutable.fromList([5, 6])
    * assert Immutable.concat([arr1, arr2, arr3]) == Immutable.fromList([1, 2, 3, 4, 5, 6])
    *
    * @since v0.6.0
@@ -1678,7 +1684,7 @@ provide module Immutable {
    *
    * @example
    * from Array use { module Immutable }
-   * assert Immutable.make(5, "foo") == Immutable.fromList(["foo", "foo", "foo", "foo", "foo"])
+   * assert Immutable.make(5, "🌾") == Immutable.fromList(["🌾", "🌾", "🌾", "🌾", "🌾"])
    *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
@@ -1728,7 +1734,7 @@ provide module Immutable {
    * from Array use { module Immutable }
    * let arr = Immutable.fromList(["a", "b", "c"])
    * let mut str = ""
-   * Immutable.forEach(e => str = str ++ e, 2, arr)
+   * Immutable.cycle(e => str = str ++ e, 2, arr)
    * assert str == "abcabc"
    *
    * @since v0.6.0
@@ -1927,7 +1933,7 @@ provide module Immutable {
    * @example
    * from Array use { module Immutable }
    * let arr = Immutable.fromList(['a', 'a', 'b', 'c'])
-   * let arr = Immutable.filter((e) => e == 'a', arr)
+   * let arr = Immutable.filter(e => e == 'a', arr)
    * assert Immutable.toList(arr) == ['a', 'a']
    *
    * @since v0.6.0
@@ -1950,7 +1956,7 @@ provide module Immutable {
    *
    * @example
    * from Array use { module Immutable }
-   * let arr = Immutable.fromList(['a', 'a' ])
+   * let arr = Immutable.fromList(['a', 'a'])
    * assert Immutable.every(e => e == 'a', arr) == true
    * @example
    * from Array use { module Immutable }
@@ -1971,12 +1977,12 @@ provide module Immutable {
    *
    * @param fn: The function to call on each element, where the returned value indicates if the element satisfies the condition
    * @param array: The array to iterate
-   * @returns `true` if one or more elements satify the condition or `false` otherwise
+   * @returns `true` if one or more elements satisfy the condition or `false` otherwise
    *
    * @example
    * from Array use { module Immutable }
-   * let arr = Immutable.fromList(['a', 'b' ])
-   * assert Immutable.some(e => e == 'a', arr) == true
+   * let arr = Immutable.fromList(['a', 'a', 'b', 'c'])
+   * assert Immutable.every(e => e == 'a', arr) == false
    * @example
    * from Array use { module Immutable }
    * let arr = Immutable.fromList(['b', 'c'])
@@ -2099,7 +2105,7 @@ provide module Immutable {
    * from Array use { module Immutable }
    * let arr1 = Immutable.fromList([1, 2])
    * let arr2 = Immutable.fromList([3, 4])
-   * assert Immutable.product(arr1, arr2) == Immutable.fromList([ (1, 3), (1, 4), (2, 3), (2, 4)])
+   * assert Immutable.product(arr1, arr2) == Immutable.fromList([(1, 3), (1, 4), (2, 3), (2, 4)])
    *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
@@ -2122,7 +2128,7 @@ provide module Immutable {
    *
    * @example
    * from Array use { module Immutable }
-   * let arr = Immutable.fromList([1,1,2,3,4])
+   * let arr = Immutable.fromList([1, 1, 2, 3, 4])
    * assert Immutable.count(e => e == 1, arr) == 2
    *
    * @since v0.6.0
@@ -2142,8 +2148,8 @@ provide module Immutable {
    *
    * @example
    * from Array use { module Immutable }
-   * let arr = Immutable.fromList([1,1,2,3,2,4])
-   * assert Immutable.unique(arr) == Immutable.fromList([1,2,3,4])
+   * let arr = Immutable.fromList([1, 1, 2, 3, 2, 4])
+   * assert Immutable.unique(arr) == Immutable.fromList([1, 2, 3, 4])
    *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
@@ -2204,7 +2210,7 @@ provide module Immutable {
    * from Array use { module Immutable }
    * let arr1 = Immutable.fromList([1, 2, 3])
    * let arr2 = Immutable.fromList([4, 5, 6])
-   * assert Immutable.zipWith((a, b) => a * b, arr1, arr2) == Immutable.fromList([4, 10])
+   * assert Immutable.zipWith((a, b) => a * b, arr1, arr2) == Immutable.fromList([4, 10, 18])
    *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
@@ -2223,8 +2229,8 @@ provide module Immutable {
    * @example
    * from Array use { module Immutable }
    * let arr1 = Immutable.fromList([(1, 2), (3, 4), (5, 6)])
-   * let arr2 = Immutable.fromList([1, 2, 3])
-   * let arr3 = Immutable.fromList([4, 5, 6])
+   * let arr2 = Immutable.fromList([1, 3, 5])
+   * let arr3 = Immutable.fromList([2, 4, 6])
    * assert Immutable.unzip(arr1) == (arr2, arr3)
    *
    * @since v0.6.0
@@ -2285,11 +2291,11 @@ provide module Immutable {
    * @example
    * from Array use { module Immutable }
    * let arr = Immutable.fromList(['a', 'b', 'c'])
-   * assert Immutable.slice(0, 2, arr) == Immutable.fromList(['a', 'b'])
+   * assert Immutable.slice(0, end=2, arr) == Immutable.fromList(['a', 'b'])
    * @example
    * from Array use { module Immutable }
    * let arr = Immutable.fromList(['a', 'b', 'c'])
-   * assert Immutable.slice(1, -1, arr) == Immutable.fromList(['b'])
+   * assert Immutable.slice(1, end=-1, arr) == Immutable.fromList(['b'])
    *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -4,6 +4,7 @@
  * An immutable array implementation is available in the `Immutable` submodule.
  *
  * @example include "array"
+ * @example [> 1, 2, 3 ]
  *
  * @since v0.2.0
  * @history v0.1.0: Originally named `arrays`
@@ -78,7 +79,7 @@ provide let length = array => {
  * @throws InvalidArgument(String): When `length` is not an integer
  * @throws InvalidArgument(String): When `length` is negative
  *
- * @example Array.make(5, "foo") // [> "foo", "foo", "foo", "foo", "foo"]
+ * @example Array.make(5, "foo") == [> "foo", "foo", "foo", "foo", "foo"]
  *
  * @since v0.1.0
  */
@@ -111,7 +112,7 @@ provide let make: (Number, a) => Array<a> = (length: Number, item: a) => {
  * @throws InvalidArgument(String): When `length` is not an integer
  * @throws InvalidArgument(String): When `length` is negative
  *
- * @example Array.init(5, n => n + 3) // [> 3, 4, 5, 6, 7]
+ * @example Array.init(5, n => n + 3) == [> 3, 4, 5, 6, 7]
  *
  * @since v0.1.0
  */
@@ -262,6 +263,8 @@ provide let concat = arrays => {
  * @param array: The array to copy
  * @returns The new array containing the elements from the input
  *
+ * @example Array.copy([> 1, 2, 3 ]) == [> 1, 2, 3 ]
+ *
  * @since v0.1.0
  */
 provide let copy = array => {
@@ -274,6 +277,11 @@ provide let copy = array => {
  * @param fn: The iterator function to call with each element
  * @param n: The number of times to iterate the given array
  * @param array: The array to iterate
+ *
+ * @example
+ * let mut str = ""
+ * Array.cycle(s => str = str ++ s, 2, [> "a", "b", "c"])
+ * assert str == "abcabc"
  *
  * @since v0.4.4
  */
@@ -292,6 +300,11 @@ provide let cycle = (fn, n, array) => {
  * @param fn: The iterator function to call with each element
  * @param array: The array to iterate
  *
+ * @example
+ * let mut str = ""
+ * Array.forEach(s => str = str ++ s, [> "a", "b", "c"])
+ * assert str == "abc"
+ *
  * @since v0.1.0
  * @history v0.2.0: Argument order changed to data-last
  */
@@ -308,6 +321,11 @@ provide let forEach = (fn, array) => {
  *
  * @param fn: The iterator function to call with each element
  * @param array: The array to iterate
+ *
+ * @example
+ * let mut str = ""
+ * Array.forEachi((s, i) => str = str ++ s ++ toString(i), [> "a", "b", "c"])
+ * assert str == "a0b1c2"
  *
  * @since v0.1.0
  * @history v0.2.0: Argument order changed to data-last
@@ -327,6 +345,8 @@ provide let forEachi = (fn, array) => {
  * @param array: The array to iterate
  * @returns The new array with mapped values
  *
+ * @example Array.map(x => x * 2, [> 1, 2, 3]) == [> 2, 4, 6 ]
+ *
  * @since v0.1.0
  * @history v0.2.0: Argument order changed to data-last
  */
@@ -344,6 +364,8 @@ provide let map = (fn, array) => {
  * @param fn: The mapper function to call on each element, where the value returned will be used to initialize the element in the new array
  * @param array: The array to iterate
  * @returns The new array with mapped values
+ *
+ * @example Array.mapi((x, i) => (x * 2, i), [> 1, 2, 3]) == [> (2, 0), (4, 1), (6, 2) ]
  *
  * @since v0.1.0
  */
@@ -368,7 +390,8 @@ provide let mapi = (fn, array) => {
  * @param array: The array to iterate
  * @returns The final accumulator returned from `fn`
  *
- * @example Array.reduce((a, b) => a + b, 0, [> 1, 2, 3]) // 6
+ * @example Array.reduce((acc, el) => acc + el, 0, [> 1, 2, 3]) == 6
+ * @example Array.reduce((acc, el) => acc ++ el, "", [> "baz", "bar", "foo"]) == "bazbarfoo"
  *
  * @since v0.3.0
  */
@@ -392,7 +415,7 @@ provide let reduce = (fn, initial, array) => {
  * @param array: The array to iterate
  * @returns The final accumulator returned from `fn`
  *
- * @example Array.reduceRight((a, b) => b ++ a, "", [> "baz", "bar", "foo"]) // "foobarbaz"
+ * @example Array.reduceRight((el, acc) => acc ++ el, "", [> "baz", "bar", "foo"]) == "bazbarfoo"
  *
  * @since v0.5.3
  */
@@ -419,6 +442,13 @@ provide let reduceRight = (fn, initial, array) => {
  * @param array: The array to iterate
  * @returns The final accumulator returned from `fn`
  *
+ * @example Array.reducei((acc, el, index) => acc + el + index, 0, [> 1, 2, 3]) == 9
+ * @example
+ * let output = Array.reducei((acc, el, index) => {
+ *   acc ++ el ++ toString(index)
+ * }, "", [> "baz", "bar", "foo"])
+ * assert output == "baz0bar1foo2"
+ *
  * @since v0.3.0
  */
 provide let reducei = (fn, initial, array) => {
@@ -438,6 +468,8 @@ provide let reducei = (fn, initial, array) => {
  * @returns The new array
  *
  * @throws InvalidArgument(String): When the combined length of all arrays is not an integer
+ *
+ * @example Array.flatMap(e => [> 1], [> 1, 2, 3]) == [> 1, 1, 1 ]
  *
  * @since v0.3.0
  */
@@ -465,6 +497,9 @@ provide let flatMap = (fn, array) => {
  * @param array: The array to check
  * @returns `true` if all elements satisfy the condition or `false` otherwise
  *
+ * @example Array.every(e => e % 2 == 0, [> 2, 4, 6 ]) == true
+ * @example Array.every(e => e % 2 == 0, [> 2, 4, 7 ]) == false
+ *
  * @since v0.3.0
  */
 provide let every = (fn, array) => {
@@ -484,6 +519,10 @@ provide let every = (fn, array) => {
  * @param array: The array to iterate
  * @returns `true` if one or more elements satisfy the condition or `false` otherwise
  *
+ * @example Array.some(e => e % 2 == 0, [> 2, 4, 6 ]) == true
+ * @example Array.some(e => e % 2 == 0, [> 2, 4, 7 ]) == true
+ * @example Array.some(e => e % 2 == 0, [> 3, 5, 7 ]) == false
+ *
  * @since v0.3.0
  */
 provide let some = (fn, array) => {
@@ -500,6 +539,11 @@ provide let some = (fn, array) => {
  *
  * @param value: The value replacing each element
  * @param array: The array to update
+ *
+ * @example
+ * let arr = [> 2, 4, 6 ]
+ * Array.fill(0, arr)
+ * assert arr == [> 0, 0, 0 ]
  *
  * @since v0.2.0
  */
@@ -522,6 +566,11 @@ provide let fill = (value, array) => {
  *
  * @throws IndexOutOfBounds: When the start index is out of bounds
  * @throws IndexOutOfBounds: When the start index is greater then the stop index
+ *
+ * @example
+ * let arr = [> 2, 4, 6, 8 ]
+ * Array.fillRange(0, 1, 3, arr)
+ * assert arr == [> 2, 0, 0, 8 ]
  *
  * @since v0.2.0
  */
@@ -552,6 +601,8 @@ provide let fillRange = (value, start, stop, array) => {
  * @param array: The array to reverse
  * @returns The new array
  *
+ * @example Array.reverse([> 1, 2, 3 ]) == [> 3, 2, 1 ]
+ *
  * @since v0.4.0
  */
 provide let reverse = array => {
@@ -567,6 +618,8 @@ provide let reverse = array => {
  *
  * @param array: The array to convert
  * @returns The list containing all elements from the array
+ *
+ * @example Array.toList([> 1, 2, 3 ]) == [ 1, 2, 3 ]
  *
  * @since v0.1.0
  */
@@ -587,6 +640,8 @@ provide let toList = array => {
  *
  * @param list: The list to convert
  * @returns The array containing all elements from the list
+ *
+ * @example Array.fromList([ 1, 2, 3 ]) == [> 1, 2, 3 ]
  *
  * @since v0.1.0
  */
@@ -619,6 +674,9 @@ provide let fromList = list => {
  * @param array: The array to inspect
  * @returns `true` if the value exists in the array or `false` otherwise
  *
+ * @example Array.contains(1, [> 1, 2, 3 ]) == true
+ * @example Array.contains(0, [> 1, 2, 3 ]) == false
+ *
  * @since v0.2.0
  */
 provide let contains = (search, array) => {
@@ -636,6 +694,10 @@ provide let contains = (search, array) => {
  * @param fn: The function to call on each element, where the returned value indicates if the element satisfies the condition
  * @param array: The array to search
  * @returns `Some(element)` containing the first value found or `None` otherwise
+ *
+ * @example Array.find((e) => e % 2 == 0, [> 1, 4, 3 ]) == Some(4)
+ * @example Array.find((e) => e % 2 == 0, [> 1, 2, 3, 4 ]) == Some(2)
+ * @example Array.find((e) => e % 2 == 0, [> 1, 3, 5 ]) == None
  *
  * @since v0.2.0
  */
@@ -656,6 +718,10 @@ provide let find = (fn, array) => {
  * @param array: The array to search
  * @returns `Some(index)` containing the index of the first element found or `None` otherwise
  *
+ * @example Array.findIndex((e) => e % 2 == 0, [> 1, 4, 3 ]) == Some(1)
+ * @example Array.findIndex((e) => e % 2 == 0, [> 1, 2, 3, 4 ]) == Some(1)
+ * @example Array.findIndex((e) => e % 2 == 0, [> 1, 3, 5 ]) == None
+ *
  * @since v0.2.0
  */
 provide let findIndex = (fn, array) => {
@@ -675,6 +741,8 @@ provide let findIndex = (fn, array) => {
  * @returns The new array containing all pairs of `(a, b)`
  *
  * @throws InvalidArgument(String): When the multiplied array lengths are not an integer
+ *
+ * @example Array.product([> 1, 2], [> 3, 4]) == [> (1, 3), (1, 4), (2, 3), (2, 4)]
  *
  * @since v0.2.0
  */
@@ -698,6 +766,8 @@ provide let product = (array1: Array<a>, array2: Array<b>) => {
  * @param array: The array to iterate
  * @returns The total number of elements that satisfy the condition
  *
+ * @example Array.count(e => e % 2 == 0, [> 1, 2, 3, 4 ]) == 2
+ *
  * @since v0.2.0
  */
 provide let count = (fn, array) => {
@@ -718,6 +788,9 @@ provide let count = (fn, array) => {
  * @param fn: The function to call on each element, where the returned value indicates if the element satisfies the condition
  * @param array: The array to iterate
  * @returns The total number of elements that satisfy the condition
+ *
+ * @example Array.counti((e, i) => e % 2 == 0 && i % 2 == 0, [> 1, 2, 3, 4, 5 ]) == 0
+ * @example Array.counti((e, i) => e % 2 == 0 && i % 2 == 0, [> 0, 1, 2, 3, 5 ]) == 1
  *
  * @since v0.3.0
  */
@@ -740,6 +813,8 @@ provide let counti = (fn, array) => {
  * @param fn: The function to call on each element, where the returned value indicates if the element satisfies the condition
  * @param array: The array to iterate
  * @returns The new array containing elements where `fn` returned `true`
+ *
+ * @example Array.filter(e => e % 2 == 0, [> 1, 2, 3, 4 ]) == [> 2, 4 ]
  *
  * @since v0.3.0
  */
@@ -766,6 +841,9 @@ provide let filter = (fn, array) => {
  * @param array: The array to iterate
  * @returns The new array containing elements where `fn` returned `true`
  *
+ * @example Array.filteri((e, i) => e % 2 == 0, [> 1, 2, 3, 4 ]) == [> 2, 4 ]
+ * @example Array.filteri((e, i) => e % 2 == 1 && i % 2 == 0, [> 1, 2, 3, 4, 5 ]) == [> 1, 3, 5 ]
+ *
  * @since v0.3.0
  */
 provide let filteri = (fn, array) => {
@@ -789,6 +867,8 @@ provide let filteri = (fn, array) => {
  * @param array: The array to filter
  * @returns The new array with only unique values
  *
+ * @example Array.unique([> 1, 2, 1, 2, 3, 1 ]) == [> 1, 2, 3 ]
+ *
  * @since v0.3.0
  */
 provide let unique = array => {
@@ -807,6 +887,8 @@ provide let unique = array => {
  * @returns The new array containing indexed pairs of `(a, b)`
  *
  * @throws IndexOutOfBounds: When the arrays have different sizes
+ *
+ * @example Array.zip([> 1, 2, 3], [> 4, 5, 6]) // [> (1, 4), (2, 5), (3, 6)]
  *
  * @since v0.4.0
  * @history v0.6.0: Support zipping arrays of different sizes
@@ -857,6 +939,8 @@ provide let zipWith = (fn, array1: Array<a>, array2: Array<b>) => {
  * @param array: The array of tuples to split
  * @returns An array containing all elements from the first tuple element, and an array containing all elements from the second tuple element
  *
+ * @example Array.unzip([> (1, 4), (2, 5), (3, 6)]) == ([> 1, 2, 3], [> 4, 5, 6])
+ *
  * @since v0.4.0
  */
 provide let unzip = array => {
@@ -881,6 +965,8 @@ provide let unzip = array => {
  * @param separator: The separator to insert between items in the string
  * @param items: The input strings
  * @returns The concatenated string
+ *
+ * @example Array.join(", ", [> "a", "b", "c"]) == "a, b, c"
  *
  * @since v0.4.0
  */
@@ -908,6 +994,9 @@ provide let join = (separator: String, items: Array<String>) => {
  * @param end: The index of the array where the slice will end (exclusive)
  * @param array: The array to be sliced
  * @returns The subset of the array that was sliced
+ *
+ * @example Array.slice(1, end=3, [> 1, 2, 3, 4 ]) == [> 2, 3 ]
+ * @example Array.slice(1, [> 1, 2, 3,4 ]) == [> 2, 3, 4 ]
  *
  * @since v0.4.0
  * @history v0.6.0: Default `end` to the Array length
@@ -939,6 +1028,12 @@ provide let slice = (start, end=length(array), array) => {
  * Ordering is calculated using a comparator function which takes two array elements and must return 0 if both are equal, a positive number if the first is greater, and a negative number if the first is smaller.
  * @param comp: The comparator function used to indicate sort order
  * @param array: The array to be sorted
+ *
+ * @example
+ * let arr = [> 3, 2, 4, 1 ]
+ * Array.sort((a, b) => a - b, arr)
+ * assert arr == [> 1, 2, 3, 4 ]
+ *
  * @since v0.4.5
  */
 provide let sort = (comp, array) => {
@@ -979,10 +1074,16 @@ provide let sort = (comp, array) => {
  * @param n: The number of elements to rotate by
  * @param arr: The array to be rotated
  *
- * @example let array = [> 1, 2, 3, 4, 5]; rotate(2, arr); arr == [> 3, 4, 5, 1, 2]
- * @example let array = [> 1, 2, 3, 4, 5]; rotate(-1, arr); arr == [> 5, 1, 2, 3, 4]
- * @since v0.4.5
+ * @example
+ * let array = [> 1, 2, 3, 4, 5]
+ * Array.rotate(2, arr)
+ * assert arr == [> 3, 4, 5, 1, 2]
+ * @example
+ * let array = [> 1, 2, 3, 4, 5]
+ * Array.rotate(-1, arr)
+ * assert arr == [> 5, 1, 2, 3, 4]
  *
+ * @since v0.4.5
  * @history v0.6.0: Behavior changed from right-rotation to left-rotation
  */
 provide let rotate = (n, arr) => {
@@ -1048,8 +1149,8 @@ let rec chunkHelp = (chunkSize, arr, arrLen, chunkStartIndex) => {
  * @throws InvalidArgument(String): When `chunkSize` is not an integer
  * @throws InvalidArgument(String): When `chunkSize` is less than one
  *
- * @example chunk(2, [> 1, 2, 3, 4, 5]) == [> [> 1, 2], [> 3, 4], [> 5] ]
- * @example chunk(2, [> 1, 2, 3, 4]) == [> [> 1, 2], [> 3, 4] ]
+ * @example Array.chunk(2, [> 1, 2, 3, 4, 5]) == [> [> 1, 2], [> 3, 4], [> 5] ]
+ * @example Array.chunk(2, [> 1, 2, 3, 4]) == [> [> 1, 2], [> 3, 4] ]
  *
  * @since v0.6.0
  */
@@ -1066,6 +1167,10 @@ provide let chunk = (chunkSize, arr) => {
 
 /**
  * An immutable array implementation.
+ *
+ * @example from Array use { module Immutable }
+ * @example Array.Immutable.empty()
+ * @example Immutable.fromList([1, 2, 3, 4, 5])
  *
  * @since v0.6.0
  * @history v0.5.4: Originally in `"immutablearray"` module
@@ -1154,6 +1259,8 @@ provide module Immutable {
   /**
    * An empty array.
    *
+   * @example Array.Immutable.empty()
+   *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
    */
@@ -1169,6 +1276,13 @@ provide module Immutable {
    * @param array: The array to check
    * @returns `true` if the array is empty and `false` otherwise
    *
+   * @example
+   * from Array use { module Immutable }
+   * Immutable.isEmpty(Immutable.fromList([1, 2, 3])) == false
+   * @example
+   * from Array use { module Immutable }
+   * Immutable.isEmpty(Immutable.fromList([])) == true
+   *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
    */
@@ -1181,7 +1295,10 @@ provide module Immutable {
    * @param array: The array to inspect
    * @returns The number of elements in the array
    *
-   * @example length(fromList([1, 2, 3, 4, 5])) == 5
+   * @example
+   * from Array use { module Immutable }
+   * Immutable.length(Immutable.fromList([1, 2, 3, 4, 5])) == 5
+   *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
    */
@@ -1237,10 +1354,15 @@ provide module Immutable {
    * @param index: The index to access
    * @param array: The array to access
    * @returns The element from the array
+   *
    * @throws IndexOutOfBounds: When the index being accessed is outside the array's bounds
    *
-   * @example get(1, fromList([1, 2, 3, 4])) == 2
-   * @example get(-1, fromList([1, 2, 3, 4])) == 4
+   * @example
+   * from Array use { module Immutable }
+   * assert Immutable.get(1, Immutable.fromList([1, 2, 3, 4])) == 2
+   * @example
+   * from Array use { module Immutable }
+   * assert Immutable.get(-1, Immutable.fromList([1, 2, 3, 4])) == 4
    *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
@@ -1275,9 +1397,14 @@ provide module Immutable {
    * @param value: The value to store
    * @param array: The array to update
    * @returns A new array containing the new element at the given index
+   *
    * @throws IndexOutOfBounds: When the index being updated is outside the array's bounds
    *
-   * @example set(1, 9, fromList([1, 2, 3, 4, 5])) == fromList([1, 9, 3, 4, 5])
+   * @example
+   * from Array use { module Immutable }
+   * let mut arr = fromList([1, 2, 3, 4, 5])
+   * arr = Immutable.set(1, 9, arr)
+   * assert arr == Immutable.fromList([1, 9, 3, 4, 5])
    *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
@@ -1449,7 +1576,11 @@ provide module Immutable {
    * @param array2: The array containing elements to appear second
    * @returns The new array containing elements from `array1` followed by elements from `array2`
    *
-   * @example append(fromList([1, 2]), fromList([3, 4, 5])) == fromList([1, 2, 3, 4, 5])
+   * @example
+   * from Array use { module Immutable }
+   * let arr1 = Immutable.fromList([1, 2])
+   * let arr2 = Immutable.fromList([3, 4, 5])
+   * assert Immutable.append(arr1, arr2) == Immutable.fromList([1, 2, 3, 4, 5])
    *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
@@ -1487,7 +1618,12 @@ provide module Immutable {
    * @param arrays: A list containing all arrays to combine
    * @returns The new array
    *
-   * @example concat([fromList([1, 2]), fromList([3, 4]), fromList([5, 6])]) == fromList([1, 2, 3, 4, 5, 6])
+   * @example
+   * from Array use { module Immutable }
+   * let arr1 = Immutable.fromList([1,2])
+   * let arr2 = Immutable.fromList([3,4])
+   * let arr3 = Immutable.fromList([5,6])
+   * assert Immutable.concat([arr1, arr2, arr3]) == Immutable.fromList([1, 2, 3, 4, 5, 6])
    *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
@@ -1506,7 +1642,12 @@ provide module Immutable {
    * @param fn: The initializer function to call with each index, where the value returned will be used to initialize the element
    * @returns The new array
    *
-   * @example init(5, i => i + 3) == fromList([3, 4, 5, 6, 7])
+   * @example
+   * from Array use { module Immutable }
+   * assert Immutable.init(5, i => i) == Immutable.fromList([0, 1, 2, 3, 4])
+   * @example
+   * from Array use { module Immutable }
+   * assert Immutable.init(5, i => i + 3) == Immutable.fromList([3, 4, 5, 6, 7])
    *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
@@ -1535,7 +1676,9 @@ provide module Immutable {
    * @param value: The value to store at each index
    * @returns The new array
    *
-   * @example make(5, "foo") == fromList(["foo", "foo", "foo", "foo", "foo"])
+   * @example
+   * from Array use { module Immutable }
+   * assert Immutable.make(5, "foo") == Immutable.fromList(["foo", "foo", "foo", "foo", "foo"])
    *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
@@ -1550,6 +1693,13 @@ provide module Immutable {
    *
    * @param fn: The iterator function to call with each element
    * @param array: The array to iterate
+   *
+   * @example
+   * from Array use { module Immutable }
+   * let arr = Immutable.fromList(["foo", "bar", "baz"])
+   * let mut str = ""
+   * Immutable.forEach(e => str = str ++ e, arr)
+   * assert str == "foobarbaz"
    *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
@@ -1574,6 +1724,13 @@ provide module Immutable {
    * @param n: The number of times to iterate the given array
    * @param array: The array to iterate
    *
+   * @example
+   * from Array use { module Immutable }
+   * let arr = Immutable.fromList(["a", "b", "c"])
+   * let mut str = ""
+   * Immutable.forEach(e => str = str ++ e, 2, arr)
+   * assert str == "abcabc"
+   *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
    */
@@ -1591,6 +1748,12 @@ provide module Immutable {
    * @param fn: The mapper function to call on each element, where the value returned will be used to initialize the element in the new array
    * @param array: The array to iterate
    * @returns The new array with mapped values
+   *
+   * @example
+   * from Array use { module Immutable }
+   * let arr = Immutable.fromList(["foo", "bar", "baz"])
+   * let arr = Immutable.map(e => e ++ "_", arr)
+   * assert arr == Immutable.fromList(["foo_", "bar_", "baz_"])
    *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
@@ -1623,7 +1786,10 @@ provide module Immutable {
    * @param array: The array to iterate
    * @returns The final accumulator returned from `fn`
    *
-   * @example reduce((acc, x) => acc + x, 0, fromList([1, 2, 3])) == 6
+   * @example
+   * from Array use { module Immutable }
+   * let arr = Immutable.fromList([1, 2, 3])
+   * assert Immutable.reduce((acc, x) => acc + x, 0, arr) == 6
    *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
@@ -1655,7 +1821,10 @@ provide module Immutable {
    * @param array: The array to iterate
    * @returns The final accumulator returned from `fn`
    *
-   * @example reduceRight((x, acc) => acc ++ x, "", fromList(["baz", "bar", "foo"])) == "foobarbaz"
+   * @example
+   * from Array use { module Immutable }
+   * let arr = Immutable.fromList(["baz", "bar", "foo"])
+   * assert Immutable.reduceRight((x, acc) => acc ++ x, "", arr) == "foobarbaz"
    *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
@@ -1683,7 +1852,11 @@ provide module Immutable {
    * @param array: The array to iterate
    * @returns The new array
    *
-   * @example flatMap(n => fromList([n, n + 1]), fromList([1, 3, 5])) == fromList([1, 2, 3, 4, 5, 6])
+   * @example
+   * from Array use { module Immutable }
+   * let arr = Immutable.fromList([1, 3, 5])
+   * let arr = Immutable.flatMap(n => Immutable.fromList([n, n + 1]), arr)
+   * assert arr == Immutable.fromList([1, 2, 3, 4, 5, 6])
    *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
@@ -1698,6 +1871,11 @@ provide module Immutable {
    *
    * @param list: The list to convert
    * @returns The array containing all elements from the list
+   *
+   * @example
+   * from Array use { module Immutable }
+   * let arr = Immutable.fromList([1, 2, 3])
+   * assert Immutable.get(1, arr) == 2
    *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
@@ -1723,6 +1901,12 @@ provide module Immutable {
    * @param array: The array to convert
    * @returns The list containing all elements from the array
    *
+   * @example
+   * from Array use { module Immutable }
+   * let arr = Immutable.fromList(['a', 'b', 'c'])
+   * let arr = Immutable.set(0, 'd', arr)
+   * assert Immutable.toList(arr) == ['d', 'b', 'c']
+   *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
    */
@@ -1739,6 +1923,12 @@ provide module Immutable {
    * @param fn: The function to call on each element, where the returned value indicates if the element satisfies the condition
    * @param array: The array to iterate
    * @returns The new array containing elements where `fn` returned `true`
+   *
+   * @example
+   * from Array use { module Immutable }
+   * let arr = Immutable.fromList(['a', 'a', 'b', 'c'])
+   * let arr = Immutable.filter((e) => e == 'a', arr)
+   * assert Immutable.toList(arr) == ['a', 'a']
    *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
@@ -1758,6 +1948,15 @@ provide module Immutable {
    * @param array: The array to check
    * @returns `true` if all elements satify the condition or `false` otherwise
    *
+   * @example
+   * from Array use { module Immutable }
+   * let arr = Immutable.fromList(['a', 'a' ])
+   * assert Immutable.every(e => e == 'a', arr) == true
+   * @example
+   * from Array use { module Immutable }
+   * let arr = Immutable.fromList(['a', 'a', 'b', 'c'])
+   * assert Immutable.every(e => e == 'a', arr) == false
+   *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
    */
@@ -1774,6 +1973,15 @@ provide module Immutable {
    * @param array: The array to iterate
    * @returns `true` if one or more elements satify the condition or `false` otherwise
    *
+   * @example
+   * from Array use { module Immutable }
+   * let arr = Immutable.fromList(['a', 'b' ])
+   * assert Immutable.some(e => e == 'a', arr) == true
+   * @example
+   * from Array use { module Immutable }
+   * let arr = Immutable.fromList(['b', 'c'])
+   * assert Immutable.some(e => e == 'a', arr) == false
+   *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
    */
@@ -1787,6 +1995,12 @@ provide module Immutable {
    *
    * @param array: The array to reverse
    * @returns The new array
+   *
+   * @example
+   * from Array use { module Immutable }
+   * let arr = Immutable.fromList(['a', 'b', 'c'])
+   * let arr = Immutable.reverse(arr)
+   * assert Immutable.toList(arr) == ['c', 'b', 'a']
    *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
@@ -1804,6 +2018,15 @@ provide module Immutable {
    * @param array: The array to inspect
    * @returns `true` if the value exists in the array or `false` otherwise
    *
+   * @example
+   * from Array use { module Immutable }
+   * let arr = Immutable.fromList(['a', 'b', 'c'])
+   * assert Immutable.contains('a', arr) == true
+   * @example
+   * from Array use { module Immutable }
+   * let arr = Immutable.fromList(['b', 'c'])
+   * assert Immutable.contains('a', arr) == false
+   *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
    */
@@ -1819,6 +2042,15 @@ provide module Immutable {
    * @param array: The array to search
    * @returns `Some(element)` containing the first value found or `None` otherwise
    *
+   * @example
+   * from Array use { module Immutable }
+   * let arr = Immutable.fromList([1, 2, 3])
+   * assert Immutable.find(e => e == 2, arr) == Some(2)
+   * @example
+   * from Array use { module Immutable }
+   * let arr = Immutable.fromList([1, 3])
+   * assert Immutable.find(e => e == 2, arr) == None
+   *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
    */
@@ -1833,6 +2065,15 @@ provide module Immutable {
    * @param fn: The function to call on each element, where the returned value indicates if the element satisfies the condition
    * @param array: The array to search
    * @returns `Some(index)` containing the index of the first element found or `None` otherwise
+   *
+   * @example
+   * from Array use { module Immutable }
+   * let arr = Immutable.fromList([1, 2, 3])
+   * assert Immutable.findIndex(e => e == 2, arr) == Some(1)
+   * @example
+   * from Array use { module Immutable }
+   * let arr = Immutable.fromList([1, 3])
+   * assert Immutable.findIndex(e => e == 2, arr) == None
    *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
@@ -1854,6 +2095,12 @@ provide module Immutable {
    * @param array2: The array to provide values for the second tuple element
    * @returns The new array containing all pairs of `(a, b)`
    *
+   * @example
+   * from Array use { module Immutable }
+   * let arr1 = Immutable.fromList([1, 2])
+   * let arr2 = Immutable.fromList([3, 4])
+   * assert Immutable.product(arr1, arr2) == Immutable.fromList([ (1, 3), (1, 4), (2, 3), (2, 4)])
+   *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
    */
@@ -1873,6 +2120,11 @@ provide module Immutable {
    * @param array: The array to iterate
    * @returns The total number of elements that satisfy the condition
    *
+   * @example
+   * from Array use { module Immutable }
+   * let arr = Immutable.fromList([1,1,2,3,4])
+   * assert Immutable.count(e => e == 1, arr) == 2
+   *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
    */
@@ -1887,6 +2139,11 @@ provide module Immutable {
    *
    * @param array: The array to filter
    * @returns The new array with only unique values
+   *
+   * @example
+   * from Array use { module Immutable }
+   * let arr = Immutable.fromList([1,1,2,3,2,4])
+   * assert Immutable.unique(arr) == Immutable.fromList([1,2,3,4])
    *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
@@ -1908,6 +2165,12 @@ provide module Immutable {
    * @param array1: The array to provide values for the first tuple element
    * @param array2: The array to provide values for the second tuple element
    * @returns The new array containing indexed pairs of `(a, b)`
+   *
+   * @example
+   * from Array use { module Immutable }
+   * let arr1 = Immutable.fromList([1, 2, 3])
+   * let arr2 = Immutable.fromList([4, 5, 6])
+   * assert Immutable.zip(arr1, arr2) == Immutable.fromList([(1, 4), (2, 5), (3, 6)])
    *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
@@ -1932,8 +2195,16 @@ provide module Immutable {
    * @param array2: The array whose elements will each be passed to the function as the second argument
    * @returns The new array containing elements derived from applying the function to pairs of input array elements
    *
-   * @example zipWith((a, b) => a + b, fromList([1, 2, 3]), fromList([4, 5, 6])) == fromList([5, 7, 9])
-   * @example zipWith((a, b) => a * b, fromList([1, 2, 3]), fromList([4, 5])) == fromList([4, 10])
+   * @example
+   * from Array use { module Immutable }
+   * let arr1 = Immutable.fromList([1, 2, 3])
+   * let arr2 = Immutable.fromList([4, 5, 6])
+   * assert Immutable.zipWith((a, b) => a + b, arr1, arr2) == Immutable.fromList([5, 7, 9])
+   * @example
+   * from Array use { module Immutable }
+   * let arr1 = Immutable.fromList([1, 2, 3])
+   * let arr2 = Immutable.fromList([4, 5, 6])
+   * assert Immutable.zipWith((a, b) => a * b, arr1, arr2) == Immutable.fromList([4, 10])
    *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
@@ -1948,6 +2219,13 @@ provide module Immutable {
    *
    * @param array: The array of tuples to split
    * @returns An array containing all elements from the first tuple element and an array containing all elements from the second tuple element
+   *
+   * @example
+   * from Array use { module Immutable }
+   * let arr1 = Immutable.fromList([(1, 2), (3, 4), (5, 6)])
+   * let arr2 = Immutable.fromList([1, 2, 3])
+   * let arr3 = Immutable.fromList([4, 5, 6])
+   * assert Immutable.unzip(arr1) == (arr2, arr3)
    *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
@@ -1964,6 +2242,11 @@ provide module Immutable {
    * @param separator: The separator to insert between items in the string
    * @param array: The input strings
    * @returns The concatenated string
+   *
+   * @example
+   * from Array use { module Immutable }
+   * let arr = Immutable.fromList(["a", "b", "c"])
+   * assert Immutable.join(", ", arr) == "a, b, c"
    *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
@@ -1999,8 +2282,14 @@ provide module Immutable {
    * @param array: The array to be sliced
    * @returns The subset of the array that was sliced
    *
-   * @example slice(0, 2, fromList(['a', 'b', 'c'])) == fromList(['a', 'b'])
-   * @example slice(1, -1, fromList(['a', 'b', 'c'])) == fromList(['b'])
+   * @example
+   * from Array use { module Immutable }
+   * let arr = Immutable.fromList(['a', 'b', 'c'])
+   * assert Immutable.slice(0, 2, arr) == Immutable.fromList(['a', 'b'])
+   * @example
+   * from Array use { module Immutable }
+   * let arr = Immutable.fromList(['a', 'b', 'c'])
+   * assert Immutable.slice(1, -1, arr) == Immutable.fromList(['b'])
    *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
@@ -2027,6 +2316,11 @@ provide module Immutable {
    * @param array: The array to be sorted
    * @returns The sorted array
    *
+   * @example
+   * from Array use { module Immutable }
+   * let arr = Immutable.fromList([2, 3, 1, 4])
+   * assert Immutable.sort((a, b) => a - b, arr) == Immutable.fromList([1, 2, 3, 4])
+   *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module
    */
@@ -2045,8 +2339,14 @@ provide module Immutable {
    * @param n: The number of elements to rotate by
    * @param array: The array to be rotated
    *
-   * @example rotate(2, fromList([1, 2, 3, 4, 5])) == fromList([3, 4, 5, 1, 2])
-   * @example rotate(-1, fromList([1, 2, 3, 4, 5])) == fromList([5, 1, 2, 3, 4])
+   * @example
+   * from Array use { module Immutable }
+   * let arr = Immutable.fromList([1, 2, 3, 4, 5])
+   * assert Immutable.rotate(2, arr) == Immutable.fromList([3, 4, 5, 1, 2])
+   * @example
+   * from Array use { module Immutable }
+   * let arr = Immutable.fromList([1, 2, 3, 4, 5])
+   * assert Immutable.rotate(-1, arr) == Immutable.fromList([5, 1, 2, 3, 4])
    *
    * @since v0.6.0
    * @history v0.5.4: Originally in `"immutablearray"` module

--- a/stdlib/array.md
+++ b/stdlib/array.md
@@ -24,7 +24,7 @@ include "array"
 ```
 
 ```grain
-[> 1, 2, 3 ]
+[> 1, 2, 3]
 ```
 
 ## Values
@@ -189,7 +189,7 @@ Throws:
 Examples:
 
 ```grain
-Array.get(1,[> 1, 2, 3, 4, 5]) == 2
+Array.get(1, [> 1, 2, 3, 4, 5]) == 2
 ```
 
 ### Array.**set**
@@ -233,7 +233,9 @@ Throws:
 Examples:
 
 ```grain
-Array.set(1, 9, [> 1, 2, 3, 4, 5]) == [> 1, 9, 3, 4, 5]
+let array = [> 1, 2, 3, 4, 5]
+Array.set(1, 9, array)
+assert array == [> 1, 9, 3, 4, 5]
 ```
 
 ### Array.**append**
@@ -342,7 +344,7 @@ Returns:
 Examples:
 
 ```grain
-Array.copy([> 1, 2, 3 ]) == [> 1, 2, 3 ]
+Array.copy([> 1, 2, 3]) == [> 1, 2, 3]
 ```
 
 ### Array.**cycle**
@@ -482,7 +484,7 @@ Returns:
 Examples:
 
 ```grain
-Array.map(x => x * 2, [> 1, 2, 3]) == [> 2, 4, 6 ]
+Array.map(x => x * 2, [> 1, 2, 3]) == [> 2, 4, 6]
 ```
 
 ### Array.**mapi**
@@ -515,7 +517,7 @@ Returns:
 Examples:
 
 ```grain
-Array.mapi((x, i) => (x * 2, i), [> 1, 2, 3]) == [> (2, 0), (4, 1), (6, 2) ]
+Array.mapi((x, i) => (x * 2, i), [> 1, 2, 3]) == [> (2, 0), (4, 1), (6, 2)]
 ```
 
 ### Array.**reduce**
@@ -597,7 +599,7 @@ Returns:
 Examples:
 
 ```grain
-Array.reduceRight((el, acc) => acc ++ el, "", [> "baz", "bar", "foo"]) == "bazbarfoo"
+Array.reduceRight((el, acc) => acc ++ el, "", [> "baz", "bar", "foo"]) == "foobarbaz"
 ```
 
 ### Array.**reducei**
@@ -685,7 +687,7 @@ Throws:
 Examples:
 
 ```grain
-Array.flatMap(e => [> 1], [> 1, 2, 3]) == [> 1, 1, 1 ]
+Array.flatMap(e => [> 1, e], [> 1, 2, 3]) == [> 1, 1, 1, 2, 1, 3]
 ```
 
 ### Array.**every**
@@ -718,11 +720,11 @@ Returns:
 Examples:
 
 ```grain
-Array.every(e => e % 2 == 0, [> 2, 4, 6 ]) == true
+Array.every(e => e % 2 == 0, [> 2, 4, 6]) == true
 ```
 
 ```grain
-Array.every(e => e % 2 == 0, [> 2, 4, 7 ]) == false
+Array.every(e => e % 2 == 0, [> 2, 4, 7]) == false
 ```
 
 ### Array.**some**
@@ -755,15 +757,15 @@ Returns:
 Examples:
 
 ```grain
-Array.some(e => e % 2 == 0, [> 2, 4, 6 ]) == true
+Array.some(e => e % 2 == 0, [> 2, 4, 6]) == true
 ```
 
 ```grain
-Array.some(e => e % 2 == 0, [> 2, 4, 7 ]) == true
+Array.some(e => e % 2 == 0, [> 2, 4, 7]) == true
 ```
 
 ```grain
-Array.some(e => e % 2 == 0, [> 3, 5, 7 ]) == false
+Array.some(e => e % 2 == 0, [> 3, 5, 7]) == false
 ```
 
 ### Array.**fill**
@@ -789,9 +791,9 @@ Parameters:
 Examples:
 
 ```grain
-let arr = [> 2, 4, 6 ]
+let arr = [> 2, 4, 6]
 Array.fill(0, arr)
-assert arr == [> 0, 0, 0 ]
+assert arr == [> 0, 0, 0]
 ```
 
 ### Array.**fillRange**
@@ -827,9 +829,9 @@ Throws:
 Examples:
 
 ```grain
-let arr = [> 2, 4, 6, 8 ]
+let arr = [> 2, 4, 6, 8]
 Array.fillRange(0, 1, 3, arr)
-assert arr == [> 2, 0, 0, 8 ]
+assert arr == [> 2, 0, 0, 8]
 ```
 
 ### Array.**reverse**
@@ -860,7 +862,7 @@ Returns:
 Examples:
 
 ```grain
-Array.reverse([> 1, 2, 3 ]) == [> 3, 2, 1 ]
+Array.reverse([> 1, 2, 3]) == [> 3, 2, 1]
 ```
 
 ### Array.**toList**
@@ -891,7 +893,7 @@ Returns:
 Examples:
 
 ```grain
-Array.toList([> 1, 2, 3 ]) == [ 1, 2, 3 ]
+Array.toList([> 1, 2, 3]) == [1, 2, 3]
 ```
 
 ### Array.**fromList**
@@ -922,7 +924,7 @@ Returns:
 Examples:
 
 ```grain
-Array.fromList([ 1, 2, 3 ]) == [> 1, 2, 3 ]
+Array.fromList([1, 2, 3]) == [> 1, 2, 3]
 ```
 
 ### Array.**contains**
@@ -955,11 +957,11 @@ Returns:
 Examples:
 
 ```grain
-Array.contains(1, [> 1, 2, 3 ]) == true
+Array.contains(1, [> 1, 2, 3]) == true
 ```
 
 ```grain
-Array.contains(0, [> 1, 2, 3 ]) == false
+Array.contains(0, [> 1, 2, 3]) == false
 ```
 
 ### Array.**find**
@@ -991,15 +993,15 @@ Returns:
 Examples:
 
 ```grain
-Array.find((e) => e % 2 == 0, [> 1, 4, 3 ]) == Some(4)
+Array.find(e => e % 2 == 0, [> 1, 4, 3]) == Some(4)
 ```
 
 ```grain
-Array.find((e) => e % 2 == 0, [> 1, 2, 3, 4 ]) == Some(2)
+Array.find(e => e % 2 == 0, [> 1, 2, 3, 4]) == Some(2)
 ```
 
 ```grain
-Array.find((e) => e % 2 == 0, [> 1, 3, 5 ]) == None
+Array.find(e => e % 2 == 0, [> 1, 3, 5]) == None
 ```
 
 ### Array.**findIndex**
@@ -1031,15 +1033,15 @@ Returns:
 Examples:
 
 ```grain
-Array.findIndex((e) => e % 2 == 0, [> 1, 4, 3 ]) == Some(1)
+Array.findIndex(e => e % 2 == 0, [> 1, 4, 3]) == Some(1)
 ```
 
 ```grain
-Array.findIndex((e) => e % 2 == 0, [> 1, 2, 3, 4 ]) == Some(1)
+Array.findIndex(e => e % 2 == 0, [> 1, 2, 3, 4]) == Some(1)
 ```
 
 ```grain
-Array.findIndex((e) => e % 2 == 0, [> 1, 3, 5 ]) == None
+Array.findIndex(e => e % 2 == 0, [> 1, 3, 5]) == None
 ```
 
 ### Array.**product**
@@ -1110,7 +1112,7 @@ Returns:
 Examples:
 
 ```grain
-Array.count(e => e % 2 == 0, [> 1, 2, 3, 4 ]) == 2
+Array.count(e => e % 2 == 0, [> 1, 2, 3, 4]) == 2
 ```
 
 ### Array.**counti**
@@ -1143,11 +1145,11 @@ Returns:
 Examples:
 
 ```grain
-Array.counti((e, i) => e % 2 == 0 && i % 2 == 0, [> 1, 2, 3, 4, 5 ]) == 0
+Array.counti((e, i) => e % 2 == 0 && i % 2 == 0, [> 1, 2, 3, 4, 5]) == 0
 ```
 
 ```grain
-Array.counti((e, i) => e % 2 == 0 && i % 2 == 0, [> 0, 1, 2, 3, 5 ]) == 1
+Array.counti((e, i) => e % 2 == 0 && i % 2 == 0, [> 0, 1, 2, 3, 5]) == 2
 ```
 
 ### Array.**filter**
@@ -1181,7 +1183,7 @@ Returns:
 Examples:
 
 ```grain
-Array.filter(e => e % 2 == 0, [> 1, 2, 3, 4 ]) == [> 2, 4 ]
+Array.filter(e => e % 2 == 0, [> 1, 2, 3, 4]) == [> 2, 4]
 ```
 
 ### Array.**filteri**
@@ -1215,11 +1217,11 @@ Returns:
 Examples:
 
 ```grain
-Array.filteri((e, i) => e % 2 == 0, [> 1, 2, 3, 4 ]) == [> 2, 4 ]
+Array.filteri((e, i) => e % 2 == 0, [> 1, 2, 3, 4]) == [> 2, 4]
 ```
 
 ```grain
-Array.filteri((e, i) => e % 2 == 1 && i % 2 == 0, [> 1, 2, 3, 4, 5 ]) == [> 1, 3, 5 ]
+Array.filteri((e, i) => e % 2 == 1 && i % 2 == 0, [> 1, 2, 3, 4, 5]) == [> 1, 3, 5]
 ```
 
 ### Array.**unique**
@@ -1251,7 +1253,7 @@ Returns:
 Examples:
 
 ```grain
-Array.unique([> 1, 2, 1, 2, 3, 1 ]) == [> 1, 2, 3 ]
+Array.unique([> 1, 2, 1, 2, 3, 1]) == [> 1, 2, 3]
 ```
 
 ### Array.**zip**
@@ -1298,7 +1300,7 @@ Throws:
 Examples:
 
 ```grain
-Array.zip([> 1, 2, 3], [> 4, 5, 6]) // [> (1, 4), (2, 5), (3, 6)]
+Array.zip([> 1, 2, 3], [> 4, 5, 6]) == [> (1, 4), (2, 5), (3, 6)]
 ```
 
 ### Array.**zipWith**
@@ -1344,11 +1346,11 @@ Throws:
 Examples:
 
 ```grain
-Array.zipWith((a, b) => a + b, [> 1, 2, 3], [> 4, 5, 6]) // [> 5, 7, 9]
+Array.zipWith((a, b) => a + b, [> 1, 2, 3], [> 4, 5, 6]) == [> 5, 7, 9]
 ```
 
 ```grain
-Array.zipWith((a, b) => a * b, [> 1, 2, 3], [> 4, 5]) // [> 4, 10]
+Array.zipWith((a, b) => a * b, [> 1, 2, 3], [> 4, 5]) == [> 4, 10]
 ```
 
 ### Array.**unzip**
@@ -1455,11 +1457,11 @@ Returns:
 Examples:
 
 ```grain
-Array.slice(1, end=3, [> 1, 2, 3, 4 ]) == [> 2, 3 ]
+Array.slice(1, end=3, [> 1, 2, 3, 4]) == [> 2, 3]
 ```
 
 ```grain
-Array.slice(1, [> 1, 2, 3,4 ]) == [> 2, 3, 4 ]
+Array.slice(1, [> 1, 2, 3, 4]) == [> 2, 3, 4]
 ```
 
 ### Array.**sort**
@@ -1487,9 +1489,9 @@ Parameters:
 Examples:
 
 ```grain
-let arr = [> 3, 2, 4, 1 ]
+let arr = [> 3, 2, 4, 1]
 Array.sort((a, b) => a - b, arr)
-assert arr == [> 1, 2, 3, 4 ]
+assert arr == [> 1, 2, 3, 4]
 ```
 
 ### Array.**rotate**
@@ -1527,14 +1529,14 @@ Examples:
 
 ```grain
 let array = [> 1, 2, 3, 4, 5]
-Array.rotate(2, arr)
-assert arr == [> 3, 4, 5, 1, 2]
+Array.rotate(2, array)
+assert array == [> 3, 4, 5, 1, 2]
 ```
 
 ```grain
 let array = [> 1, 2, 3, 4, 5]
-Array.rotate(-1, arr)
-assert arr == [> 5, 1, 2, 3, 4]
+Array.rotate(-1, array)
+assert array == [> 5, 1, 2, 3, 4]
 ```
 
 ### Array.**chunk**
@@ -1574,11 +1576,11 @@ Throws:
 Examples:
 
 ```grain
-Array.chunk(2, [> 1, 2, 3, 4, 5]) == [> [> 1, 2], [> 3, 4], [> 5] ]
+Array.chunk(2, [> 1, 2, 3, 4, 5]) == [> [> 1, 2], [> 3, 4], [> 5]]
 ```
 
 ```grain
-Array.chunk(2, [> 1, 2, 3, 4]) == [> [> 1, 2], [> 3, 4] ]
+Array.chunk(2, [> 1, 2, 3, 4]) == [> [> 1, 2], [> 3, 4]]
 ```
 
 ## Array.Immutable
@@ -1602,7 +1604,7 @@ from Array use { module Immutable }
 ```
 
 ```grain
-Array.Immutable.empty()
+Array.Immutable.empty
 ```
 
 ```grain
@@ -1646,7 +1648,7 @@ An empty array.
 Examples:
 
 ```grain
-Array.Immutable.empty()
+Array.Immutable.empty == Array.Immutable.fromList([])
 ```
 
 #### Array.Immutable.**isEmpty**
@@ -1685,12 +1687,12 @@ Examples:
 
 ```grain
 from Array use { module Immutable }
-Immutable.isEmpty(Immutable.fromList([1, 2, 3])) == false
+assert Immutable.isEmpty(Immutable.fromList([1, 2, 3])) == false
 ```
 
 ```grain
 from Array use { module Immutable }
-Immutable.isEmpty(Immutable.fromList([])) == true
+assert Immutable.isEmpty(Immutable.fromList([])) == true
 ```
 
 #### Array.Immutable.**length**
@@ -1729,7 +1731,7 @@ Examples:
 
 ```grain
 from Array use { module Immutable }
-Immutable.length(Immutable.fromList([1, 2, 3, 4, 5])) == 5
+assert Immutable.length(Immutable.fromList([1, 2, 3, 4, 5])) == 5
 ```
 
 #### Array.Immutable.**get**
@@ -1830,9 +1832,10 @@ Examples:
 
 ```grain
 from Array use { module Immutable }
-let mut arr = fromList([1, 2, 3, 4, 5])
-arr = Immutable.set(1, 9, arr)
-assert arr == Immutable.fromList([1, 9, 3, 4, 5])
+let arr = Immutable.fromList([1, 2, 3, 4, 5])
+let array = Immutable.set(1, 9, arr)
+assert arr == Immutable.fromList([1, 2, 3, 4, 5])
+assert array == Immutable.fromList([1, 9, 3, 4, 5])
 ```
 
 #### Array.Immutable.**append**
@@ -1877,6 +1880,8 @@ from Array use { module Immutable }
 let arr1 = Immutable.fromList([1, 2])
 let arr2 = Immutable.fromList([3, 4, 5])
 assert Immutable.append(arr1, arr2) == Immutable.fromList([1, 2, 3, 4, 5])
+assert arr1 == Immutable.fromList([1, 2])
+assert arr2 == Immutable.fromList([3, 4, 5])
 ```
 
 #### Array.Immutable.**concat**
@@ -1916,9 +1921,9 @@ Examples:
 
 ```grain
 from Array use { module Immutable }
-let arr1 = Immutable.fromList([1,2])
-let arr2 = Immutable.fromList([3,4])
-let arr3 = Immutable.fromList([5,6])
+let arr1 = Immutable.fromList([1, 2])
+let arr2 = Immutable.fromList([3, 4])
+let arr3 = Immutable.fromList([5, 6])
 assert Immutable.concat([arr1, arr2, arr3]) == Immutable.fromList([1, 2, 3, 4, 5, 6])
 ```
 
@@ -2007,7 +2012,7 @@ Examples:
 
 ```grain
 from Array use { module Immutable }
-assert Immutable.make(5, "foo") == Immutable.fromList(["foo", "foo", "foo", "foo", "foo"])
+assert Immutable.make(5, "🌾") == Immutable.fromList(["🌾", "🌾", "🌾", "🌾", "🌾"])
 ```
 
 #### Array.Immutable.**forEach**
@@ -2081,7 +2086,7 @@ Examples:
 from Array use { module Immutable }
 let arr = Immutable.fromList(["a", "b", "c"])
 let mut str = ""
-Immutable.forEach(e => str = str ++ e, 2, arr)
+Immutable.cycle(e => str = str ++ e, 2, arr)
 assert str == "abcabc"
 ```
 
@@ -2392,7 +2397,7 @@ Examples:
 ```grain
 from Array use { module Immutable }
 let arr = Immutable.fromList(['a', 'a', 'b', 'c'])
-let arr = Immutable.filter((e) => e == 'a', arr)
+let arr = Immutable.filter(e => e == 'a', arr)
 assert Immutable.toList(arr) == ['a', 'a']
 ```
 
@@ -2434,7 +2439,7 @@ Examples:
 
 ```grain
 from Array use { module Immutable }
-let arr = Immutable.fromList(['a', 'a' ])
+let arr = Immutable.fromList(['a', 'a'])
 assert Immutable.every(e => e == 'a', arr) == true
 ```
 
@@ -2476,14 +2481,14 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`Bool`|`true` if one or more elements satify the condition or `false` otherwise|
+|`Bool`|`true` if one or more elements satisfy the condition or `false` otherwise|
 
 Examples:
 
 ```grain
 from Array use { module Immutable }
-let arr = Immutable.fromList(['a', 'b' ])
-assert Immutable.some(e => e == 'a', arr) == true
+let arr = Immutable.fromList(['a', 'a', 'b', 'c'])
+assert Immutable.every(e => e == 'a', arr) == false
 ```
 
 ```grain
@@ -2717,7 +2722,7 @@ Examples:
 from Array use { module Immutable }
 let arr1 = Immutable.fromList([1, 2])
 let arr2 = Immutable.fromList([3, 4])
-assert Immutable.product(arr1, arr2) == Immutable.fromList([ (1, 3), (1, 4), (2, 3), (2, 4)])
+assert Immutable.product(arr1, arr2) == Immutable.fromList([(1, 3), (1, 4), (2, 3), (2, 4)])
 ```
 
 #### Array.Immutable.**count**
@@ -2757,7 +2762,7 @@ Examples:
 
 ```grain
 from Array use { module Immutable }
-let arr = Immutable.fromList([1,1,2,3,4])
+let arr = Immutable.fromList([1, 1, 2, 3, 4])
 assert Immutable.count(e => e == 1, arr) == 2
 ```
 
@@ -2798,8 +2803,8 @@ Examples:
 
 ```grain
 from Array use { module Immutable }
-let arr = Immutable.fromList([1,1,2,3,2,4])
-assert Immutable.unique(arr) == Immutable.fromList([1,2,3,4])
+let arr = Immutable.fromList([1, 1, 2, 3, 2, 4])
+assert Immutable.unique(arr) == Immutable.fromList([1, 2, 3, 4])
 ```
 
 #### Array.Immutable.**zip**
@@ -2907,7 +2912,7 @@ assert Immutable.zipWith((a, b) => a + b, arr1, arr2) == Immutable.fromList([5, 
 from Array use { module Immutable }
 let arr1 = Immutable.fromList([1, 2, 3])
 let arr2 = Immutable.fromList([4, 5, 6])
-assert Immutable.zipWith((a, b) => a * b, arr1, arr2) == Immutable.fromList([4, 10])
+assert Immutable.zipWith((a, b) => a * b, arr1, arr2) == Immutable.fromList([4, 10, 18])
 ```
 
 #### Array.Immutable.**unzip**
@@ -2948,8 +2953,8 @@ Examples:
 ```grain
 from Array use { module Immutable }
 let arr1 = Immutable.fromList([(1, 2), (3, 4), (5, 6)])
-let arr2 = Immutable.fromList([1, 2, 3])
-let arr3 = Immutable.fromList([4, 5, 6])
+let arr2 = Immutable.fromList([1, 3, 5])
+let arr3 = Immutable.fromList([2, 4, 6])
 assert Immutable.unzip(arr1) == (arr2, arr3)
 ```
 
@@ -3040,13 +3045,13 @@ Examples:
 ```grain
 from Array use { module Immutable }
 let arr = Immutable.fromList(['a', 'b', 'c'])
-assert Immutable.slice(0, 2, arr) == Immutable.fromList(['a', 'b'])
+assert Immutable.slice(0, end=2, arr) == Immutable.fromList(['a', 'b'])
 ```
 
 ```grain
 from Array use { module Immutable }
 let arr = Immutable.fromList(['a', 'b', 'c'])
-assert Immutable.slice(1, -1, arr) == Immutable.fromList(['b'])
+assert Immutable.slice(1, end=-1, arr) == Immutable.fromList(['b'])
 ```
 
 #### Array.Immutable.**sort**

--- a/stdlib/array.md
+++ b/stdlib/array.md
@@ -23,6 +23,10 @@ An immutable array implementation is available in the `Immutable` submodule.
 include "array"
 ```
 
+```grain
+[> 1, 2, 3 ]
+```
+
 ## Values
 
 Functions and constants included in the Array module.
@@ -95,7 +99,7 @@ Throws:
 Examples:
 
 ```grain
-Array.make(5, "foo") // [> "foo", "foo", "foo", "foo", "foo"]
+Array.make(5, "foo") == [> "foo", "foo", "foo", "foo", "foo"]
 ```
 
 ### Array.**init**
@@ -136,7 +140,7 @@ Throws:
 Examples:
 
 ```grain
-Array.init(5, n => n + 3) // [> 3, 4, 5, 6, 7]
+Array.init(5, n => n + 3) == [> 3, 4, 5, 6, 7]
 ```
 
 ### Array.**get**
@@ -335,6 +339,12 @@ Returns:
 |----|-----------|
 |`Array<a>`|The new array containing the elements from the input|
 
+Examples:
+
+```grain
+Array.copy([> 1, 2, 3 ]) == [> 1, 2, 3 ]
+```
+
 ### Array.**cycle**
 
 <details disabled>
@@ -355,6 +365,14 @@ Parameters:
 |`fn`|`a => Void`|The iterator function to call with each element|
 |`n`|`Number`|The number of times to iterate the given array|
 |`array`|`Array<a>`|The array to iterate|
+
+Examples:
+
+```grain
+let mut str = ""
+Array.cycle(s => str = str ++ s, 2, [> "a", "b", "c"])
+assert str == "abcabc"
+```
 
 ### Array.**forEach**
 
@@ -383,6 +401,14 @@ Parameters:
 |`fn`|`a => Void`|The iterator function to call with each element|
 |`array`|`Array<a>`|The array to iterate|
 
+Examples:
+
+```grain
+let mut str = ""
+Array.forEach(s => str = str ++ s, [> "a", "b", "c"])
+assert str == "abc"
+```
+
 ### Array.**forEachi**
 
 <details>
@@ -410,6 +436,14 @@ Parameters:
 |-----|----|-----------|
 |`fn`|`(a, Number) => Void`|The iterator function to call with each element|
 |`array`|`Array<a>`|The array to iterate|
+
+Examples:
+
+```grain
+let mut str = ""
+Array.forEachi((s, i) => str = str ++ s ++ toString(i), [> "a", "b", "c"])
+assert str == "a0b1c2"
+```
 
 ### Array.**map**
 
@@ -445,6 +479,12 @@ Returns:
 |----|-----------|
 |`Array<b>`|The new array with mapped values|
 
+Examples:
+
+```grain
+Array.map(x => x * 2, [> 1, 2, 3]) == [> 2, 4, 6 ]
+```
+
 ### Array.**mapi**
 
 <details disabled>
@@ -471,6 +511,12 @@ Returns:
 |type|description|
 |----|-----------|
 |`Array<b>`|The new array with mapped values|
+
+Examples:
+
+```grain
+Array.mapi((x, i) => (x * 2, i), [> 1, 2, 3]) == [> (2, 0), (4, 1), (6, 2) ]
+```
 
 ### Array.**reduce**
 
@@ -508,7 +554,11 @@ Returns:
 Examples:
 
 ```grain
-Array.reduce((a, b) => a + b, 0, [> 1, 2, 3]) // 6
+Array.reduce((acc, el) => acc + el, 0, [> 1, 2, 3]) == 6
+```
+
+```grain
+Array.reduce((acc, el) => acc ++ el, "", [> "baz", "bar", "foo"]) == "bazbarfoo"
 ```
 
 ### Array.**reduceRight**
@@ -547,7 +597,7 @@ Returns:
 Examples:
 
 ```grain
-Array.reduceRight((a, b) => b ++ a, "", [> "baz", "bar", "foo"]) // "foobarbaz"
+Array.reduceRight((el, acc) => acc ++ el, "", [> "baz", "bar", "foo"]) == "bazbarfoo"
 ```
 
 ### Array.**reducei**
@@ -584,6 +634,19 @@ Returns:
 |----|-----------|
 |`a`|The final accumulator returned from `fn`|
 
+Examples:
+
+```grain
+Array.reducei((acc, el, index) => acc + el + index, 0, [> 1, 2, 3]) == 9
+```
+
+```grain
+let output = Array.reducei((acc, el, index) => {
+  acc ++ el ++ toString(index)
+}, "", [> "baz", "bar", "foo"])
+assert output == "baz0bar1foo2"
+```
+
 ### Array.**flatMap**
 
 <details disabled>
@@ -619,6 +682,12 @@ Throws:
 
 * When the combined length of all arrays is not an integer
 
+Examples:
+
+```grain
+Array.flatMap(e => [> 1], [> 1, 2, 3]) == [> 1, 1, 1 ]
+```
+
 ### Array.**every**
 
 <details disabled>
@@ -645,6 +714,16 @@ Returns:
 |type|description|
 |----|-----------|
 |`Bool`|`true` if all elements satisfy the condition or `false` otherwise|
+
+Examples:
+
+```grain
+Array.every(e => e % 2 == 0, [> 2, 4, 6 ]) == true
+```
+
+```grain
+Array.every(e => e % 2 == 0, [> 2, 4, 7 ]) == false
+```
 
 ### Array.**some**
 
@@ -673,6 +752,20 @@ Returns:
 |----|-----------|
 |`Bool`|`true` if one or more elements satisfy the condition or `false` otherwise|
 
+Examples:
+
+```grain
+Array.some(e => e % 2 == 0, [> 2, 4, 6 ]) == true
+```
+
+```grain
+Array.some(e => e % 2 == 0, [> 2, 4, 7 ]) == true
+```
+
+```grain
+Array.some(e => e % 2 == 0, [> 3, 5, 7 ]) == false
+```
+
 ### Array.**fill**
 
 <details disabled>
@@ -692,6 +785,14 @@ Parameters:
 |-----|----|-----------|
 |`value`|`a`|The value replacing each element|
 |`array`|`Array<a>`|The array to update|
+
+Examples:
+
+```grain
+let arr = [> 2, 4, 6 ]
+Array.fill(0, arr)
+assert arr == [> 0, 0, 0 ]
+```
 
 ### Array.**fillRange**
 
@@ -723,6 +824,14 @@ Throws:
 * When the start index is out of bounds
 * When the start index is greater then the stop index
 
+Examples:
+
+```grain
+let arr = [> 2, 4, 6, 8 ]
+Array.fillRange(0, 1, 3, arr)
+assert arr == [> 2, 0, 0, 8 ]
+```
+
 ### Array.**reverse**
 
 <details disabled>
@@ -747,6 +856,12 @@ Returns:
 |type|description|
 |----|-----------|
 |`Array<a>`|The new array|
+
+Examples:
+
+```grain
+Array.reverse([> 1, 2, 3 ]) == [> 3, 2, 1 ]
+```
 
 ### Array.**toList**
 
@@ -773,6 +888,12 @@ Returns:
 |----|-----------|
 |`List<a>`|The list containing all elements from the array|
 
+Examples:
+
+```grain
+Array.toList([> 1, 2, 3 ]) == [ 1, 2, 3 ]
+```
+
 ### Array.**fromList**
 
 <details disabled>
@@ -797,6 +918,12 @@ Returns:
 |type|description|
 |----|-----------|
 |`Array<a>`|The array containing all elements from the list|
+
+Examples:
+
+```grain
+Array.fromList([ 1, 2, 3 ]) == [> 1, 2, 3 ]
+```
 
 ### Array.**contains**
 
@@ -825,6 +952,16 @@ Returns:
 |----|-----------|
 |`Bool`|`true` if the value exists in the array or `false` otherwise|
 
+Examples:
+
+```grain
+Array.contains(1, [> 1, 2, 3 ]) == true
+```
+
+```grain
+Array.contains(0, [> 1, 2, 3 ]) == false
+```
+
 ### Array.**find**
 
 <details disabled>
@@ -851,6 +988,20 @@ Returns:
 |----|-----------|
 |`Option<a>`|`Some(element)` containing the first value found or `None` otherwise|
 
+Examples:
+
+```grain
+Array.find((e) => e % 2 == 0, [> 1, 4, 3 ]) == Some(4)
+```
+
+```grain
+Array.find((e) => e % 2 == 0, [> 1, 2, 3, 4 ]) == Some(2)
+```
+
+```grain
+Array.find((e) => e % 2 == 0, [> 1, 3, 5 ]) == None
+```
+
 ### Array.**findIndex**
 
 <details disabled>
@@ -876,6 +1027,20 @@ Returns:
 |type|description|
 |----|-----------|
 |`Option<Number>`|`Some(index)` containing the index of the first element found or `None` otherwise|
+
+Examples:
+
+```grain
+Array.findIndex((e) => e % 2 == 0, [> 1, 4, 3 ]) == Some(1)
+```
+
+```grain
+Array.findIndex((e) => e % 2 == 0, [> 1, 2, 3, 4 ]) == Some(1)
+```
+
+```grain
+Array.findIndex((e) => e % 2 == 0, [> 1, 3, 5 ]) == None
+```
 
 ### Array.**product**
 
@@ -910,6 +1075,12 @@ Throws:
 
 * When the multiplied array lengths are not an integer
 
+Examples:
+
+```grain
+Array.product([> 1, 2], [> 3, 4]) == [> (1, 3), (1, 4), (2, 3), (2, 4)]
+```
+
 ### Array.**count**
 
 <details disabled>
@@ -935,6 +1106,12 @@ Returns:
 |type|description|
 |----|-----------|
 |`Number`|The total number of elements that satisfy the condition|
+
+Examples:
+
+```grain
+Array.count(e => e % 2 == 0, [> 1, 2, 3, 4 ]) == 2
+```
 
 ### Array.**counti**
 
@@ -962,6 +1139,16 @@ Returns:
 |type|description|
 |----|-----------|
 |`Number`|The total number of elements that satisfy the condition|
+
+Examples:
+
+```grain
+Array.counti((e, i) => e % 2 == 0 && i % 2 == 0, [> 1, 2, 3, 4, 5 ]) == 0
+```
+
+```grain
+Array.counti((e, i) => e % 2 == 0 && i % 2 == 0, [> 0, 1, 2, 3, 5 ]) == 1
+```
 
 ### Array.**filter**
 
@@ -991,6 +1178,12 @@ Returns:
 |----|-----------|
 |`Array<a>`|The new array containing elements where `fn` returned `true`|
 
+Examples:
+
+```grain
+Array.filter(e => e % 2 == 0, [> 1, 2, 3, 4 ]) == [> 2, 4 ]
+```
+
 ### Array.**filteri**
 
 <details disabled>
@@ -1019,6 +1212,16 @@ Returns:
 |----|-----------|
 |`Array<a>`|The new array containing elements where `fn` returned `true`|
 
+Examples:
+
+```grain
+Array.filteri((e, i) => e % 2 == 0, [> 1, 2, 3, 4 ]) == [> 2, 4 ]
+```
+
+```grain
+Array.filteri((e, i) => e % 2 == 1 && i % 2 == 0, [> 1, 2, 3, 4, 5 ]) == [> 1, 3, 5 ]
+```
+
 ### Array.**unique**
 
 <details disabled>
@@ -1044,6 +1247,12 @@ Returns:
 |type|description|
 |----|-----------|
 |`Array<a>`|The new array with only unique values|
+
+Examples:
+
+```grain
+Array.unique([> 1, 2, 1, 2, 3, 1 ]) == [> 1, 2, 3 ]
+```
 
 ### Array.**zip**
 
@@ -1085,6 +1294,12 @@ Throws:
 `IndexOutOfBounds`
 
 * When the arrays have different sizes
+
+Examples:
+
+```grain
+Array.zip([> 1, 2, 3], [> 4, 5, 6]) // [> (1, 4), (2, 5), (3, 6)]
+```
 
 ### Array.**zipWith**
 
@@ -1161,6 +1376,12 @@ Returns:
 |----|-----------|
 |`(Array<a>, Array<b>)`|An array containing all elements from the first tuple element, and an array containing all elements from the second tuple element|
 
+Examples:
+
+```grain
+Array.unzip([> (1, 4), (2, 5), (3, 6)]) == ([> 1, 2, 3], [> 4, 5, 6])
+```
+
 ### Array.**join**
 
 <details disabled>
@@ -1186,6 +1407,12 @@ Returns:
 |type|description|
 |----|-----------|
 |`String`|The concatenated string|
+
+Examples:
+
+```grain
+Array.join(", ", [> "a", "b", "c"]) == "a, b, c"
+```
 
 ### Array.**slice**
 
@@ -1225,6 +1452,16 @@ Returns:
 |----|-----------|
 |`Array<a>`|The subset of the array that was sliced|
 
+Examples:
+
+```grain
+Array.slice(1, end=3, [> 1, 2, 3, 4 ]) == [> 2, 3 ]
+```
+
+```grain
+Array.slice(1, [> 1, 2, 3,4 ]) == [> 2, 3, 4 ]
+```
+
 ### Array.**sort**
 
 <details disabled>
@@ -1246,6 +1483,14 @@ Parameters:
 |-----|----|-----------|
 |`comp`|`(a, a) => Number`|The comparator function used to indicate sort order|
 |`array`|`Array<a>`|The array to be sorted|
+
+Examples:
+
+```grain
+let arr = [> 3, 2, 4, 1 ]
+Array.sort((a, b) => a - b, arr)
+assert arr == [> 1, 2, 3, 4 ]
+```
 
 ### Array.**rotate**
 
@@ -1281,11 +1526,15 @@ Parameters:
 Examples:
 
 ```grain
-let array = [> 1, 2, 3, 4, 5]; rotate(2, arr); arr == [> 3, 4, 5, 1, 2]
+let array = [> 1, 2, 3, 4, 5]
+Array.rotate(2, arr)
+assert arr == [> 3, 4, 5, 1, 2]
 ```
 
 ```grain
-let array = [> 1, 2, 3, 4, 5]; rotate(-1, arr); arr == [> 5, 1, 2, 3, 4]
+let array = [> 1, 2, 3, 4, 5]
+Array.rotate(-1, arr)
+assert arr == [> 5, 1, 2, 3, 4]
 ```
 
 ### Array.**chunk**
@@ -1325,11 +1574,11 @@ Throws:
 Examples:
 
 ```grain
-chunk(2, [> 1, 2, 3, 4, 5]) == [> [> 1, 2], [> 3, 4], [> 5] ]
+Array.chunk(2, [> 1, 2, 3, 4, 5]) == [> [> 1, 2], [> 3, 4], [> 5] ]
 ```
 
 ```grain
-chunk(2, [> 1, 2, 3, 4]) == [> [> 1, 2], [> 3, 4] ]
+Array.chunk(2, [> 1, 2, 3, 4]) == [> [> 1, 2], [> 3, 4] ]
 ```
 
 ## Array.Immutable
@@ -1347,6 +1596,18 @@ An immutable array implementation.
 </tbody>
 </table>
 </details>
+
+```grain
+from Array use { module Immutable }
+```
+
+```grain
+Array.Immutable.empty()
+```
+
+```grain
+Immutable.fromList([1, 2, 3, 4, 5])
+```
 
 ### Types
 
@@ -1382,6 +1643,12 @@ empty : ImmutableArray<a>
 
 An empty array.
 
+Examples:
+
+```grain
+Array.Immutable.empty()
+```
+
 #### Array.Immutable.**isEmpty**
 
 <details>
@@ -1413,6 +1680,18 @@ Returns:
 |type|description|
 |----|-----------|
 |`Bool`|`true` if the array is empty and `false` otherwise|
+
+Examples:
+
+```grain
+from Array use { module Immutable }
+Immutable.isEmpty(Immutable.fromList([1, 2, 3])) == false
+```
+
+```grain
+from Array use { module Immutable }
+Immutable.isEmpty(Immutable.fromList([])) == true
+```
 
 #### Array.Immutable.**length**
 
@@ -1449,7 +1728,8 @@ Returns:
 Examples:
 
 ```grain
-length(fromList([1, 2, 3, 4, 5])) == 5
+from Array use { module Immutable }
+Immutable.length(Immutable.fromList([1, 2, 3, 4, 5])) == 5
 ```
 
 #### Array.Immutable.**get**
@@ -1495,11 +1775,13 @@ Throws:
 Examples:
 
 ```grain
-get(1, fromList([1, 2, 3, 4])) == 2
+from Array use { module Immutable }
+assert Immutable.get(1, Immutable.fromList([1, 2, 3, 4])) == 2
 ```
 
 ```grain
-get(-1, fromList([1, 2, 3, 4])) == 4
+from Array use { module Immutable }
+assert Immutable.get(-1, Immutable.fromList([1, 2, 3, 4])) == 4
 ```
 
 #### Array.Immutable.**set**
@@ -1547,7 +1829,10 @@ Throws:
 Examples:
 
 ```grain
-set(1, 9, fromList([1, 2, 3, 4, 5])) == fromList([1, 9, 3, 4, 5])
+from Array use { module Immutable }
+let mut arr = fromList([1, 2, 3, 4, 5])
+arr = Immutable.set(1, 9, arr)
+assert arr == Immutable.fromList([1, 9, 3, 4, 5])
 ```
 
 #### Array.Immutable.**append**
@@ -1588,7 +1873,10 @@ Returns:
 Examples:
 
 ```grain
-append(fromList([1, 2]), fromList([3, 4, 5])) == fromList([1, 2, 3, 4, 5])
+from Array use { module Immutable }
+let arr1 = Immutable.fromList([1, 2])
+let arr2 = Immutable.fromList([3, 4, 5])
+assert Immutable.append(arr1, arr2) == Immutable.fromList([1, 2, 3, 4, 5])
 ```
 
 #### Array.Immutable.**concat**
@@ -1627,7 +1915,11 @@ Returns:
 Examples:
 
 ```grain
-concat([fromList([1, 2]), fromList([3, 4]), fromList([5, 6])]) == fromList([1, 2, 3, 4, 5, 6])
+from Array use { module Immutable }
+let arr1 = Immutable.fromList([1,2])
+let arr2 = Immutable.fromList([3,4])
+let arr3 = Immutable.fromList([5,6])
+assert Immutable.concat([arr1, arr2, arr3]) == Immutable.fromList([1, 2, 3, 4, 5, 6])
 ```
 
 #### Array.Immutable.**init**
@@ -1668,7 +1960,13 @@ Returns:
 Examples:
 
 ```grain
-init(5, i => i + 3) == fromList([3, 4, 5, 6, 7])
+from Array use { module Immutable }
+assert Immutable.init(5, i => i) == Immutable.fromList([0, 1, 2, 3, 4])
+```
+
+```grain
+from Array use { module Immutable }
+assert Immutable.init(5, i => i + 3) == Immutable.fromList([3, 4, 5, 6, 7])
 ```
 
 #### Array.Immutable.**make**
@@ -1708,7 +2006,8 @@ Returns:
 Examples:
 
 ```grain
-make(5, "foo") == fromList(["foo", "foo", "foo", "foo", "foo"])
+from Array use { module Immutable }
+assert Immutable.make(5, "foo") == Immutable.fromList(["foo", "foo", "foo", "foo", "foo"])
 ```
 
 #### Array.Immutable.**forEach**
@@ -1738,6 +2037,16 @@ Parameters:
 |`fn`|`a => Void`|The iterator function to call with each element|
 |`array`|`ImmutableArray<a>`|The array to iterate|
 
+Examples:
+
+```grain
+from Array use { module Immutable }
+let arr = Immutable.fromList(["foo", "bar", "baz"])
+let mut str = ""
+Immutable.forEach(e => str = str ++ e, arr)
+assert str == "foobarbaz"
+```
+
 #### Array.Immutable.**cycle**
 
 <details>
@@ -1765,6 +2074,16 @@ Parameters:
 |`fn`|`a => Void`|The iterator function to call with each element|
 |`n`|`Number`|The number of times to iterate the given array|
 |`array`|`ImmutableArray<a>`|The array to iterate|
+
+Examples:
+
+```grain
+from Array use { module Immutable }
+let arr = Immutable.fromList(["a", "b", "c"])
+let mut str = ""
+Immutable.forEach(e => str = str ++ e, 2, arr)
+assert str == "abcabc"
+```
 
 #### Array.Immutable.**map**
 
@@ -1799,6 +2118,15 @@ Returns:
 |type|description|
 |----|-----------|
 |`ImmutableArray<b>`|The new array with mapped values|
+
+Examples:
+
+```grain
+from Array use { module Immutable }
+let arr = Immutable.fromList(["foo", "bar", "baz"])
+let arr = Immutable.map(e => e ++ "_", arr)
+assert arr == Immutable.fromList(["foo_", "bar_", "baz_"])
+```
 
 #### Array.Immutable.**reduce**
 
@@ -1843,7 +2171,9 @@ Returns:
 Examples:
 
 ```grain
-reduce((acc, x) => acc + x, 0, fromList([1, 2, 3])) == 6
+from Array use { module Immutable }
+let arr = Immutable.fromList([1, 2, 3])
+assert Immutable.reduce((acc, x) => acc + x, 0, arr) == 6
 ```
 
 #### Array.Immutable.**reduceRight**
@@ -1889,7 +2219,9 @@ Returns:
 Examples:
 
 ```grain
-reduceRight((x, acc) => acc ++ x, "", fromList(["baz", "bar", "foo"])) == "foobarbaz"
+from Array use { module Immutable }
+let arr = Immutable.fromList(["baz", "bar", "foo"])
+assert Immutable.reduceRight((x, acc) => acc ++ x, "", arr) == "foobarbaz"
 ```
 
 #### Array.Immutable.**flatMap**
@@ -1933,7 +2265,10 @@ Returns:
 Examples:
 
 ```grain
-flatMap(n => fromList([n, n + 1]), fromList([1, 3, 5])) == fromList([1, 2, 3, 4, 5, 6])
+from Array use { module Immutable }
+let arr = Immutable.fromList([1, 3, 5])
+let arr = Immutable.flatMap(n => Immutable.fromList([n, n + 1]), arr)
+assert arr == Immutable.fromList([1, 2, 3, 4, 5, 6])
 ```
 
 #### Array.Immutable.**fromList**
@@ -1968,6 +2303,14 @@ Returns:
 |----|-----------|
 |`ImmutableArray<a>`|The array containing all elements from the list|
 
+Examples:
+
+```grain
+from Array use { module Immutable }
+let arr = Immutable.fromList([1, 2, 3])
+assert Immutable.get(1, arr) == 2
+```
+
 #### Array.Immutable.**toList**
 
 <details>
@@ -1999,6 +2342,15 @@ Returns:
 |type|description|
 |----|-----------|
 |`List<a>`|The list containing all elements from the array|
+
+Examples:
+
+```grain
+from Array use { module Immutable }
+let arr = Immutable.fromList(['a', 'b', 'c'])
+let arr = Immutable.set(0, 'd', arr)
+assert Immutable.toList(arr) == ['d', 'b', 'c']
+```
 
 #### Array.Immutable.**filter**
 
@@ -2035,6 +2387,15 @@ Returns:
 |----|-----------|
 |`ImmutableArray<a>`|The new array containing elements where `fn` returned `true`|
 
+Examples:
+
+```grain
+from Array use { module Immutable }
+let arr = Immutable.fromList(['a', 'a', 'b', 'c'])
+let arr = Immutable.filter((e) => e == 'a', arr)
+assert Immutable.toList(arr) == ['a', 'a']
+```
+
 #### Array.Immutable.**every**
 
 <details>
@@ -2068,6 +2429,20 @@ Returns:
 |type|description|
 |----|-----------|
 |`Bool`|`true` if all elements satify the condition or `false` otherwise|
+
+Examples:
+
+```grain
+from Array use { module Immutable }
+let arr = Immutable.fromList(['a', 'a' ])
+assert Immutable.every(e => e == 'a', arr) == true
+```
+
+```grain
+from Array use { module Immutable }
+let arr = Immutable.fromList(['a', 'a', 'b', 'c'])
+assert Immutable.every(e => e == 'a', arr) == false
+```
 
 #### Array.Immutable.**some**
 
@@ -2103,6 +2478,20 @@ Returns:
 |----|-----------|
 |`Bool`|`true` if one or more elements satify the condition or `false` otherwise|
 
+Examples:
+
+```grain
+from Array use { module Immutable }
+let arr = Immutable.fromList(['a', 'b' ])
+assert Immutable.some(e => e == 'a', arr) == true
+```
+
+```grain
+from Array use { module Immutable }
+let arr = Immutable.fromList(['b', 'c'])
+assert Immutable.some(e => e == 'a', arr) == false
+```
+
 #### Array.Immutable.**reverse**
 
 <details>
@@ -2134,6 +2523,15 @@ Returns:
 |type|description|
 |----|-----------|
 |`ImmutableArray<a>`|The new array|
+
+Examples:
+
+```grain
+from Array use { module Immutable }
+let arr = Immutable.fromList(['a', 'b', 'c'])
+let arr = Immutable.reverse(arr)
+assert Immutable.toList(arr) == ['c', 'b', 'a']
+```
 
 #### Array.Immutable.**contains**
 
@@ -2169,6 +2567,20 @@ Returns:
 |----|-----------|
 |`Bool`|`true` if the value exists in the array or `false` otherwise|
 
+Examples:
+
+```grain
+from Array use { module Immutable }
+let arr = Immutable.fromList(['a', 'b', 'c'])
+assert Immutable.contains('a', arr) == true
+```
+
+```grain
+from Array use { module Immutable }
+let arr = Immutable.fromList(['b', 'c'])
+assert Immutable.contains('a', arr) == false
+```
+
 #### Array.Immutable.**find**
 
 <details>
@@ -2202,6 +2614,20 @@ Returns:
 |----|-----------|
 |`Option<a>`|`Some(element)` containing the first value found or `None` otherwise|
 
+Examples:
+
+```grain
+from Array use { module Immutable }
+let arr = Immutable.fromList([1, 2, 3])
+assert Immutable.find(e => e == 2, arr) == Some(2)
+```
+
+```grain
+from Array use { module Immutable }
+let arr = Immutable.fromList([1, 3])
+assert Immutable.find(e => e == 2, arr) == None
+```
+
 #### Array.Immutable.**findIndex**
 
 <details>
@@ -2234,6 +2660,20 @@ Returns:
 |type|description|
 |----|-----------|
 |`Option<Number>`|`Some(index)` containing the index of the first element found or `None` otherwise|
+
+Examples:
+
+```grain
+from Array use { module Immutable }
+let arr = Immutable.fromList([1, 2, 3])
+assert Immutable.findIndex(e => e == 2, arr) == Some(1)
+```
+
+```grain
+from Array use { module Immutable }
+let arr = Immutable.fromList([1, 3])
+assert Immutable.findIndex(e => e == 2, arr) == None
+```
 
 #### Array.Immutable.**product**
 
@@ -2271,6 +2711,15 @@ Returns:
 |----|-----------|
 |`ImmutableArray<(a, b)>`|The new array containing all pairs of `(a, b)`|
 
+Examples:
+
+```grain
+from Array use { module Immutable }
+let arr1 = Immutable.fromList([1, 2])
+let arr2 = Immutable.fromList([3, 4])
+assert Immutable.product(arr1, arr2) == Immutable.fromList([ (1, 3), (1, 4), (2, 3), (2, 4)])
+```
+
 #### Array.Immutable.**count**
 
 <details>
@@ -2304,6 +2753,14 @@ Returns:
 |----|-----------|
 |`Number`|The total number of elements that satisfy the condition|
 
+Examples:
+
+```grain
+from Array use { module Immutable }
+let arr = Immutable.fromList([1,1,2,3,4])
+assert Immutable.count(e => e == 1, arr) == 2
+```
+
 #### Array.Immutable.**unique**
 
 <details>
@@ -2336,6 +2793,14 @@ Returns:
 |type|description|
 |----|-----------|
 |`ImmutableArray<a>`|The new array with only unique values|
+
+Examples:
+
+```grain
+from Array use { module Immutable }
+let arr = Immutable.fromList([1,1,2,3,2,4])
+assert Immutable.unique(arr) == Immutable.fromList([1,2,3,4])
+```
 
 #### Array.Immutable.**zip**
 
@@ -2376,6 +2841,15 @@ Returns:
 |type|description|
 |----|-----------|
 |`ImmutableArray<(a, b)>`|The new array containing indexed pairs of `(a, b)`|
+
+Examples:
+
+```grain
+from Array use { module Immutable }
+let arr1 = Immutable.fromList([1, 2, 3])
+let arr2 = Immutable.fromList([4, 5, 6])
+assert Immutable.zip(arr1, arr2) == Immutable.fromList([(1, 4), (2, 5), (3, 6)])
+```
 
 #### Array.Immutable.**zipWith**
 
@@ -2423,11 +2897,17 @@ Returns:
 Examples:
 
 ```grain
-zipWith((a, b) => a + b, fromList([1, 2, 3]), fromList([4, 5, 6])) == fromList([5, 7, 9])
+from Array use { module Immutable }
+let arr1 = Immutable.fromList([1, 2, 3])
+let arr2 = Immutable.fromList([4, 5, 6])
+assert Immutable.zipWith((a, b) => a + b, arr1, arr2) == Immutable.fromList([5, 7, 9])
 ```
 
 ```grain
-zipWith((a, b) => a * b, fromList([1, 2, 3]), fromList([4, 5])) == fromList([4, 10])
+from Array use { module Immutable }
+let arr1 = Immutable.fromList([1, 2, 3])
+let arr2 = Immutable.fromList([4, 5, 6])
+assert Immutable.zipWith((a, b) => a * b, arr1, arr2) == Immutable.fromList([4, 10])
 ```
 
 #### Array.Immutable.**unzip**
@@ -2463,6 +2943,16 @@ Returns:
 |----|-----------|
 |`(ImmutableArray<a>, ImmutableArray<b>)`|An array containing all elements from the first tuple element and an array containing all elements from the second tuple element|
 
+Examples:
+
+```grain
+from Array use { module Immutable }
+let arr1 = Immutable.fromList([(1, 2), (3, 4), (5, 6)])
+let arr2 = Immutable.fromList([1, 2, 3])
+let arr3 = Immutable.fromList([4, 5, 6])
+assert Immutable.unzip(arr1) == (arr2, arr3)
+```
+
 #### Array.Immutable.**join**
 
 <details>
@@ -2495,6 +2985,14 @@ Returns:
 |type|description|
 |----|-----------|
 |`String`|The concatenated string|
+
+Examples:
+
+```grain
+from Array use { module Immutable }
+let arr = Immutable.fromList(["a", "b", "c"])
+assert Immutable.join(", ", arr) == "a, b, c"
+```
 
 #### Array.Immutable.**slice**
 
@@ -2540,11 +3038,15 @@ Returns:
 Examples:
 
 ```grain
-slice(0, 2, fromList(['a', 'b', 'c'])) == fromList(['a', 'b'])
+from Array use { module Immutable }
+let arr = Immutable.fromList(['a', 'b', 'c'])
+assert Immutable.slice(0, 2, arr) == Immutable.fromList(['a', 'b'])
 ```
 
 ```grain
-slice(1, -1, fromList(['a', 'b', 'c'])) == fromList(['b'])
+from Array use { module Immutable }
+let arr = Immutable.fromList(['a', 'b', 'c'])
+assert Immutable.slice(1, -1, arr) == Immutable.fromList(['b'])
 ```
 
 #### Array.Immutable.**sort**
@@ -2583,6 +3085,14 @@ Returns:
 |----|-----------|
 |`ImmutableArray<a>`|The sorted array|
 
+Examples:
+
+```grain
+from Array use { module Immutable }
+let arr = Immutable.fromList([2, 3, 1, 4])
+assert Immutable.sort((a, b) => a - b, arr) == Immutable.fromList([1, 2, 3, 4])
+```
+
 #### Array.Immutable.**rotate**
 
 <details>
@@ -2617,10 +3127,14 @@ Parameters:
 Examples:
 
 ```grain
-rotate(2, fromList([1, 2, 3, 4, 5])) == fromList([3, 4, 5, 1, 2])
+from Array use { module Immutable }
+let arr = Immutable.fromList([1, 2, 3, 4, 5])
+assert Immutable.rotate(2, arr) == Immutable.fromList([3, 4, 5, 1, 2])
 ```
 
 ```grain
-rotate(-1, fromList([1, 2, 3, 4, 5])) == fromList([5, 1, 2, 3, 4])
+from Array use { module Immutable }
+let arr = Immutable.fromList([1, 2, 3, 4, 5])
+assert Immutable.rotate(-1, arr) == Immutable.fromList([5, 1, 2, 3, 4])
 ```
 


### PR DESCRIPTION
This pull request adds examples to every function in the array module, along with standardizing the style of the examples.

I plan on going through and adding examples to all the modules in the stdlib starting with this so it makes sense to note some style decisions:
* All the examples are runnable
  *  The only thing that needs to be added is the module header and the include
  * for single line examples an assert needs to be added as well
* Single line examples are treated as if they were assertions
* Syntax for creating the data type is added as an example to the `module`, It seems like a good place to show a basic example of how to create the data type that were working with. I think this will be more helpful with the number libs later on.
* Examples are placed between `@throws` and `@since`
* Examples are mostly kept as simple as possible