### PR TITLE
chore(stdlib): Add examples to `Int8` module

### DIFF
--- a/stdlib/int8.gr
+++ b/stdlib/int8.gr
@@ -2,6 +2,9 @@
  * Utilities for working with the Int8 type.
  * @example include "int8"
  *
+ * @example 1s
+ * @example -1s
+ *
  * @since v0.6.0
  */
 
@@ -51,6 +54,8 @@ provide { fromNumber, toNumber }
  * @param number: The value to convert
  * @returns The Uint8 represented as an Int8
  *
+ * @example Int8.fromUint8(1us) == 1s
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -66,6 +71,9 @@ provide let fromUint8 = (x: Uint8) => {
  *
  * @param value: The value to increment
  * @returns The incremented value
+ *
+ * @example Int8.incr(1s) == 2s
+ * @example Int8.incr(-2s) == -1s
  *
  * @since v0.6.0
  */
@@ -83,6 +91,9 @@ provide let incr = (value: Int8) => {
  * @param value: The value to decrement
  * @returns The decremented value
  *
+ * @example Int8.decr(2s) == 1s
+ * @example Int8.decr(0s) == -1s
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -99,6 +110,10 @@ provide let decr = (value: Int8) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The sum of the two operands
+ *
+ * @example
+ * from Int use { (+) }
+ * assert 1s + 1s == 2s
  *
  * @since v0.6.0
  */
@@ -121,6 +136,10 @@ provide let (+) = (x: Int8, y: Int8) => {
  * @param y: The second operand
  * @returns The difference of the two operands
  *
+ * @example
+ * from Int8 use { (-) }
+ * assert 2s - 1s == 1s
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -139,6 +158,10 @@ provide let (-) = (x: Int8, y: Int8) => {
  * @param y: The second operand
  * @returns The product of the two operands
  *
+ * @example
+ * from Int8 use { (*) }
+ * assert 2s * 2s == 4s
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -155,6 +178,10 @@ provide let (*) = (x: Int8, y: Int8) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The quotient of its operands
+ *
+ * @example
+ * from Int8 use { (/) }
+ * assert 8s / 2s == 4s
  *
  * @since v0.6.0
  */
@@ -173,6 +200,8 @@ provide let (/) = (x: Int8, y: Int8) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The remainder of its operands
+ *
+ * @example Int8.rem(8s, 3s) == 2s
  *
  * @since v0.6.0
  */
@@ -201,6 +230,10 @@ let abs = n => {
  * @returns The modulus of its operands
  *
  * @throws ModuloByZero: When `y` is zero
+ *
+ * @example
+ * from Int8 use { (%) }
+ * assert -5s % 3s == 1s
  *
  * @since v0.6.0
  */
@@ -233,6 +266,10 @@ provide let (%) = (x: Int8, y: Int8) => {
  * @param amount: The number of bits to shift by
  * @returns The shifted value
  *
+ * @example
+ * from Int8 use { (<<) }
+ * assert (5s << 1s) == 10s
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -251,6 +288,10 @@ provide let (<<) = (value: Int8, amount: Int8) => {
  * @param value: The value to shift
  * @param amount: The amount to shift by
  * @returns The shifted value
+ *
+ * @example
+ * from Int8 use { (>>) }
+ * assert (5s >> 1s) == 2s
  *
  * @since v0.6.0
  */
@@ -271,6 +312,10 @@ provide let (>>) = (value: Int8, amount: Int8) => {
  * @param y: The second value
  * @returns `true` if the first value is equal to the second value or `false` otherwise
  *
+ * @example
+ * from Int8 use { (==) }
+ * assert 1s == 1s
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -286,6 +331,10 @@ provide let (==) = (x: Int8, y: Int8) => {
  * @param x: The first value
  * @param y: The second value
  * @returns `true` if the first value is not equal to the second value or `false` otherwise
+ *
+ * @example
+ * from Int8 use { (!=) }
+ * assert 1s != 2s
  *
  * @since v0.6.0
  */
@@ -303,6 +352,10 @@ provide let (!=) = (x: Int8, y: Int8) => {
  * @param y: The second value
  * @returns `true` if the first value is less than the second value or `false` otherwise
  *
+ * @example
+ * from Int8 use { (<) }
+ * assert 1s < 2s
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -318,6 +371,10 @@ provide let (<) = (x: Int8, y: Int8) => {
  * @param x: The first value
  * @param y: The second value
  * @returns `true` if the first value is greater than the second value or `false` otherwise
+ *
+ * @example
+ * from Int8 use { (>) }
+ * assert 2s > 1s
  *
  * @since v0.6.0
  */
@@ -335,6 +392,13 @@ provide let (>) = (x: Int8, y: Int8) => {
  * @param y: The second value
  * @returns `true` if the first value is less than or equal to the second value or `false` otherwise
  *
+ * @example
+ * from Int8 use { (<=) }
+ * assert 1s <= 2s
+ * @example
+ * from Int8 use { (<=) }
+ * assert 1s <= 1s
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -351,6 +415,13 @@ provide let (<=) = (x: Int8, y: Int8) => {
  * @param y: The second value
  * @returns `true` if the first value is greater than or equal to the second value or `false` otherwise
  *
+ * @example
+ * from Int8 use { (>=) }
+ * assert 2s >= 1s
+ * @example
+ * from Int8 use { (>=) }
+ * assert 1s >= 1s
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -366,6 +437,8 @@ provide let (>=) = (x: Int8, y: Int8) => {
  * @param value: The given value
  * @returns Containing the inverted bits of the given value
  *
+ * @example Int.lnot(-5s) == 4s
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -380,6 +453,10 @@ provide let lnot = (value: Int8) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns Containing a `1` in each bit position for which the corresponding bits of both operands are `1`
+ *
+ * @example
+ * from Int8 use { (&) }
+ * assert (3s & 4s) == 0s
  *
  * @since v0.6.0
  */
@@ -399,6 +476,10 @@ provide let (&) = (x: Int8, y: Int8) => {
  * @param y: The second operand
  * @returns Containing a `1` in each bit position for which the corresponding bits of either or both operands are `1`
  *
+ * @example
+ * from Int8 use { (|) }
+ * assert (3s | 4s) == 7s
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -416,6 +497,10 @@ provide let (|) = (x: Int8, y: Int8) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns Containing a `1` in each bit position for which the corresponding bits of either but not both operands are `1`
+ *
+ * @example
+ * from Int8 use { (^) }
+ * assert (3s ^ 5s) == 6s
  *
  * @since v0.6.0
  */

--- a/stdlib/int8.gr
+++ b/stdlib/int8.gr
@@ -112,7 +112,7 @@ provide let decr = (value: Int8) => {
  * @returns The sum of the two operands
  *
  * @example
- * from Int use { (+) }
+ * from Int8 use { (+) }
  * assert 1s + 1s == 2s
  *
  * @since v0.6.0

--- a/stdlib/int8.md
+++ b/stdlib/int8.md
@@ -13,6 +13,14 @@ No other changes yet.
 include "int8"
 ```
 
+```grain
+1s
+```
+
+```grain
+-1s
+```
+
 ## Values
 
 Functions and constants included in the Int8 module.
@@ -92,6 +100,12 @@ Returns:
 |----|-----------|
 |`Int8`|The Uint8 represented as an Int8|
 
+Examples:
+
+```grain
+Int8.fromUint8(1us) == 1s
+```
+
 ### Int8.**incr**
 
 <details disabled>
@@ -117,6 +131,16 @@ Returns:
 |----|-----------|
 |`Int8`|The incremented value|
 
+Examples:
+
+```grain
+Int8.incr(1s) == 2s
+```
+
+```grain
+Int8.incr(-2s) == -1s
+```
+
 ### Int8.**decr**
 
 <details disabled>
@@ -141,6 +165,16 @@ Returns:
 |type|description|
 |----|-----------|
 |`Int8`|The decremented value|
+
+Examples:
+
+```grain
+Int8.decr(2s) == 1s
+```
+
+```grain
+Int8.decr(0s) == -1s
+```
 
 ### Int8.**(+)**
 
@@ -168,6 +202,13 @@ Returns:
 |----|-----------|
 |`Int8`|The sum of the two operands|
 
+Examples:
+
+```grain
+from Int use { (+) }
+assert 1s + 1s == 2s
+```
+
 ### Int8.**(-)**
 
 <details disabled>
@@ -193,6 +234,13 @@ Returns:
 |type|description|
 |----|-----------|
 |`Int8`|The difference of the two operands|
+
+Examples:
+
+```grain
+from Int8 use { (-) }
+assert 2s - 1s == 1s
+```
 
 ### Int8.**(*)**
 
@@ -220,6 +268,13 @@ Returns:
 |----|-----------|
 |`Int8`|The product of the two operands|
 
+Examples:
+
+```grain
+from Int8 use { (*) }
+assert 2s * 2s == 4s
+```
+
 ### Int8.**(/)**
 
 <details disabled>
@@ -246,6 +301,13 @@ Returns:
 |----|-----------|
 |`Int8`|The quotient of its operands|
 
+Examples:
+
+```grain
+from Int8 use { (/) }
+assert 8s / 2s == 4s
+```
+
 ### Int8.**rem**
 
 <details disabled>
@@ -271,6 +333,12 @@ Returns:
 |type|description|
 |----|-----------|
 |`Int8`|The remainder of its operands|
+
+Examples:
+
+```grain
+Int8.rem(8s, 3s) == 2s
+```
 
 ### Int8.**(%)**
 
@@ -305,6 +373,13 @@ Throws:
 
 * When `y` is zero
 
+Examples:
+
+```grain
+from Int8 use { (%) }
+assert -5s % 3s == 1s
+```
+
 ### Int8.**(<<)**
 
 <details disabled>
@@ -330,6 +405,13 @@ Returns:
 |type|description|
 |----|-----------|
 |`Int8`|The shifted value|
+
+Examples:
+
+```grain
+from Int8 use { (<<) }
+assert (5s << 1s) == 10s
+```
 
 ### Int8.**(>>)**
 
@@ -357,6 +439,13 @@ Returns:
 |----|-----------|
 |`Int8`|The shifted value|
 
+Examples:
+
+```grain
+from Int8 use { (>>) }
+assert (5s >> 1s) == 2s
+```
+
 ### Int8.**(==)**
 
 <details disabled>
@@ -382,6 +471,13 @@ Returns:
 |type|description|
 |----|-----------|
 |`Bool`|`true` if the first value is equal to the second value or `false` otherwise|
+
+Examples:
+
+```grain
+from Int8 use { (==) }
+assert 1s == 1s
+```
 
 ### Int8.**(!=)**
 
@@ -409,6 +505,13 @@ Returns:
 |----|-----------|
 |`Bool`|`true` if the first value is not equal to the second value or `false` otherwise|
 
+Examples:
+
+```grain
+from Int8 use { (!=) }
+assert 1s != 2s
+```
+
 ### Int8.**(<)**
 
 <details disabled>
@@ -434,6 +537,13 @@ Returns:
 |type|description|
 |----|-----------|
 |`Bool`|`true` if the first value is less than the second value or `false` otherwise|
+
+Examples:
+
+```grain
+from Int8 use { (<) }
+assert 1s < 2s
+```
 
 ### Int8.**(>)**
 
@@ -461,6 +571,13 @@ Returns:
 |----|-----------|
 |`Bool`|`true` if the first value is greater than the second value or `false` otherwise|
 
+Examples:
+
+```grain
+from Int8 use { (>) }
+assert 2s > 1s
+```
+
 ### Int8.**(<=)**
 
 <details disabled>
@@ -486,6 +603,18 @@ Returns:
 |type|description|
 |----|-----------|
 |`Bool`|`true` if the first value is less than or equal to the second value or `false` otherwise|
+
+Examples:
+
+```grain
+from Int8 use { (<=) }
+assert 1s <= 2s
+```
+
+```grain
+from Int8 use { (<=) }
+assert 1s <= 1s
+```
 
 ### Int8.**(>=)**
 
@@ -513,6 +642,18 @@ Returns:
 |----|-----------|
 |`Bool`|`true` if the first value is greater than or equal to the second value or `false` otherwise|
 
+Examples:
+
+```grain
+from Int8 use { (>=) }
+assert 2s >= 1s
+```
+
+```grain
+from Int8 use { (>=) }
+assert 1s >= 1s
+```
+
 ### Int8.**lnot**
 
 <details disabled>
@@ -537,6 +678,12 @@ Returns:
 |type|description|
 |----|-----------|
 |`Int8`|Containing the inverted bits of the given value|
+
+Examples:
+
+```grain
+Int.lnot(-5s) == 4s
+```
 
 ### Int8.**(&)**
 
@@ -564,6 +711,13 @@ Returns:
 |----|-----------|
 |`Int8`|Containing a `1` in each bit position for which the corresponding bits of both operands are `1`|
 
+Examples:
+
+```grain
+from Int8 use { (&) }
+assert (3s & 4s) == 0s
+```
+
 ### Int8.**(|)**
 
 <details disabled>
@@ -590,6 +744,13 @@ Returns:
 |----|-----------|
 |`Int8`|Containing a `1` in each bit position for which the corresponding bits of either or both operands are `1`|
 
+Examples:
+
+```grain
+from Int8 use { (|) }
+assert (3s | 4s) == 7s
+```
+
 ### Int8.**(^)**
 
 <details disabled>
@@ -615,4 +776,11 @@ Returns:
 |type|description|
 |----|-----------|
 |`Int8`|Containing a `1` in each bit position for which the corresponding bits of either but not both operands are `1`|
+
+Examples:
+
+```grain
+from Int8 use { (^) }
+assert (3s ^ 5s) == 6s
+```
 

--- a/stdlib/int8.md
+++ b/stdlib/int8.md
@@ -205,7 +205,7 @@ Returns:
 Examples:
 
 ```grain
-from Int use { (+) }
+from Int8 use { (+) }
 assert 1s + 1s == 2s
 ```
 


### PR DESCRIPTION
This pr adds examples to the docs for `Int8` 