### PR TITLE
chore(stdlib): Add examples to `Bytes` module

### DIFF
--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -91,7 +91,7 @@ provide let make = (size: Number) => {
 /**
  * An empty byte sequence.
  *
- * @example Bytes.empty() == b""
+ * @example Bytes.empty == b""
  *
  * @since v0.3.2
  */
@@ -124,6 +124,7 @@ provide let fromString = (string: String) => {
  * @returns The string representation of the bytes
  *
  * @example Bytes.toString(b"\x48\x65\x6c\x6c\x6f\x20\x57\x6f\x72\x6c\x64") == "Hello World"
+ * @example Bytes.toString(b"Hello World") == "Hello World"
  *
  * @since v0.3.2
  */

--- a/stdlib/bytes.gr
+++ b/stdlib/bytes.gr
@@ -3,6 +3,9 @@
  *
  * @example include "bytes"
  *
+ * @example b"\x00"
+ * @example Bytes.make(1)
+ *
  * @since v0.3.2
  */
 
@@ -71,6 +74,9 @@ let getSize = ptr => WasmI32.load(ptr, _SIZE_OFFSET)
  * @param size: The number of bytes to store
  * @returns The new byte sequence
  *
+ * @example Bytes.make(0) == b"""
+ * @example Bytes.make(1) == b"\x00"
+ *
  * @since v0.3.2
  */
 @unsafe
@@ -85,6 +91,8 @@ provide let make = (size: Number) => {
 /**
  * An empty byte sequence.
  *
+ * @example Bytes.empty() == b""
+ *
  * @since v0.3.2
  */
 provide let empty = make(0)
@@ -94,6 +102,8 @@ provide let empty = make(0)
  *
  * @param string: The string to copy into a byte sequence
  * @returns The new byte sequence
+ *
+ * @example Bytes.fromString("\x00\x00") == b"\x00\x00"
  *
  * @since v0.3.2
  */
@@ -113,6 +123,8 @@ provide let fromString = (string: String) => {
  * @param bytes: The source byte sequence
  * @returns The string representation of the bytes
  *
+ * @example Bytes.toString(b"\x48\x65\x6c\x6c\x6f\x20\x57\x6f\x72\x6c\x64") == "Hello World"
+ *
  * @since v0.3.2
  */
 @unsafe
@@ -131,6 +143,9 @@ provide let toString = (bytes: Bytes) => {
  * @param bytes: The byte sequence to inspect
  * @returns The number of bytes
  *
+ * @example Bytes.length(b"") == 0
+ * @example Bytes.length(b"\x48") == 1
+ *
  * @since v0.3.2
  */
 @unsafe
@@ -144,6 +159,8 @@ provide let length = (bytes: Bytes) => {
  *
  * @param bytes: The byte sequence to copy
  * @returns The new byte sequence
+ *
+ * @example Bytes.copy(b"\x48") == b"\x48"
  *
  * @since v0.3.2
  */
@@ -166,6 +183,11 @@ provide let copy = (b: Bytes) => {
  * @returns A byte sequence with of the copied bytes
  *
  * @throws InvalidArgument(String): When `start + length` is greater than the bytes size
+ *
+ * @example
+ * assert Bytes.toString(
+ *   Bytes.slice(0, 5, b"\x48\x65\x6c\x6c\x6f\x20\x57\x6f\x72\x6c\x64")
+ * ) == "Hello"
  *
  * @since v0.3.2
  */
@@ -200,6 +222,8 @@ provide let slice = (start: Number, length: Number, bytes: Bytes) => {
  * @returns A resized byte sequence
  *
  * @throws InvalidArgument(String): When the new size is negative
+ *
+ * @example Bytes.length(Bytes.resize(0, 3, b"")) == 3
  *
  * @since v0.3.2
  */
@@ -255,6 +279,11 @@ provide let resize = (left: Number, right: Number, bytes: Bytes) => {
  * @throws InvalidArgument(String): When `srcIndex + length` is greater than the `src` bytes size
  * @throws InvalidArgument(String): When the `dstIndex + length` is greater than the `dst` bytes size
  *
+ * @example
+ * let bytes = Bytes.make(5)
+ * Bytes.move(0, 0, 5, b"\x48\x64\x6c\x6f\x20\x57\x6f\x72\x6c\x64", bytes)
+ * assert Bytes.toString(bytes) == "Hello"
+ *
  * @since v0.3.2
  */
 @unsafe
@@ -298,6 +327,11 @@ provide let move =
  * @param bytes2: The ending byte sequence
  * @returns The new byte sequence
  *
+ * @example
+ * let helloBytes = Bytes.fromString("Hello ")
+ * let worldBytes = Bytes.fromString("World")
+ * assert Bytes.toString(Bytes.concat(helloBytes, worldBytes)) == "Hello World"
+ *
  * @since v0.3.2
  */
 provide let concat = (bytes1: Bytes, bytes2: Bytes) => {
@@ -313,6 +347,11 @@ provide let concat = (bytes1: Bytes, bytes2: Bytes) => {
  *
  * @param value: The value replacing each byte
  * @param bytes: The byte sequence to update
+ *
+ * @example
+ * let bytes = Bytes.make(5)
+ * Bytes.fill(1us, bytes)
+ * assert bytes == b"\x01\x01\x01\x01\x01"
  *
  * @since v0.3.2
  * @history v0.6.0: `value` argument type changed to `Uint8`
@@ -330,6 +369,12 @@ provide let fill = (value: Uint8, bytes: Bytes) => {
  * Replaces all bytes in a byte sequence with zeroes.
  *
  * @param bytes: The byte sequence to clear
+ *
+ * @example
+ * let bytes = Bytes.make(5)
+ * Bytes.fill(1us, bytes)
+ * Bytes.clear(bytes)
+ * assert bytes == b"\x00\x00\x00\x00\x00"
  *
  * @since v0.5.0
  */
@@ -350,6 +395,11 @@ provide let clear = (bytes: Bytes) => {
  *
  * @throws IndexOutOfBounds: When `index` is negative
  * @throws IndexOutOfBounds: When `index + 1` is greater than the bytes size
+ *
+ * @example
+ * let bytes = Bytes.make(1)
+ * Bytes.setInt8(0, 1s, bytes)
+ * assert Bytes.getInt8(0, bytes) == 1s
  *
  * @since v0.6.0
  * @history v0.3.2: Originally called `getInt8S`, returning an `Int32`
@@ -375,6 +425,11 @@ provide let getInt8 = (index: Number, bytes: Bytes) => {
  * @throws IndexOutOfBounds: When `index` is negative
  * @throws IndexOutOfBounds: When `index + 1` is greater than the bytes size
  *
+ * @example
+ * let bytes = Bytes.make(1)
+ * Bytes.setInt8(0, 2s, bytes)
+ * assert Bytes.getInt8(0, bytes) == 2s
+ *
  * @since v0.3.2
  * @history v0.6.0: `value` argument type changed to `Int8`
  */
@@ -398,6 +453,11 @@ provide let setInt8 = (index: Number, value: Int8, bytes: Bytes) => {
  *
  * @throws IndexOutOfBounds: When `index` is negative
  * @throws IndexOutOfBounds: When `index + 1` is greater than the bytes size
+ *
+ * @example
+ * let bytes = Bytes.make(1)
+ * Bytes.setUint8(0, 1us, bytes)
+ * assert Bytes.getUint8(0, bytes) == 1us
  *
  * @since v0.6.0
  * @history v0.3.2: Originally called `getInt8U`, returning an `Int32`
@@ -423,6 +483,11 @@ provide let getUint8 = (index: Number, bytes: Bytes) => {
  * @throws IndexOutOfBounds: When `index` is negative
  * @throws IndexOutOfBounds: When `index + 1` is greater than the bytes size
  *
+ * @example
+ * let bytes = Bytes.make(2)
+ * Bytes.setUint8(1, 2us, bytes)
+ * assert Bytes.getUint8(1, bytes) == 2us
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -445,6 +510,11 @@ provide let setUint8 = (index: Number, value: Uint8, bytes: Bytes) => {
  *
  * @throws IndexOutOfBounds: When `index` is negative
  * @throws IndexOutOfBounds: When `index + 2` is greater than the bytes size
+ *
+ * @example
+ * let bytes = Bytes.make(2)
+ * Bytes.setInt16(0, -2S, bytes)
+ * assert Bytes.getInt16(0, bytes) == -2S
  *
  * @since v0.6.0
  * @history v0.3.2: Originally called `getInt16S`, returning an `Int32`
@@ -470,6 +540,11 @@ provide let getInt16 = (index: Number, bytes: Bytes) => {
  * @throws IndexOutOfBounds: When `index` is negative
  * @throws IndexOutOfBounds: When `index + 2` is greater than the bytes size
  *
+ * @example
+ * let bytes = Bytes.make(2)
+ * Bytes.setInt16(0, -1S, bytes)
+ * assert Bytes.getInt16(0, bytes) == -1S
+ *
  * @since v0.3.2
  * @history v0.6.0: `value` argument type changed to `Int16`
  */
@@ -493,6 +568,11 @@ provide let setInt16 = (index: Number, value: Int16, bytes: Bytes) => {
  *
  * @throws IndexOutOfBounds: When `index` is negative
  * @throws IndexOutOfBounds: When `index + 2` is greater than the bytes size
+ *
+ * @example
+ * let bytes = Bytes.make(2)
+ * Bytes.setUint16(0, 2uS, bytes)
+ * assert Bytes.getUint16(0, bytes) == 2uS
  *
  * @since v0.6.0
  * @history v0.3.2: Originally called `getInt16U`, returning an `Int32`
@@ -518,6 +598,11 @@ provide let getUint16 = (index: Number, bytes: Bytes) => {
  * @throws IndexOutOfBounds: When `index` is negative
  * @throws IndexOutOfBounds: When `index + 2` is greater than the bytes size
  *
+ * @example
+ * let bytes = Bytes.make(2)
+ * Bytes.setUint16(0, 2uS, bytes)
+ * assert Bytes.getUint16(0, bytes) == 2uS
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -540,6 +625,11 @@ provide let setUint16 = (index: Number, value: Uint16, bytes: Bytes) => {
  *
  * @throws IndexOutOfBounds: When `index` is negative
  * @throws IndexOutOfBounds: When `index + 4` is greater than the bytes size
+ *
+ * @example
+ * let bytes = Bytes.make(4)
+ * Bytes.setInt32(0, 1l, bytes)
+ * assert Bytes.getInt32(0, bytes) == 1l
  *
  * @since v0.3.2
  */
@@ -564,6 +654,11 @@ provide let getInt32 = (index: Number, bytes: Bytes) => {
  * @throws IndexOutOfBounds: When `index` is negative
  * @throws IndexOutOfBounds: When `index + 4` is greater than the bytes size
  *
+ * @example
+ * let bytes = Bytes.make(4)
+ * Bytes.setInt32(0, 1l, bytes)
+ * assert Bytes.getInt32(0, bytes) == 1l
+ *
  * @since v0.3.2
  */
 @unsafe
@@ -586,6 +681,11 @@ provide let setInt32 = (index: Number, value: Int32, bytes: Bytes) => {
  *
  * @throws IndexOutOfBounds: When `index` is negative
  * @throws IndexOutOfBounds: When `index + 4` is greater than the bytes size
+ *
+ * @example
+ * let bytes = Bytes.make(4)
+ * Bytes.setUint32(0, 1ul, bytes)
+ * assert Bytes.getUint32(0, bytes) == 1ul
  *
  * @since v0.6.0
  */
@@ -610,6 +710,11 @@ provide let getUint32 = (index: Number, bytes: Bytes) => {
  * @throws IndexOutOfBounds: When `index` is negative
  * @throws IndexOutOfBounds: When `index + 4` is greater than the bytes size
  *
+ * @example
+ * let bytes = Bytes.make(4)
+ * Bytes.setUint32(0, 1ul, bytes)
+ * assert Bytes.getUint32(0, bytes) == 1ul
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -632,6 +737,11 @@ provide let setUint32 = (index: Number, value: Uint32, bytes: Bytes) => {
  *
  * @throws IndexOutOfBounds: When `index` is negative
  * @throws IndexOutOfBounds: When `index + 4` is greater than the bytes size
+ *
+ * @example
+ * let bytes = Bytes.make(4)
+ * Bytes.setFloat32(0, 1.0f, bytes)
+ * assert Bytes.getFloat32(0, bytes) == 1.0f
  *
  * @since v0.3.2
  */
@@ -656,6 +766,11 @@ provide let getFloat32 = (index: Number, bytes: Bytes) => {
  * @throws IndexOutOfBounds: When `index` is negative
  * @throws IndexOutOfBounds: When `index + 4` is greater than the bytes size
  *
+ * @example
+ * let bytes = Bytes.make(4)
+ * Bytes.setFloat32(0, 1.0f, bytes)
+ * assert Bytes.getFloat32(0, bytes) == 1.0f
+ *
  * @since v0.3.2
  */
 @unsafe
@@ -678,6 +793,11 @@ provide let setFloat32 = (index: Number, value: Float32, bytes: Bytes) => {
  *
  * @throws IndexOutOfBounds: When `index` is negative
  * @throws IndexOutOfBounds: When `index + 8` is greater than the bytes size
+ *
+ * @example
+ * let bytes = Bytes.make(8)
+ * Bytes.setInt64(0, 1L, bytes)
+ * assert Bytes.getInt64(0, bytes) == 1L
  *
  * @since v0.3.2
  */
@@ -702,6 +822,11 @@ provide let getInt64 = (index: Number, bytes: Bytes) => {
  * @throws IndexOutOfBounds: When `index` is negative
  * @throws IndexOutOfBounds: When `index + 8` is greater than the bytes size
  *
+ * @example
+ * let bytes = Bytes.make(8)
+ * Bytes.setInt64(0, 1L, bytes)
+ * assert Bytes.getInt64(0, bytes) == 1L
+ *
  * @since v0.3.2
  */
 @unsafe
@@ -724,6 +849,11 @@ provide let setInt64 = (index: Number, value: Int64, bytes: Bytes) => {
  *
  * @throws IndexOutOfBounds: When `index` is negative
  * @throws IndexOutOfBounds: When `index + 8` is greater than the bytes size
+ *
+ * @example
+ * let bytes = Bytes.make(8)
+ * Bytes.setUint64(0, 1uL, bytes)
+ * assert Bytes.getUint64(0, bytes) == 1uL
  *
  * @since v0.6.0
  */
@@ -748,6 +878,11 @@ provide let getUint64 = (index: Number, bytes: Bytes) => {
  * @throws IndexOutOfBounds: When `index` is negative
  * @throws IndexOutOfBounds: When `index + 8` is greater than the bytes size
  *
+ * @example
+ * let bytes = Bytes.make(8)
+ * Bytes.setUint64(0, 1uL, bytes)
+ * assert Bytes.getUint64(0, bytes) == 1uL
+ *
  * @since v0.6.0
  */
 @unsafe
@@ -771,6 +906,11 @@ provide let setUint64 = (index: Number, value: Uint64, bytes: Bytes) => {
  * @throws IndexOutOfBounds: When `index` is negative
  * @throws IndexOutOfBounds: When `index + 8` is greater than the bytes size
  *
+ * @example
+ * let bytes = Bytes.make(8)
+ * Bytes.setFloat64(0, 1.0d, bytes)
+ * assert Bytes.getFloat64(0, bytes) == 1.0d
+ *
  * @since v0.3.2
  */
 @unsafe
@@ -793,6 +933,11 @@ provide let getFloat64 = (index: Number, bytes: Bytes) => {
  *
  * @throws IndexOutOfBounds: When `index` is negative
  * @throws IndexOutOfBounds: When `index + 8` is greater than the bytes size
+ *
+ * @example
+ * let bytes = Bytes.make(8)
+ * Bytes.setFloat64(0, 1.0d, bytes)
+ * assert Bytes.getFloat64(0, bytes) == 1.0d
  *
  * @since v0.3.2
  */

--- a/stdlib/bytes.md
+++ b/stdlib/bytes.md
@@ -76,7 +76,7 @@ An empty byte sequence.
 Examples:
 
 ```grain
-Bytes.empty() == b""
+Bytes.empty == b""
 ```
 
 ### Bytes.**fromString**
@@ -139,6 +139,10 @@ Examples:
 
 ```grain
 Bytes.toString(b"\x48\x65\x6c\x6c\x6f\x20\x57\x6f\x72\x6c\x64") == "Hello World"
+```
+
+```grain
+Bytes.toString(b"Hello World") == "Hello World"
 ```
 
 ### Bytes.**length**

--- a/stdlib/bytes.md
+++ b/stdlib/bytes.md
@@ -13,6 +13,14 @@ No other changes yet.
 include "bytes"
 ```
 
+```grain
+b"\x00"
+```
+
+```grain
+Bytes.make(1)
+```
+
 ## Values
 
 Functions and constants included in the Bytes module.
@@ -42,6 +50,16 @@ Returns:
 |----|-----------|
 |`Bytes`|The new byte sequence|
 
+Examples:
+
+```grain
+Bytes.make(0) == b"""
+```
+
+```grain
+Bytes.make(1) == b"\x00"
+```
+
 ### Bytes.**empty**
 
 <details disabled>
@@ -54,6 +72,12 @@ empty : Bytes
 ```
 
 An empty byte sequence.
+
+Examples:
+
+```grain
+Bytes.empty() == b""
+```
 
 ### Bytes.**fromString**
 
@@ -80,6 +104,12 @@ Returns:
 |----|-----------|
 |`Bytes`|The new byte sequence|
 
+Examples:
+
+```grain
+Bytes.fromString("\x00\x00") == b"\x00\x00"
+```
+
 ### Bytes.**toString**
 
 <details disabled>
@@ -104,6 +134,12 @@ Returns:
 |type|description|
 |----|-----------|
 |`String`|The string representation of the bytes|
+
+Examples:
+
+```grain
+Bytes.toString(b"\x48\x65\x6c\x6c\x6f\x20\x57\x6f\x72\x6c\x64") == "Hello World"
+```
 
 ### Bytes.**length**
 
@@ -130,6 +166,16 @@ Returns:
 |----|-----------|
 |`Number`|The number of bytes|
 
+Examples:
+
+```grain
+Bytes.length(b"") == 0
+```
+
+```grain
+Bytes.length(b"\x48") == 1
+```
+
 ### Bytes.**copy**
 
 <details disabled>
@@ -154,6 +200,12 @@ Returns:
 |type|description|
 |----|-----------|
 |`Bytes`|The new byte sequence|
+
+Examples:
+
+```grain
+Bytes.copy(b"\x48") == b"\x48"
+```
 
 ### Bytes.**slice**
 
@@ -187,6 +239,14 @@ Throws:
 `InvalidArgument(String)`
 
 * When `start + length` is greater than the bytes size
+
+Examples:
+
+```grain
+assert Bytes.toString(
+  Bytes.slice(0, 5, b"\x48\x65\x6c\x6c\x6f\x20\x57\x6f\x72\x6c\x64")
+) == "Hello"
+```
 
 ### Bytes.**resize**
 
@@ -223,6 +283,12 @@ Throws:
 
 * When the new size is negative
 
+Examples:
+
+```grain
+Bytes.length(Bytes.resize(0, 3, b"")) == 3
+```
+
 ### Bytes.**move**
 
 <details disabled>
@@ -256,6 +322,14 @@ Throws:
 * When `srcIndex + length` is greater than the `src` bytes size
 * When the `dstIndex + length` is greater than the `dst` bytes size
 
+Examples:
+
+```grain
+let bytes = Bytes.make(5)
+Bytes.move(0, 0, 5, b"\x48\x64\x6c\x6f\x20\x57\x6f\x72\x6c\x64", bytes)
+assert Bytes.toString(bytes) == "Hello"
+```
+
 ### Bytes.**concat**
 
 <details disabled>
@@ -281,6 +355,14 @@ Returns:
 |type|description|
 |----|-----------|
 |`Bytes`|The new byte sequence|
+
+Examples:
+
+```grain
+let helloBytes = Bytes.fromString("Hello ")
+let worldBytes = Bytes.fromString("World")
+assert Bytes.toString(Bytes.concat(helloBytes, worldBytes)) == "Hello World"
+```
 
 ### Bytes.**fill**
 
@@ -309,6 +391,14 @@ Parameters:
 |`value`|`Uint8`|The value replacing each byte|
 |`bytes`|`Bytes`|The byte sequence to update|
 
+Examples:
+
+```grain
+let bytes = Bytes.make(5)
+Bytes.fill(1us, bytes)
+assert bytes == b"\x01\x01\x01\x01\x01"
+```
+
 ### Bytes.**clear**
 
 <details disabled>
@@ -327,6 +417,15 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`bytes`|`Bytes`|The byte sequence to clear|
+
+Examples:
+
+```grain
+let bytes = Bytes.make(5)
+Bytes.fill(1us, bytes)
+Bytes.clear(bytes)
+assert bytes == b"\x00\x00\x00\x00\x00"
+```
 
 ### Bytes.**getInt8**
 
@@ -368,6 +467,14 @@ Throws:
 * When `index` is negative
 * When `index + 1` is greater than the bytes size
 
+Examples:
+
+```grain
+let bytes = Bytes.make(1)
+Bytes.setInt8(0, 1s, bytes)
+assert Bytes.getInt8(0, bytes) == 1s
+```
+
 ### Bytes.**setInt8**
 
 <details>
@@ -402,6 +509,14 @@ Throws:
 
 * When `index` is negative
 * When `index + 1` is greater than the bytes size
+
+Examples:
+
+```grain
+let bytes = Bytes.make(1)
+Bytes.setInt8(0, 2s, bytes)
+assert Bytes.getInt8(0, bytes) == 2s
+```
 
 ### Bytes.**getUint8**
 
@@ -443,6 +558,14 @@ Throws:
 * When `index` is negative
 * When `index + 1` is greater than the bytes size
 
+Examples:
+
+```grain
+let bytes = Bytes.make(1)
+Bytes.setUint8(0, 1us, bytes)
+assert Bytes.getUint8(0, bytes) == 1us
+```
+
 ### Bytes.**setUint8**
 
 <details disabled>
@@ -470,6 +593,14 @@ Throws:
 
 * When `index` is negative
 * When `index + 1` is greater than the bytes size
+
+Examples:
+
+```grain
+let bytes = Bytes.make(2)
+Bytes.setUint8(1, 2us, bytes)
+assert Bytes.getUint8(1, bytes) == 2us
+```
 
 ### Bytes.**getInt16**
 
@@ -511,6 +642,14 @@ Throws:
 * When `index` is negative
 * When `index + 2` is greater than the bytes size
 
+Examples:
+
+```grain
+let bytes = Bytes.make(2)
+Bytes.setInt16(0, -2S, bytes)
+assert Bytes.getInt16(0, bytes) == -2S
+```
+
 ### Bytes.**setInt16**
 
 <details>
@@ -545,6 +684,14 @@ Throws:
 
 * When `index` is negative
 * When `index + 2` is greater than the bytes size
+
+Examples:
+
+```grain
+let bytes = Bytes.make(2)
+Bytes.setInt16(0, -1S, bytes)
+assert Bytes.getInt16(0, bytes) == -1S
+```
 
 ### Bytes.**getUint16**
 
@@ -586,6 +733,14 @@ Throws:
 * When `index` is negative
 * When `index + 2` is greater than the bytes size
 
+Examples:
+
+```grain
+let bytes = Bytes.make(2)
+Bytes.setUint16(0, 2uS, bytes)
+assert Bytes.getUint16(0, bytes) == 2uS
+```
+
 ### Bytes.**setUint16**
 
 <details disabled>
@@ -613,6 +768,14 @@ Throws:
 
 * When `index` is negative
 * When `index + 2` is greater than the bytes size
+
+Examples:
+
+```grain
+let bytes = Bytes.make(2)
+Bytes.setUint16(0, 2uS, bytes)
+assert Bytes.getUint16(0, bytes) == 2uS
+```
 
 ### Bytes.**getInt32**
 
@@ -647,6 +810,14 @@ Throws:
 * When `index` is negative
 * When `index + 4` is greater than the bytes size
 
+Examples:
+
+```grain
+let bytes = Bytes.make(4)
+Bytes.setInt32(0, 1l, bytes)
+assert Bytes.getInt32(0, bytes) == 1l
+```
+
 ### Bytes.**setInt32**
 
 <details disabled>
@@ -674,6 +845,14 @@ Throws:
 
 * When `index` is negative
 * When `index + 4` is greater than the bytes size
+
+Examples:
+
+```grain
+let bytes = Bytes.make(4)
+Bytes.setInt32(0, 1l, bytes)
+assert Bytes.getInt32(0, bytes) == 1l
+```
 
 ### Bytes.**getUint32**
 
@@ -708,6 +887,14 @@ Throws:
 * When `index` is negative
 * When `index + 4` is greater than the bytes size
 
+Examples:
+
+```grain
+let bytes = Bytes.make(4)
+Bytes.setUint32(0, 1ul, bytes)
+assert Bytes.getUint32(0, bytes) == 1ul
+```
+
 ### Bytes.**setUint32**
 
 <details disabled>
@@ -735,6 +922,14 @@ Throws:
 
 * When `index` is negative
 * When `index + 4` is greater than the bytes size
+
+Examples:
+
+```grain
+let bytes = Bytes.make(4)
+Bytes.setUint32(0, 1ul, bytes)
+assert Bytes.getUint32(0, bytes) == 1ul
+```
 
 ### Bytes.**getFloat32**
 
@@ -769,6 +964,14 @@ Throws:
 * When `index` is negative
 * When `index + 4` is greater than the bytes size
 
+Examples:
+
+```grain
+let bytes = Bytes.make(4)
+Bytes.setFloat32(0, 1.0f, bytes)
+assert Bytes.getFloat32(0, bytes) == 1.0f
+```
+
 ### Bytes.**setFloat32**
 
 <details disabled>
@@ -796,6 +999,14 @@ Throws:
 
 * When `index` is negative
 * When `index + 4` is greater than the bytes size
+
+Examples:
+
+```grain
+let bytes = Bytes.make(4)
+Bytes.setFloat32(0, 1.0f, bytes)
+assert Bytes.getFloat32(0, bytes) == 1.0f
+```
 
 ### Bytes.**getInt64**
 
@@ -830,6 +1041,14 @@ Throws:
 * When `index` is negative
 * When `index + 8` is greater than the bytes size
 
+Examples:
+
+```grain
+let bytes = Bytes.make(8)
+Bytes.setInt64(0, 1L, bytes)
+assert Bytes.getInt64(0, bytes) == 1L
+```
+
 ### Bytes.**setInt64**
 
 <details disabled>
@@ -857,6 +1076,14 @@ Throws:
 
 * When `index` is negative
 * When `index + 8` is greater than the bytes size
+
+Examples:
+
+```grain
+let bytes = Bytes.make(8)
+Bytes.setInt64(0, 1L, bytes)
+assert Bytes.getInt64(0, bytes) == 1L
+```
 
 ### Bytes.**getUint64**
 
@@ -891,6 +1118,14 @@ Throws:
 * When `index` is negative
 * When `index + 8` is greater than the bytes size
 
+Examples:
+
+```grain
+let bytes = Bytes.make(8)
+Bytes.setUint64(0, 1uL, bytes)
+assert Bytes.getUint64(0, bytes) == 1uL
+```
+
 ### Bytes.**setUint64**
 
 <details disabled>
@@ -918,6 +1153,14 @@ Throws:
 
 * When `index` is negative
 * When `index + 8` is greater than the bytes size
+
+Examples:
+
+```grain
+let bytes = Bytes.make(8)
+Bytes.setUint64(0, 1uL, bytes)
+assert Bytes.getUint64(0, bytes) == 1uL
+```
 
 ### Bytes.**getFloat64**
 
@@ -952,6 +1195,14 @@ Throws:
 * When `index` is negative
 * When `index + 8` is greater than the bytes size
 
+Examples:
+
+```grain
+let bytes = Bytes.make(8)
+Bytes.setFloat64(0, 1.0d, bytes)
+assert Bytes.getFloat64(0, bytes) == 1.0d
+```
+
 ### Bytes.**setFloat64**
 
 <details disabled>
@@ -979,4 +1230,12 @@ Throws:
 
 * When `index` is negative
 * When `index + 8` is greater than the bytes size
+
+Examples:
+
+```grain
+let bytes = Bytes.make(8)
+Bytes.setFloat64(0, 1.0d, bytes)
+assert Bytes.getFloat64(0, bytes) == 1.0d
+```
 


### PR DESCRIPTION
This pr adds examples to the docs for `Bytes`