### PR TITLE
chore(ci): Improve reliability of docker builds on AWS

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -39,7 +39,7 @@ jobs:
         id: instance
         run: |
           aws ec2 start-instances --instance-ids ${{ env.AWS_EC2_INSTANCE_ID }}
-          aws ec2 wait instance-running --instance-ids ${{ env.AWS_EC2_INSTANCE_ID }}
+          aws ec2 wait instance-status-ok --instance-ids ${{ env.AWS_EC2_INSTANCE_ID }}
           echo ::set-output name=ip::$(aws ec2 describe-instances --filters "Name=instance-id,Values=${{ env.AWS_EC2_INSTANCE_ID }}" --query 'Reservations[*].Instances[*].[PublicIpAddress]' --output text)
 
       - name: Bring in SSH keys
@@ -119,7 +119,7 @@ jobs:
         id: instance
         run: |
           aws ec2 start-instances --instance-ids ${{ env.AWS_EC2_INSTANCE_ID }}
-          aws ec2 wait instance-running --instance-ids ${{ env.AWS_EC2_INSTANCE_ID }}
+          aws ec2 wait instance-status-ok --instance-ids ${{ env.AWS_EC2_INSTANCE_ID }}
           echo ::set-output name=ip::$(aws ec2 describe-instances --filters "Name=instance-id,Values=${{ env.AWS_EC2_INSTANCE_ID }}" --query 'Reservations[*].Instances[*].[PublicIpAddress]' --output text)
 
       - name: Bring in SSH keys


### PR DESCRIPTION
I believe the flakiness happening with the docker builds is that one job starts the machine and the other sees that it's already running and decides to move forward, even if the machine isn't truly ready yet. This makes the CI wait until the machine reports OK status rather than just running.