### PR TITLE
chore(stdlib): Simplify `Float64.infinity`, `Float64.nan` definitions

### DIFF
--- a/stdlib/float64.gr
+++ b/stdlib/float64.gr
@@ -26,14 +26,7 @@ from Numbers use {
  * @since v0.4.0
  */
 @unsafe
-provide let infinity = {
-  let ptr = newFloat64(
-    WasmF64.reinterpretI64(
-      0b0111111111110000000000000000000000000000000000000000000000000000N
-    )
-  )
-  WasmI32.toGrain(ptr): Float64
-}
+provide let infinity = Infinityd
 
 /**
  * NaN (Not a Number) represented as a Float64 value.
@@ -41,14 +34,7 @@ provide let infinity = {
  * @since v0.4.0
  */
 @unsafe
-provide let nan = {
-  let ptr = newFloat64(
-    WasmF64.reinterpretI64(
-      0b0111111111110000000000000000000000000000000000000000000000000001N
-    )
-  )
-  WasmI32.toGrain(ptr): Float64
-}
+provide let nan = NaNd
 
 /**
  * Pi represented as a Float64 value.


### PR DESCRIPTION
Repurposed this pr to remove the `Float64.Infinity` and `Float64.nan` in favour of `Infinityd` and `NaNd`