### PR TITLE
chore(stdlib): Add examples to `Exception` module

### DIFF
--- a/stdlib/exception.gr
+++ b/stdlib/exception.gr
@@ -1,11 +1,14 @@
 /**
  * Utilities for working with the Exception type.
  *
- * The Exception type represents an error that has occured during computation.
+ * The Exception type represents an error that has occurred during computation.
  *
  * @example include "exception"
  *
- * @since 0.3.0
+ * @example exception ExampleError(Number)
+ * @example exception ExampleError
+ *
+ * @since v0.3.0
  */
 
 module Exception
@@ -21,6 +24,20 @@ include "runtime/exception"
  * used as the exception's string value.
  *
  * @param printer: The exception printer to register
+ *
+ * @example
+ * exception ExampleError(Number)
+ *
+ * Exception.registerPrinter(e => {
+ *   match (e) {
+ *     ExampleError(lineNumber) =>
+ *       Some("Error found on line: " ++ toString(lineNumber)),
+ *     _ => None,
+ *   }
+ * })
+ *
+ * throw ExampleError(1) // Error found on line: 1
+ *
  * @since v0.3.0
  */
 @disableGC

--- a/stdlib/exception.md
+++ b/stdlib/exception.md
@@ -4,7 +4,7 @@ title: Exception
 
 Utilities for working with the Exception type.
 
-The Exception type represents an error that has occured during computation.
+The Exception type represents an error that has occurred during computation.
 
 <details disabled>
 <summary tabindex="-1">Added in <code>0.3.0</code></summary>
@@ -13,6 +13,14 @@ No other changes yet.
 
 ```grain
 include "exception"
+```
+
+```grain
+exception ExampleError(Number)
+```
+
+```grain
+exception ExampleError
 ```
 
 ## Values
@@ -40,4 +48,20 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`printer`|`Exception => Option<String>`|The exception printer to register|
+
+Examples:
+
+```grain
+exception ExampleError(Number)
+
+Exception.registerPrinter(e => {
+  match (e) {
+    ExampleError(lineNumber) =>
+      Some("Error found on line: " ++ toString(lineNumber)),
+    _ => None,
+  }
+})
+
+throw ExampleError(1) // Error found on line: 1
+```
 


### PR DESCRIPTION
This pr improves the docs for exceptions, by adding examples. Changes the since attribute to use the `v` pattern used by the rest of the stdlib. and fixes a small spelling mistake.