### PR TITLE
chore(stdlib): Export `@array.length` primitive directly

### DIFF
--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -23,9 +23,9 @@ include "runtime/numbers"
 from Numbers use { coerceNumberToWasmI32 }
 
 @unsafe
-let mut _ARRAY_LENGTH_OFFSET = 4n
-@unsafe
 let mut _ARRAY_START_OFFSET = 8n
+
+primitive length = "@array.length"
 
 @unsafe
 let checkLength = length => {
@@ -62,10 +62,7 @@ let wrapNegativeIndex = (arrLen, idx) => {
  * @since v0.1.0
  */
 @unsafe
-provide let length = array => {
-  let ptr = WasmI32.fromGrain(array: Array<a>)
-  tagSimpleNumber(WasmI32.load(ptr, _ARRAY_LENGTH_OFFSET))
-}
+provide let length = array => length(array)
 
 /**
  * Creates a new array of the specified length with each element being

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -25,8 +25,6 @@ from Numbers use { coerceNumberToWasmI32 }
 @unsafe
 let mut _ARRAY_START_OFFSET = 8n
 
-primitive length = "@array.length"
-
 @unsafe
 let checkLength = length => {
   from WasmI32 use { (&), (>>), (<) }
@@ -62,7 +60,7 @@ let wrapNegativeIndex = (arrLen, idx) => {
  * @since v0.1.0
  */
 @unsafe
-provide let length = array => length(array)
+provide primitive length = "@array.length"
 
 /**
  * Creates a new array of the specified length with each element being


### PR DESCRIPTION
This is a really small pr that changes the implementation of `Array.length` to use the internal instruction.