### PR TITLE
feat(stdlib): Simplify `equal` using `Memory.compare`

### DIFF
--- a/stdlib/runtime/equal.gr
+++ b/stdlib/runtime/equal.gr
@@ -8,6 +8,7 @@ include "runtime/unsafe/wasmf32" as WasmF32
 include "runtime/unsafe/tags" as Tags
 include "runtime/numbers" as Numbers
 from Numbers use { isNumber, numberEqual }
+include "runtime/unsafe/memory"
 
 primitive (!) = "@not"
 primitive (||) = "@or"
@@ -125,29 +126,7 @@ let rec heapEqualHelp = (heapTag, xptr, yptr) => {
       if (xlength != ylength) {
         false
       } else {
-        let extra = xlength % 8n
-        let first = xlength - extra
-        let mut result = true
-        for (let mut i = 0n; i < first; i += 8n) {
-          from WasmI64 use { (!=) }
-          if (WasmI64.load(xptr + i, 8n) != WasmI64.load(yptr + i, 8n)) {
-            result = false
-            break
-          }
-        }
-        if (result) {
-          for (let mut i = 0n; i < extra; i += 1n) {
-            if (
-              WasmI32.load8U(xptr + first + i, 8n) !=
-              WasmI32.load8U(yptr + first + i, 8n)
-            ) {
-              result = false
-              break
-            }
-          }
-        }
-
-        result
+        Memory.compare(xptr + 8n, yptr + 8n, xlength) == 0n
       }
     },
     t when t == Tags._GRAIN_TUPLE_HEAP_TAG => {

--- a/stdlib/runtime/equal.gr
+++ b/stdlib/runtime/equal.gr
@@ -1,6 +1,7 @@
 /* grainc-flags --no-pervasives */
 module Equal
 
+include "runtime/unsafe/memory"
 include "runtime/unsafe/wasmi32" as WasmI32
 from WasmI32 use { (==), (!=), (&), (^), (+), (-), (*), (<), remS as (%), (<<) }
 include "runtime/unsafe/wasmi64" as WasmI64
@@ -8,7 +9,6 @@ include "runtime/unsafe/wasmf32" as WasmF32
 include "runtime/unsafe/tags" as Tags
 include "runtime/numbers" as Numbers
 from Numbers use { isNumber, numberEqual }
-include "runtime/unsafe/memory"
 
 primitive (!) = "@not"
 primitive (||) = "@or"


### PR DESCRIPTION
This replaces the logic for `String` equality and `Bytes` equality using the `Memory.compare` function. which should help reduce the size of the generated function and increase performance a tiny bit.