### PR TITLE
chore(compiler): Add labels to primitive function types

### DIFF
--- a/compiler/src/typed/typecore.re
+++ b/compiler/src/typed/typecore.re
@@ -270,10 +270,13 @@ let prim1_type =
       );
     }
   | Assert =>
-    prim_type([("bool", Builtin_types.type_bool)], Builtin_types.type_void)
+    prim_type(
+      [("condition", Builtin_types.type_bool)],
+      Builtin_types.type_void,
+    )
   | Throw =>
     prim_type(
-      [("exc", Builtin_types.type_exception)],
+      [("exn", Builtin_types.type_exception)],
       newgenvar(~name="a", ()),
     )
   | Magic =>
@@ -296,7 +299,7 @@ let prim1_type =
   | WasmUnaryF32({arg_type, ret_type})
   | WasmUnaryF64({arg_type, ret_type}) =>
     prim_type(
-      [("int", grain_type_of_wasm_prim_type(arg_type))],
+      [("num", grain_type_of_wasm_prim_type(arg_type))],
       grain_type_of_wasm_prim_type(ret_type),
     )
   | WasmMemoryGrow =>
@@ -319,15 +322,15 @@ let prim2_type =
   | Or =>
     prim_type(
       [
-        ("value1", Builtin_types.type_bool),
-        ("value2", Builtin_types.type_bool),
+        ("left", Builtin_types.type_bool),
+        ("right", Builtin_types.type_bool),
       ],
       Builtin_types.type_bool,
     )
   | Is
   | Eq => {
       let v = newgenvar(~name="a", ());
-      prim_type([("value1", v), ("value2", v)], Builtin_types.type_bool);
+      prim_type([("left", v), ("right", v)], Builtin_types.type_bool);
     }
   | WasmBinaryI32({arg_types: (arg1_type, arg2_type), ret_type})
   | WasmBinaryI64({arg_types: (arg1_type, arg2_type), ret_type})
@@ -335,8 +338,8 @@ let prim2_type =
   | WasmBinaryF64({arg_types: (arg1_type, arg2_type), ret_type}) =>
     prim_type(
       [
-        ("value1", grain_type_of_wasm_prim_type(arg1_type)),
-        ("value2", grain_type_of_wasm_prim_type(arg2_type)),
+        ("left", grain_type_of_wasm_prim_type(arg1_type)),
+        ("right", grain_type_of_wasm_prim_type(arg2_type)),
       ],
       grain_type_of_wasm_prim_type(ret_type),
     )
@@ -415,7 +418,7 @@ let primn_type =
     prim_type(
       [
         ("source", Builtin_types.type_wasmi32),
-        ("dest", Builtin_types.type_wasmi32),
+        ("destination", Builtin_types.type_wasmi32),
         ("length", Builtin_types.type_wasmi32),
       ],
       Builtin_types.type_void,

--- a/compiler/src/typed/typecore.re
+++ b/compiler/src/typed/typecore.re
@@ -108,9 +108,6 @@ let grain_type_of_wasm_prim_type =
   | Grain_bool => Builtin_types.type_bool;
 
 let prim_type = (args, ret) =>
-  newgenty(TTyArrow(List.map(ty => (Unlabeled, ty), args), ret, TComOk));
-
-let prim_type_labeled = (args, ret) =>
   newgenty(
     TTyArrow(
       List.map(
@@ -142,108 +139,195 @@ let prim1_type =
   | AllocateTuple
   | AllocateBytes
   | AllocateString
-  | AllocateBigInt
-  | LoadAdtVariant
+  | AllocateBigInt =>
+    prim_type(
+      [("size", Builtin_types.type_wasmi32)],
+      Builtin_types.type_wasmi32,
+    )
   | StringSize
-  | BytesSize =>
-    prim_type([Builtin_types.type_wasmi32], Builtin_types.type_wasmi32)
+  | BytesSize
+  | LoadAdtVariant =>
+    prim_type(
+      [("ptr", Builtin_types.type_wasmi32)],
+      Builtin_types.type_wasmi32,
+    )
   | NewInt32 =>
-    prim_type([Builtin_types.type_wasmi32], Builtin_types.type_wasmi32)
+    prim_type(
+      [("int", Builtin_types.type_wasmi32)],
+      Builtin_types.type_wasmi32,
+    )
   | NewInt64 =>
-    prim_type([Builtin_types.type_wasmi64], Builtin_types.type_wasmi32)
+    prim_type(
+      [("int", Builtin_types.type_wasmi64)],
+      Builtin_types.type_wasmi32,
+    )
   | NewUint32 =>
-    prim_type([Builtin_types.type_wasmi32], Builtin_types.type_wasmi32)
+    prim_type(
+      [("int", Builtin_types.type_wasmi32)],
+      Builtin_types.type_wasmi32,
+    )
   | NewUint64 =>
-    prim_type([Builtin_types.type_wasmi64], Builtin_types.type_wasmi32)
+    prim_type(
+      [("int", Builtin_types.type_wasmi64)],
+      Builtin_types.type_wasmi32,
+    )
   | NewFloat32 =>
-    prim_type([Builtin_types.type_wasmf32], Builtin_types.type_wasmi32)
+    prim_type(
+      [("float", Builtin_types.type_wasmf32)],
+      Builtin_types.type_wasmi32,
+    )
   | NewFloat64 =>
-    prim_type([Builtin_types.type_wasmf64], Builtin_types.type_wasmi32)
+    prim_type(
+      [("float", Builtin_types.type_wasmf64)],
+      Builtin_types.type_wasmi32,
+    )
   | BuiltinId =>
-    prim_type([Builtin_types.type_string], Builtin_types.type_number)
+    prim_type(
+      [("str", Builtin_types.type_string)],
+      Builtin_types.type_number,
+    )
   | TagSimpleNumber =>
-    prim_type([Builtin_types.type_wasmi32], Builtin_types.type_number)
+    prim_type(
+      [("num", Builtin_types.type_wasmi32)],
+      Builtin_types.type_number,
+    )
   | UntagSimpleNumber =>
-    prim_type([Builtin_types.type_number], Builtin_types.type_wasmi32)
+    prim_type(
+      [("num", Builtin_types.type_number)],
+      Builtin_types.type_wasmi32,
+    )
   | TagChar =>
-    prim_type([Builtin_types.type_wasmi32], Builtin_types.type_char)
+    prim_type(
+      [("char", Builtin_types.type_wasmi32)],
+      Builtin_types.type_char,
+    )
   | UntagChar =>
-    prim_type([Builtin_types.type_char], Builtin_types.type_wasmi32)
+    prim_type(
+      [("char", Builtin_types.type_char)],
+      Builtin_types.type_wasmi32,
+    )
   | TagInt8 =>
-    prim_type([Builtin_types.type_wasmi32], Builtin_types.type_int8)
+    prim_type(
+      [("int", Builtin_types.type_wasmi32)],
+      Builtin_types.type_int8,
+    )
   | UntagInt8 =>
-    prim_type([Builtin_types.type_int8], Builtin_types.type_wasmi32)
+    prim_type(
+      [("int", Builtin_types.type_int8)],
+      Builtin_types.type_wasmi32,
+    )
   | TagInt16 =>
-    prim_type([Builtin_types.type_wasmi32], Builtin_types.type_int16)
+    prim_type(
+      [("int", Builtin_types.type_wasmi32)],
+      Builtin_types.type_int16,
+    )
   | UntagInt16 =>
-    prim_type([Builtin_types.type_int16], Builtin_types.type_wasmi32)
+    prim_type(
+      [("int", Builtin_types.type_int16)],
+      Builtin_types.type_wasmi32,
+    )
   | TagUint8 =>
-    prim_type([Builtin_types.type_wasmi32], Builtin_types.type_uint8)
+    prim_type(
+      [("int", Builtin_types.type_wasmi32)],
+      Builtin_types.type_uint8,
+    )
   | UntagUint8 =>
-    prim_type([Builtin_types.type_uint8], Builtin_types.type_wasmi32)
+    prim_type(
+      [("int", Builtin_types.type_uint8)],
+      Builtin_types.type_wasmi32,
+    )
   | TagUint16 =>
-    prim_type([Builtin_types.type_wasmi32], Builtin_types.type_uint16)
+    prim_type(
+      [("int", Builtin_types.type_wasmi32)],
+      Builtin_types.type_uint16,
+    )
   | UntagUint16 =>
-    prim_type([Builtin_types.type_uint16], Builtin_types.type_wasmi32)
-  | Not => prim_type([Builtin_types.type_bool], Builtin_types.type_bool)
+    prim_type(
+      [("int", Builtin_types.type_uint16)],
+      Builtin_types.type_wasmi32,
+    )
+  | Not =>
+    prim_type([("bool", Builtin_types.type_bool)], Builtin_types.type_bool)
   | Box
   | BoxBind => {
       let var = newgenvar(~name="a", ());
-      prim_type([var], Builtin_types.type_box(var));
+      prim_type([("value", var)], Builtin_types.type_box(var));
     }
   | Unbox
   | UnboxBind => {
       let var = newgenvar(~name="a", ());
-      prim_type([Builtin_types.type_box(var)], var);
+      prim_type([("value", Builtin_types.type_box(var))], var);
     }
   | Ignore => {
       let var = newgenvar(~name="a", ());
-      prim_type([var], Builtin_types.type_void);
+      prim_type([("value", var)], Builtin_types.type_void);
     }
   | ArrayLength => {
       let var = newgenvar(~name="a", ());
-      prim_type_labeled(
+      prim_type(
         [("array", Builtin_types.type_array(var))],
         Builtin_types.type_number,
       );
     }
-  | Assert => prim_type([Builtin_types.type_bool], Builtin_types.type_void)
+  | Assert =>
+    prim_type([("bool", Builtin_types.type_bool)], Builtin_types.type_void)
   | Throw =>
-    prim_type([Builtin_types.type_exception], newgenvar(~name="a", ()))
+    prim_type(
+      [("exc", Builtin_types.type_exception)],
+      newgenvar(~name="a", ()),
+    )
   | Magic =>
-    prim_type([newgenvar(~name="a", ())], newgenvar(~name="b", ()))
+    prim_type(
+      [("value", newgenvar(~name="a", ()))],
+      newgenvar(~name="b", ()),
+    )
   | WasmFromGrain =>
-    prim_type([newgenvar(~name="a", ())], Builtin_types.type_wasmi32)
+    prim_type(
+      [("value", newgenvar(~name="a", ()))],
+      Builtin_types.type_wasmi32,
+    )
   | WasmToGrain =>
-    prim_type([Builtin_types.type_wasmi32], newgenvar(~name="a", ()))
+    prim_type(
+      [("value", Builtin_types.type_wasmi32)],
+      newgenvar(~name="a", ()),
+    )
   | WasmUnaryI32({arg_type, ret_type})
   | WasmUnaryI64({arg_type, ret_type})
   | WasmUnaryF32({arg_type, ret_type})
   | WasmUnaryF64({arg_type, ret_type}) =>
     prim_type(
-      [grain_type_of_wasm_prim_type(arg_type)],
+      [("int", grain_type_of_wasm_prim_type(arg_type))],
       grain_type_of_wasm_prim_type(ret_type),
     )
   | WasmMemoryGrow =>
-    prim_type([Builtin_types.type_wasmi32], Builtin_types.type_wasmi32);
+    prim_type(
+      [("size", Builtin_types.type_wasmi32)],
+      Builtin_types.type_wasmi32,
+    );
 
 let prim2_type =
   fun
   | NewRational =>
     prim_type(
-      [Builtin_types.type_wasmi32, Builtin_types.type_wasmi32],
+      [
+        ("numerator", Builtin_types.type_wasmi32),
+        ("denominator", Builtin_types.type_wasmi32),
+      ],
       Builtin_types.type_wasmi32,
     )
   | And
   | Or =>
     prim_type(
-      [Builtin_types.type_bool, Builtin_types.type_bool],
+      [
+        ("value1", Builtin_types.type_bool),
+        ("value2", Builtin_types.type_bool),
+      ],
       Builtin_types.type_bool,
     )
   | Is
   | Eq => {
       let v = newgenvar(~name="a", ());
-      prim_type([v, v], Builtin_types.type_bool);
+      prim_type([("value1", v), ("value2", v)], Builtin_types.type_bool);
     }
   | WasmBinaryI32({arg_types: (arg1_type, arg2_type), ret_type})
   | WasmBinaryI64({arg_types: (arg1_type, arg2_type), ret_type})
@@ -251,29 +335,41 @@ let prim2_type =
   | WasmBinaryF64({arg_types: (arg1_type, arg2_type), ret_type}) =>
     prim_type(
       [
-        grain_type_of_wasm_prim_type(arg1_type),
-        grain_type_of_wasm_prim_type(arg2_type),
+        ("value1", grain_type_of_wasm_prim_type(arg1_type)),
+        ("value2", grain_type_of_wasm_prim_type(arg2_type)),
       ],
       grain_type_of_wasm_prim_type(ret_type),
     )
   | WasmLoadI32(_) =>
     prim_type(
-      [Builtin_types.type_wasmi32, Builtin_types.type_wasmi32],
+      [
+        ("ptr", Builtin_types.type_wasmi32),
+        ("offset", Builtin_types.type_wasmi32),
+      ],
       Builtin_types.type_wasmi32,
     )
   | WasmLoadI64(_) =>
     prim_type(
-      [Builtin_types.type_wasmi32, Builtin_types.type_wasmi32],
+      [
+        ("ptr", Builtin_types.type_wasmi32),
+        ("offset", Builtin_types.type_wasmi32),
+      ],
       Builtin_types.type_wasmi64,
     )
   | WasmLoadF32 =>
     prim_type(
-      [Builtin_types.type_wasmi32, Builtin_types.type_wasmi32],
+      [
+        ("ptr", Builtin_types.type_wasmi32),
+        ("offset", Builtin_types.type_wasmi32),
+      ],
       Builtin_types.type_wasmf32,
     )
   | WasmLoadF64 =>
     prim_type(
-      [Builtin_types.type_wasmi32, Builtin_types.type_wasmi32],
+      [
+        ("ptr", Builtin_types.type_wasmi32),
+        ("offset", Builtin_types.type_wasmi32),
+      ],
       Builtin_types.type_wasmf64,
     );
 
@@ -282,55 +378,63 @@ let primn_type =
   | WasmStoreI32(_) =>
     prim_type(
       [
-        Builtin_types.type_wasmi32,
-        Builtin_types.type_wasmi32,
-        Builtin_types.type_wasmi32,
+        ("ptr", Builtin_types.type_wasmi32),
+        ("value", Builtin_types.type_wasmi32),
+        ("offset", Builtin_types.type_wasmi32),
       ],
       Builtin_types.type_void,
     )
   | WasmStoreI64(_) =>
     prim_type(
       [
-        Builtin_types.type_wasmi32,
-        Builtin_types.type_wasmi64,
-        Builtin_types.type_wasmi32,
+        ("ptr", Builtin_types.type_wasmi32),
+        ("value", Builtin_types.type_wasmi64),
+        ("offset", Builtin_types.type_wasmi32),
       ],
       Builtin_types.type_void,
     )
   | WasmStoreF32 =>
     prim_type(
       [
-        Builtin_types.type_wasmi32,
-        Builtin_types.type_wasmf32,
-        Builtin_types.type_wasmi32,
+        ("ptr", Builtin_types.type_wasmi32),
+        ("value", Builtin_types.type_wasmf32),
+        ("offset", Builtin_types.type_wasmi32),
       ],
       Builtin_types.type_void,
     )
   | WasmStoreF64 =>
     prim_type(
       [
-        Builtin_types.type_wasmi32,
-        Builtin_types.type_wasmf64,
-        Builtin_types.type_wasmi32,
+        ("ptr", Builtin_types.type_wasmi32),
+        ("value", Builtin_types.type_wasmf64),
+        ("offset", Builtin_types.type_wasmi32),
       ],
       Builtin_types.type_void,
     )
-  | WasmMemoryCopy
+  | WasmMemoryCopy =>
+    prim_type(
+      [
+        ("source", Builtin_types.type_wasmi32),
+        ("dest", Builtin_types.type_wasmi32),
+        ("length", Builtin_types.type_wasmi32),
+      ],
+      Builtin_types.type_void,
+    )
   | WasmMemoryFill =>
     prim_type(
       [
-        Builtin_types.type_wasmi32,
-        Builtin_types.type_wasmi32,
-        Builtin_types.type_wasmi32,
+        ("ptr", Builtin_types.type_wasmi32),
+        ("value", Builtin_types.type_wasmi32),
+        ("length", Builtin_types.type_wasmi32),
       ],
       Builtin_types.type_void,
     )
   | WasmMemoryCompare =>
     prim_type(
       [
-        Builtin_types.type_wasmi32,
-        Builtin_types.type_wasmi32,
-        Builtin_types.type_wasmi32,
+        ("ptr1", Builtin_types.type_wasmi32),
+        ("ptr2", Builtin_types.type_wasmi32),
+        ("length", Builtin_types.type_wasmi32),
       ],
       Builtin_types.type_wasmi32,
     );

--- a/stdlib/pervasives.gr
+++ b/stdlib/pervasives.gr
@@ -48,7 +48,7 @@ from String use { toString, print, concat as (++) }
  * Computes the logical NOT (`!`) of the given operand.
  * Inverts the given Boolean value.
  *
- * @param 0: The operand
+ * @param bool: The operand
  * @returns The inverted value
  *
  * @example !true // false
@@ -64,8 +64,8 @@ provide primitive (!) = "@not"
  * If the first operand is `false`, returns `false` without evaluating the second operand.
  * If the first operand is `true`, returns the value of the second operand.
  *
- * @param 0: The first operand
- * @param 1: The second operand
+ * @param value1: The first operand
+ * @param value2: The second operand
  * @returns The first operand if it is `false` or the value of the second operand otherwise
  *
  * @since v0.1.0
@@ -78,8 +78,8 @@ provide primitive (&&) = "@and"
  * If the first operand is `true`, returns `true` without evaluating the second operand.
  * If the first operand is `false`, returns the value of the second operand.
  *
- * @param 0: The first operand
- * @param 1: The second operand
+ * @param value1: The first operand
+ * @param value2: The second operand
  * @returns The first operand if it is `true` or the value of the second operand otherwise
  *
  * @since v0.1.0
@@ -104,8 +104,8 @@ provide let (!=) = (value1, value2) => !(value1 == value2)
  * Checks that two values are physically equal.
  * Use this operator if you don’t need or want structural equality.
  *
- * @param 0: The first operand
- * @param 1: The second operand
+ * @param value1: The first operand
+ * @param value2: The second operand
  * @returns `true` if the values are physically equal or `false` otherwise
  *
  * @since v0.1.0
@@ -159,7 +159,7 @@ provide { toString, print }
 /**
  * Accepts any value and always returns `void`.
  *
- * @param 0: The value to ignore
+ * @param value: The value to ignore
  *
  * @since v0.1.0
  */
@@ -168,7 +168,7 @@ provide primitive ignore = "@ignore"
 /**
  * Assert that the given Boolean condition is `true`.
  *
- * @param 0: The condition to assert
+ * @param bool: The condition to assert
  *
  * @throws AssertionError: When the `condition` is false
  *
@@ -186,7 +186,7 @@ provide exception InvalidArgument(String)
 /**
  * Throw an exception. Currently, exceptions cannot be caught and will crash your program.
  *
- * @param 0: The exception to be thrown
+ * @param exc: The exception to be thrown
  * @returns Anything and nothing—your program won't continue past a throw
  *
  * @since v0.3.0
@@ -217,7 +217,7 @@ provide let identity = value => value
  * Values inside a box can be swapped out with the `:=` operator.
  * Generally, `let mut` expressions are preferable to using a Box.
  *
- * @param 0: The initial value inside the box
+ * @param value: The initial value inside the box
  * @returns The box containing the initial value
  *
  * @since v0.1.0
@@ -227,7 +227,7 @@ provide primitive box = "@box"
 /**
  * Retrieves the current value from a box.
  *
- * @param 0: The box to unwrap
+ * @param value: The box to unwrap
  * @returns The value inside the box
  *
  * @since v0.1.0

--- a/stdlib/pervasives.gr
+++ b/stdlib/pervasives.gr
@@ -64,8 +64,8 @@ provide primitive (!) = "@not"
  * If the first operand is `false`, returns `false` without evaluating the second operand.
  * If the first operand is `true`, returns the value of the second operand.
  *
- * @param value1: The first operand
- * @param value2: The second operand
+ * @param left: The first operand
+ * @param right: The second operand
  * @returns The first operand if it is `false` or the value of the second operand otherwise
  *
  * @since v0.1.0
@@ -78,8 +78,8 @@ provide primitive (&&) = "@and"
  * If the first operand is `true`, returns `true` without evaluating the second operand.
  * If the first operand is `false`, returns the value of the second operand.
  *
- * @param value1: The first operand
- * @param value2: The second operand
+ * @param left: The first operand
+ * @param right: The second operand
  * @returns The first operand if it is `true` or the value of the second operand otherwise
  *
  * @since v0.1.0
@@ -104,8 +104,8 @@ provide let (!=) = (value1, value2) => !(value1 == value2)
  * Checks that two values are physically equal.
  * Use this operator if you don’t need or want structural equality.
  *
- * @param value1: The first operand
- * @param value2: The second operand
+ * @param left: The first operand
+ * @param right: The second operand
  * @returns `true` if the values are physically equal or `false` otherwise
  *
  * @since v0.1.0
@@ -168,7 +168,7 @@ provide primitive ignore = "@ignore"
 /**
  * Assert that the given Boolean condition is `true`.
  *
- * @param bool: The condition to assert
+ * @param condition: The condition to assert
  *
  * @throws AssertionError: When the `condition` is false
  *
@@ -186,7 +186,7 @@ provide exception InvalidArgument(String)
 /**
  * Throw an exception. Currently, exceptions cannot be caught and will crash your program.
  *
- * @param exc: The exception to be thrown
+ * @param exn: The exception to be thrown
  * @returns Anything and nothing—your program won't continue past a throw
  *
  * @since v0.3.0

--- a/stdlib/pervasives.md
+++ b/stdlib/pervasives.md
@@ -25,7 +25,7 @@ No other changes yet.
 </details>
 
 ```grain
-(!) : Bool => Bool
+(!) : (bool: Bool) => Bool
 ```
 
 Computes the logical NOT (`!`) of the given operand.
@@ -35,7 +35,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`Bool`|The operand|
+|`bool`|`Bool`|The operand|
 
 Returns:
 
@@ -61,7 +61,7 @@ No other changes yet.
 </details>
 
 ```grain
-(&&) : (Bool, Bool) => Bool
+(&&) : (value1: Bool, value2: Bool) => Bool
 ```
 
 Computes the logical AND (`&&`) of the given operands.
@@ -73,8 +73,8 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`Bool`|The first operand|
-|`1`|`Bool`|The second operand|
+|`value1`|`Bool`|The first operand|
+|`value2`|`Bool`|The second operand|
 
 Returns:
 
@@ -90,7 +90,7 @@ No other changes yet.
 </details>
 
 ```grain
-(||) : (Bool, Bool) => Bool
+(||) : (value1: Bool, value2: Bool) => Bool
 ```
 
 Computes the logical OR `||` of the given operands.
@@ -102,8 +102,8 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`Bool`|The first operand|
-|`1`|`Bool`|The second operand|
+|`value1`|`Bool`|The first operand|
+|`value2`|`Bool`|The second operand|
 
 Returns:
 
@@ -173,7 +173,7 @@ No other changes yet.
 </details>
 
 ```grain
-is : (a, a) => Bool
+is : (value1: a, value2: a) => Bool
 ```
 
 Checks that two values are physically equal.
@@ -183,8 +183,8 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`a`|The first operand|
-|`1`|`a`|The second operand|
+|`value1`|`a`|The first operand|
+|`value2`|`a`|The second operand|
 
 Returns:
 
@@ -882,7 +882,7 @@ No other changes yet.
 </details>
 
 ```grain
-ignore : a => Void
+ignore : (value: a) => Void
 ```
 
 Accepts any value and always returns `void`.
@@ -891,7 +891,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`a`|The value to ignore|
+|`value`|`a`|The value to ignore|
 
 ### Pervasives.**assert**
 
@@ -901,7 +901,7 @@ No other changes yet.
 </details>
 
 ```grain
-assert : Bool => Void
+assert : (bool: Bool) => Void
 ```
 
 Assert that the given Boolean condition is `true`.
@@ -910,7 +910,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`Bool`|The condition to assert|
+|`bool`|`Bool`|The condition to assert|
 
 Throws:
 
@@ -936,7 +936,7 @@ No other changes yet.
 </details>
 
 ```grain
-throw : Exception => a
+throw : (exc: Exception) => a
 ```
 
 Throw an exception. Currently, exceptions cannot be caught and will crash your program.
@@ -945,7 +945,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`Exception`|The exception to be thrown|
+|`exc`|`Exception`|The exception to be thrown|
 
 Returns:
 
@@ -1007,7 +1007,7 @@ No other changes yet.
 </details>
 
 ```grain
-box : a => Box<a>
+box : (value: a) => Box<a>
 ```
 
 Creates a box containing the given initial value.
@@ -1018,7 +1018,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`a`|The initial value inside the box|
+|`value`|`a`|The initial value inside the box|
 
 Returns:
 
@@ -1034,7 +1034,7 @@ No other changes yet.
 </details>
 
 ```grain
-unbox : Box<a> => a
+unbox : (value: Box<a>) => a
 ```
 
 Retrieves the current value from a box.
@@ -1043,7 +1043,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`Box<a>`|The box to unwrap|
+|`value`|`Box<a>`|The box to unwrap|
 
 Returns:
 

--- a/stdlib/pervasives.md
+++ b/stdlib/pervasives.md
@@ -61,7 +61,7 @@ No other changes yet.
 </details>
 
 ```grain
-(&&) : (value1: Bool, value2: Bool) => Bool
+(&&) : (left: Bool, right: Bool) => Bool
 ```
 
 Computes the logical AND (`&&`) of the given operands.
@@ -73,8 +73,8 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`value1`|`Bool`|The first operand|
-|`value2`|`Bool`|The second operand|
+|`left`|`Bool`|The first operand|
+|`right`|`Bool`|The second operand|
 
 Returns:
 
@@ -90,7 +90,7 @@ No other changes yet.
 </details>
 
 ```grain
-(||) : (value1: Bool, value2: Bool) => Bool
+(||) : (left: Bool, right: Bool) => Bool
 ```
 
 Computes the logical OR `||` of the given operands.
@@ -102,8 +102,8 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`value1`|`Bool`|The first operand|
-|`value2`|`Bool`|The second operand|
+|`left`|`Bool`|The first operand|
+|`right`|`Bool`|The second operand|
 
 Returns:
 
@@ -173,7 +173,7 @@ No other changes yet.
 </details>
 
 ```grain
-is : (value1: a, value2: a) => Bool
+is : (left: a, right: a) => Bool
 ```
 
 Checks that two values are physically equal.
@@ -183,8 +183,8 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`value1`|`a`|The first operand|
-|`value2`|`a`|The second operand|
+|`left`|`a`|The first operand|
+|`right`|`a`|The second operand|
 
 Returns:
 
@@ -901,7 +901,7 @@ No other changes yet.
 </details>
 
 ```grain
-assert : (bool: Bool) => Void
+assert : (condition: Bool) => Void
 ```
 
 Assert that the given Boolean condition is `true`.
@@ -910,7 +910,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`bool`|`Bool`|The condition to assert|
+|`condition`|`Bool`|The condition to assert|
 
 Throws:
 
@@ -936,7 +936,7 @@ No other changes yet.
 </details>
 
 ```grain
-throw : (exc: Exception) => a
+throw : (exn: Exception) => a
 ```
 
 Throw an exception. Currently, exceptions cannot be caught and will crash your program.
@@ -945,7 +945,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`exc`|`Exception`|The exception to be thrown|
+|`exn`|`Exception`|The exception to be thrown|
 
 Returns:
 

--- a/stdlib/runtime/dataStructures.gr
+++ b/stdlib/runtime/dataStructures.gr
@@ -4,7 +4,7 @@ module DataStructures
 /**
  * Allocates a new Grain array.
  *
- * @param 0: The number of elements to be contained in this array
+ * @param size: The number of elements to be contained in this array
  * @returns The pointer to the array
  */
 @unsafe
@@ -13,7 +13,7 @@ provide primitive allocateArray = "@allocate.array"
 /**
  * Allocates a new Grain tuple.
  *
- * @param 0: The number of elements to be contained in this tuple
+ * @param size: The number of elements to be contained in this tuple
  * @returns The pointer to the tuple
  */
 @unsafe
@@ -22,7 +22,7 @@ provide primitive allocateTuple = "@allocate.tuple"
 /**
  * Allocates a new Grain bytes.
  *
- * @param 0: The number of bytes to be contained in this buffer
+ * @param size: The number of bytes to be contained in this buffer
  * @returns The pointer to the bytes
  */
 @unsafe
@@ -31,7 +31,7 @@ provide primitive allocateBytes = "@allocate.bytes"
 /**
  * Allocates a new Grain string.
  *
- * @param 0: The size (in bytes) of the string to allocate
+ * @param size: The size (in bytes) of the string to allocate
  * @returns The pointer to the string
  */
 @unsafe
@@ -49,8 +49,8 @@ provide primitive allocateInt32 = "@allocate.int32"
 
 /**
  * Allocates a new Int32 with a prepopulated value
- * 
- * @param 0: The value to store
+ *
+ * @param int: The value to store
  * @returns The pointer to the Int32
  */
 @unsafe
@@ -66,8 +66,8 @@ provide primitive allocateUint32 = "@allocate.uint32"
 
 /**
  * Allocates a new Uint32 with a prepopulated value
- * 
- * @param 0: The value to store
+ *
+ * @param int: The value to store
  * @returns The pointer to the Uint32
  */
 @unsafe
@@ -83,8 +83,8 @@ provide primitive allocateInt64 = "@allocate.int64"
 
 /**
  * Allocates a new Int64 with a prepopulated value
- * 
- * @param 0: The value to store
+ *
+ * @param int: The value to store
  * @returns The pointer to the Int64
  */
 @unsafe
@@ -100,8 +100,8 @@ provide primitive allocateUint64 = "@allocate.uint64"
 
 /**
  * Allocates a new Uint64 with a prepopulated value
- * 
- * @param 0: The value to store
+ *
+ * @param int: The value to store
  * @returns The pointer to the Uint64
  */
 @unsafe
@@ -119,8 +119,8 @@ provide primitive allocateFloat32 = "@allocate.float32"
 
 /**
  * Allocates a new Float32 with a prepopulated value
- * 
- * @param 0: The value to store
+ *
+ * @param float: The value to store
  * @returns the pointer to the Float32
  */
 @unsafe
@@ -136,8 +136,8 @@ provide primitive allocateFloat64 = "@allocate.float64"
 
 /**
  * Allocates a new Float64 with a prepopulated value
- * 
- * @param 0: The value to store
+ *
+ * @param float: The value to store
  * @returns The pointer to the Float64
  */
 @unsafe
@@ -155,9 +155,9 @@ provide primitive allocateRational = "@allocate.rational"
 
 /**
  * Allocates a new Rational with a prepopulated value
- * 
- * @param 0: The numerator value to store
- * @param 1: The denominator value to store
+ *
+ * @param numerator: The numerator value to store
+ * @param denominator: The denominator value to store
  * @returns The pointer to the Rational
  */
 @unsafe
@@ -166,7 +166,7 @@ provide primitive newRational = "@new.rational"
 /**
  * Load the (tagged) variant of an ADT.
  *
- * @param 0: Untagged pointer to the ADT
+ * @param ptr: Untagged pointer to the ADT
  * @returns The (tagged) ADT variant id
  */
 @unsafe
@@ -175,7 +175,7 @@ provide primitive loadAdtVariant = "@adt.load_variant"
 /**
  * Load an untagged string's size.
  *
- * @param 0: Untagged pointer to the string
+ * @param ptr: Untagged pointer to the string
  * @returns The string size (in bytes)
  */
 @unsafe
@@ -184,7 +184,7 @@ provide primitive stringSize = "@string.size"
 /**
  * Load an untagged Bytes' size.
  *
- * @param 0: Untagged pointer to the Bytes
+ * @param ptr: Untagged pointer to the Bytes
  * @returns The Bytes size (in bytes)
  */
 @unsafe
@@ -193,7 +193,7 @@ provide primitive bytesSize = "@bytes.size"
 /**
  * Tag a simple number.
  *
- * @param 0: The number to tag
+ * @param num: The number to tag
  * @returns The tagged number
  */
 @unsafe
@@ -202,7 +202,7 @@ provide primitive tagSimpleNumber = "@tag.simple_number"
 /**
  * Untag a simple number.
  *
- * @param 0: The number to untag
+ * @param num: The number to untag
  * @returns The untagged number
  */
 @unsafe
@@ -211,7 +211,7 @@ provide primitive untagSimpleNumber = "@untag.simple_number"
 /**
  * Tag a char.
  *
- * @param 0: The usv to tag
+ * @param char: The usv to tag
  * @returns The tagged char
  */
 @unsafe
@@ -220,7 +220,7 @@ provide primitive tagChar = "@tag.char"
 /**
  * Untag a char.
  *
- * @param 0: The char to untag
+ * @param char: The char to untag
  * @returns The untagged usv
  */
 @unsafe
@@ -229,7 +229,7 @@ provide primitive untagChar = "@untag.char"
 /**
  * Tag an int8.
  *
- * @param 0: The int8 to tag
+ * @param int: The int8 to tag
  * @returns The tagged int8
  */
 @unsafe
@@ -238,7 +238,7 @@ provide primitive tagInt8 = "@tag.int8"
 /**
  * Untag an int8.
  *
- * @param 0: The int8 to untag
+ * @param int: The int8 to untag
  * @returns The untagged int8
  */
 @unsafe
@@ -247,7 +247,7 @@ provide primitive untagInt8 = "@untag.int8"
 /**
  * Tag an int16.
  *
- * @param 0: The int16 to tag
+ * @param int: The int16 to tag
  * @returns The tagged int16
  */
 @unsafe
@@ -256,7 +256,7 @@ provide primitive tagInt16 = "@tag.int16"
 /**
  * Untag an int16.
  *
- * @param 0: The int16 to untag
+ * @param int: The int16 to untag
  * @returns The untagged int16
  */
 @unsafe
@@ -265,7 +265,7 @@ provide primitive untagInt16 = "@untag.int16"
 /**
  * Tag a uint8.
  *
- * @param 0: The uint8 to tag
+ * @param int: The uint8 to tag
  * @returns The tagged uint8
  */
 @unsafe
@@ -274,7 +274,7 @@ provide primitive tagUint8 = "@tag.uint8"
 /**
  * Untag a uint8.
  *
- * @param 0: The uint8 to untag
+ * @param int: The uint8 to untag
  * @returns The untagged uint8
  */
 @unsafe
@@ -283,7 +283,7 @@ provide primitive untagUint8 = "@untag.uint8"
 /**
  * Tag a uint16.
  *
- * @param 0: The uint16 to tag
+ * @param int: The uint16 to tag
  * @returns The tagged uint16
  */
 @unsafe
@@ -292,7 +292,7 @@ provide primitive tagUint16 = "@tag.uint16"
 /**
  * Untag a uint16.
  *
- * @param 0: The uint16 to untag
+ * @param int: The uint16 to untag
  * @returns The untagged uint16
  */
 @unsafe

--- a/stdlib/runtime/dataStructures.md
+++ b/stdlib/runtime/dataStructures.md
@@ -9,7 +9,7 @@ Functions and constants included in the DataStructures module.
 ### DataStructures.**allocateArray**
 
 ```grain
-allocateArray : WasmI32 => WasmI32
+allocateArray : (size: WasmI32) => WasmI32
 ```
 
 Allocates a new Grain array.
@@ -18,7 +18,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`WasmI32`|The number of elements to be contained in this array|
+|`size`|`WasmI32`|The number of elements to be contained in this array|
 
 Returns:
 
@@ -29,7 +29,7 @@ Returns:
 ### DataStructures.**allocateTuple**
 
 ```grain
-allocateTuple : WasmI32 => WasmI32
+allocateTuple : (size: WasmI32) => WasmI32
 ```
 
 Allocates a new Grain tuple.
@@ -38,7 +38,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`WasmI32`|The number of elements to be contained in this tuple|
+|`size`|`WasmI32`|The number of elements to be contained in this tuple|
 
 Returns:
 
@@ -49,7 +49,7 @@ Returns:
 ### DataStructures.**allocateBytes**
 
 ```grain
-allocateBytes : WasmI32 => WasmI32
+allocateBytes : (size: WasmI32) => WasmI32
 ```
 
 Allocates a new Grain bytes.
@@ -58,7 +58,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`WasmI32`|The number of bytes to be contained in this buffer|
+|`size`|`WasmI32`|The number of bytes to be contained in this buffer|
 
 Returns:
 
@@ -69,7 +69,7 @@ Returns:
 ### DataStructures.**allocateString**
 
 ```grain
-allocateString : WasmI32 => WasmI32
+allocateString : (size: WasmI32) => WasmI32
 ```
 
 Allocates a new Grain string.
@@ -78,7 +78,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`WasmI32`|The size (in bytes) of the string to allocate|
+|`size`|`WasmI32`|The size (in bytes) of the string to allocate|
 
 Returns:
 
@@ -103,7 +103,7 @@ Returns:
 ### DataStructures.**newInt32**
 
 ```grain
-newInt32 : WasmI32 => WasmI32
+newInt32 : (int: WasmI32) => WasmI32
 ```
 
 Allocates a new Int32 with a prepopulated value
@@ -112,7 +112,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`WasmI32`|The value to store|
+|`int`|`WasmI32`|The value to store|
 
 Returns:
 
@@ -137,7 +137,7 @@ Returns:
 ### DataStructures.**newUint32**
 
 ```grain
-newUint32 : WasmI32 => WasmI32
+newUint32 : (int: WasmI32) => WasmI32
 ```
 
 Allocates a new Uint32 with a prepopulated value
@@ -146,7 +146,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`WasmI32`|The value to store|
+|`int`|`WasmI32`|The value to store|
 
 Returns:
 
@@ -171,7 +171,7 @@ Returns:
 ### DataStructures.**newInt64**
 
 ```grain
-newInt64 : WasmI64 => WasmI32
+newInt64 : (int: WasmI64) => WasmI32
 ```
 
 Allocates a new Int64 with a prepopulated value
@@ -180,7 +180,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`WasmI64`|The value to store|
+|`int`|`WasmI64`|The value to store|
 
 Returns:
 
@@ -205,7 +205,7 @@ Returns:
 ### DataStructures.**newUint64**
 
 ```grain
-newUint64 : WasmI64 => WasmI32
+newUint64 : (int: WasmI64) => WasmI32
 ```
 
 Allocates a new Uint64 with a prepopulated value
@@ -214,7 +214,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`WasmI64`|The value to store|
+|`int`|`WasmI64`|The value to store|
 
 Returns:
 
@@ -239,7 +239,7 @@ Returns:
 ### DataStructures.**newFloat32**
 
 ```grain
-newFloat32 : WasmF32 => WasmI32
+newFloat32 : (float: WasmF32) => WasmI32
 ```
 
 Allocates a new Float32 with a prepopulated value
@@ -248,7 +248,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`WasmF32`|The value to store|
+|`float`|`WasmF32`|The value to store|
 
 Returns:
 
@@ -273,7 +273,7 @@ Returns:
 ### DataStructures.**newFloat64**
 
 ```grain
-newFloat64 : WasmF64 => WasmI32
+newFloat64 : (float: WasmF64) => WasmI32
 ```
 
 Allocates a new Float64 with a prepopulated value
@@ -282,7 +282,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`WasmF64`|The value to store|
+|`float`|`WasmF64`|The value to store|
 
 Returns:
 
@@ -307,7 +307,7 @@ Returns:
 ### DataStructures.**newRational**
 
 ```grain
-newRational : (WasmI32, WasmI32) => WasmI32
+newRational : (numerator: WasmI32, denominator: WasmI32) => WasmI32
 ```
 
 Allocates a new Rational with a prepopulated value
@@ -316,8 +316,8 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`WasmI32`|The numerator value to store|
-|`1`|`WasmI32`|The denominator value to store|
+|`numerator`|`WasmI32`|The numerator value to store|
+|`denominator`|`WasmI32`|The denominator value to store|
 
 Returns:
 
@@ -328,7 +328,7 @@ Returns:
 ### DataStructures.**loadAdtVariant**
 
 ```grain
-loadAdtVariant : WasmI32 => WasmI32
+loadAdtVariant : (ptr: WasmI32) => WasmI32
 ```
 
 Load the (tagged) variant of an ADT.
@@ -337,7 +337,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`WasmI32`|Untagged pointer to the ADT|
+|`ptr`|`WasmI32`|Untagged pointer to the ADT|
 
 Returns:
 
@@ -348,7 +348,7 @@ Returns:
 ### DataStructures.**stringSize**
 
 ```grain
-stringSize : WasmI32 => WasmI32
+stringSize : (ptr: WasmI32) => WasmI32
 ```
 
 Load an untagged string's size.
@@ -357,7 +357,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`WasmI32`|Untagged pointer to the string|
+|`ptr`|`WasmI32`|Untagged pointer to the string|
 
 Returns:
 
@@ -368,7 +368,7 @@ Returns:
 ### DataStructures.**bytesSize**
 
 ```grain
-bytesSize : WasmI32 => WasmI32
+bytesSize : (ptr: WasmI32) => WasmI32
 ```
 
 Load an untagged Bytes' size.
@@ -377,7 +377,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`WasmI32`|Untagged pointer to the Bytes|
+|`ptr`|`WasmI32`|Untagged pointer to the Bytes|
 
 Returns:
 
@@ -388,7 +388,7 @@ Returns:
 ### DataStructures.**tagSimpleNumber**
 
 ```grain
-tagSimpleNumber : WasmI32 => Number
+tagSimpleNumber : (num: WasmI32) => Number
 ```
 
 Tag a simple number.
@@ -397,7 +397,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`WasmI32`|The number to tag|
+|`num`|`WasmI32`|The number to tag|
 
 Returns:
 
@@ -408,7 +408,7 @@ Returns:
 ### DataStructures.**untagSimpleNumber**
 
 ```grain
-untagSimpleNumber : Number => WasmI32
+untagSimpleNumber : (num: Number) => WasmI32
 ```
 
 Untag a simple number.
@@ -417,7 +417,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`Number`|The number to untag|
+|`num`|`Number`|The number to untag|
 
 Returns:
 
@@ -428,7 +428,7 @@ Returns:
 ### DataStructures.**tagChar**
 
 ```grain
-tagChar : WasmI32 => Char
+tagChar : (char: WasmI32) => Char
 ```
 
 Tag a char.
@@ -437,7 +437,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`WasmI32`|The usv to tag|
+|`char`|`WasmI32`|The usv to tag|
 
 Returns:
 
@@ -448,7 +448,7 @@ Returns:
 ### DataStructures.**untagChar**
 
 ```grain
-untagChar : Char => WasmI32
+untagChar : (char: Char) => WasmI32
 ```
 
 Untag a char.
@@ -457,7 +457,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`Char`|The char to untag|
+|`char`|`Char`|The char to untag|
 
 Returns:
 
@@ -468,7 +468,7 @@ Returns:
 ### DataStructures.**tagInt8**
 
 ```grain
-tagInt8 : WasmI32 => Int8
+tagInt8 : (int: WasmI32) => Int8
 ```
 
 Tag an int8.
@@ -477,7 +477,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`WasmI32`|The int8 to tag|
+|`int`|`WasmI32`|The int8 to tag|
 
 Returns:
 
@@ -488,7 +488,7 @@ Returns:
 ### DataStructures.**untagInt8**
 
 ```grain
-untagInt8 : Int8 => WasmI32
+untagInt8 : (int: Int8) => WasmI32
 ```
 
 Untag an int8.
@@ -497,7 +497,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`Int8`|The int8 to untag|
+|`int`|`Int8`|The int8 to untag|
 
 Returns:
 
@@ -508,7 +508,7 @@ Returns:
 ### DataStructures.**tagInt16**
 
 ```grain
-tagInt16 : WasmI32 => Int16
+tagInt16 : (int: WasmI32) => Int16
 ```
 
 Tag an int16.
@@ -517,7 +517,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`WasmI32`|The int16 to tag|
+|`int`|`WasmI32`|The int16 to tag|
 
 Returns:
 
@@ -528,7 +528,7 @@ Returns:
 ### DataStructures.**untagInt16**
 
 ```grain
-untagInt16 : Int16 => WasmI32
+untagInt16 : (int: Int16) => WasmI32
 ```
 
 Untag an int16.
@@ -537,7 +537,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`Int16`|The int16 to untag|
+|`int`|`Int16`|The int16 to untag|
 
 Returns:
 
@@ -548,7 +548,7 @@ Returns:
 ### DataStructures.**tagUint8**
 
 ```grain
-tagUint8 : WasmI32 => Uint8
+tagUint8 : (int: WasmI32) => Uint8
 ```
 
 Tag a uint8.
@@ -557,7 +557,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`WasmI32`|The uint8 to tag|
+|`int`|`WasmI32`|The uint8 to tag|
 
 Returns:
 
@@ -568,7 +568,7 @@ Returns:
 ### DataStructures.**untagUint8**
 
 ```grain
-untagUint8 : Uint8 => WasmI32
+untagUint8 : (int: Uint8) => WasmI32
 ```
 
 Untag a uint8.
@@ -577,7 +577,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`Uint8`|The uint8 to untag|
+|`int`|`Uint8`|The uint8 to untag|
 
 Returns:
 
@@ -588,7 +588,7 @@ Returns:
 ### DataStructures.**tagUint16**
 
 ```grain
-tagUint16 : WasmI32 => Uint16
+tagUint16 : (int: WasmI32) => Uint16
 ```
 
 Tag a uint16.
@@ -597,7 +597,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`WasmI32`|The uint16 to tag|
+|`int`|`WasmI32`|The uint16 to tag|
 
 Returns:
 
@@ -608,7 +608,7 @@ Returns:
 ### DataStructures.**untagUint16**
 
 ```grain
-untagUint16 : Uint16 => WasmI32
+untagUint16 : (int: Uint16) => WasmI32
 ```
 
 Untag a uint16.
@@ -617,7 +617,7 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`Uint16`|The uint16 to untag|
+|`int`|`Uint16`|The uint16 to untag|
 
 Returns:
 

--- a/stdlib/runtime/unsafe/memory.md
+++ b/stdlib/runtime/unsafe/memory.md
@@ -45,6 +45,6 @@ fill : (dest: WasmI32, c: WasmI32, n: WasmI32) => Void
 ### Memory.**compare**
 
 ```grain
-compare : (WasmI32, WasmI32, WasmI32) => WasmI32
+compare : (ptr1: WasmI32, ptr2: WasmI32, length: WasmI32) => WasmI32
 ```
 

--- a/stdlib/runtime/unsafe/wasmf32.md
+++ b/stdlib/runtime/unsafe/wasmf32.md
@@ -21,156 +21,156 @@ store : (ptr: WasmI32, value: WasmF32, offset: WasmI32) => Void
 ### WasmF32.**neg**
 
 ```grain
-neg : (int: WasmF32) => WasmF32
+neg : (num: WasmF32) => WasmF32
 ```
 
 ### WasmF32.**abs**
 
 ```grain
-abs : (int: WasmF32) => WasmF32
+abs : (num: WasmF32) => WasmF32
 ```
 
 ### WasmF32.**ceil**
 
 ```grain
-ceil : (int: WasmF32) => WasmF32
+ceil : (num: WasmF32) => WasmF32
 ```
 
 ### WasmF32.**floor**
 
 ```grain
-floor : (int: WasmF32) => WasmF32
+floor : (num: WasmF32) => WasmF32
 ```
 
 ### WasmF32.**trunc**
 
 ```grain
-trunc : (int: WasmF32) => WasmF32
+trunc : (num: WasmF32) => WasmF32
 ```
 
 ### WasmF32.**nearest**
 
 ```grain
-nearest : (int: WasmF32) => WasmF32
+nearest : (num: WasmF32) => WasmF32
 ```
 
 ### WasmF32.**sqrt**
 
 ```grain
-sqrt : (int: WasmF32) => WasmF32
+sqrt : (num: WasmF32) => WasmF32
 ```
 
 ### WasmF32.**(+)**
 
 ```grain
-(+) : (value1: WasmF32, value2: WasmF32) => WasmF32
+(+) : (left: WasmF32, right: WasmF32) => WasmF32
 ```
 
 ### WasmF32.**(-)**
 
 ```grain
-(-) : (value1: WasmF32, value2: WasmF32) => WasmF32
+(-) : (left: WasmF32, right: WasmF32) => WasmF32
 ```
 
 ### WasmF32.**(*)**
 
 ```grain
-(*) : (value1: WasmF32, value2: WasmF32) => WasmF32
+(*) : (left: WasmF32, right: WasmF32) => WasmF32
 ```
 
 ### WasmF32.**(/)**
 
 ```grain
-(/) : (value1: WasmF32, value2: WasmF32) => WasmF32
+(/) : (left: WasmF32, right: WasmF32) => WasmF32
 ```
 
 ### WasmF32.**copySign**
 
 ```grain
-copySign : (value1: WasmF32, value2: WasmF32) => WasmF32
+copySign : (left: WasmF32, right: WasmF32) => WasmF32
 ```
 
 ### WasmF32.**min**
 
 ```grain
-min : (value1: WasmF32, value2: WasmF32) => WasmF32
+min : (left: WasmF32, right: WasmF32) => WasmF32
 ```
 
 ### WasmF32.**max**
 
 ```grain
-max : (value1: WasmF32, value2: WasmF32) => WasmF32
+max : (left: WasmF32, right: WasmF32) => WasmF32
 ```
 
 ### WasmF32.**(==)**
 
 ```grain
-(==) : (value1: WasmF32, value2: WasmF32) => Bool
+(==) : (left: WasmF32, right: WasmF32) => Bool
 ```
 
 ### WasmF32.**(!=)**
 
 ```grain
-(!=) : (value1: WasmF32, value2: WasmF32) => Bool
+(!=) : (left: WasmF32, right: WasmF32) => Bool
 ```
 
 ### WasmF32.**(<)**
 
 ```grain
-(<) : (value1: WasmF32, value2: WasmF32) => Bool
+(<) : (left: WasmF32, right: WasmF32) => Bool
 ```
 
 ### WasmF32.**(<=)**
 
 ```grain
-(<=) : (value1: WasmF32, value2: WasmF32) => Bool
+(<=) : (left: WasmF32, right: WasmF32) => Bool
 ```
 
 ### WasmF32.**(>)**
 
 ```grain
-(>) : (value1: WasmF32, value2: WasmF32) => Bool
+(>) : (left: WasmF32, right: WasmF32) => Bool
 ```
 
 ### WasmF32.**(>=)**
 
 ```grain
-(>=) : (value1: WasmF32, value2: WasmF32) => Bool
+(>=) : (left: WasmF32, right: WasmF32) => Bool
 ```
 
 ### WasmF32.**reinterpretI32**
 
 ```grain
-reinterpretI32 : (int: WasmI32) => WasmF32
+reinterpretI32 : (num: WasmI32) => WasmF32
 ```
 
 ### WasmF32.**convertI32S**
 
 ```grain
-convertI32S : (int: WasmI32) => WasmF32
+convertI32S : (num: WasmI32) => WasmF32
 ```
 
 ### WasmF32.**convertI32U**
 
 ```grain
-convertI32U : (int: WasmI32) => WasmF32
+convertI32U : (num: WasmI32) => WasmF32
 ```
 
 ### WasmF32.**convertI64S**
 
 ```grain
-convertI64S : (int: WasmI64) => WasmF32
+convertI64S : (num: WasmI64) => WasmF32
 ```
 
 ### WasmF32.**convertI64U**
 
 ```grain
-convertI64U : (int: WasmI64) => WasmF32
+convertI64U : (num: WasmI64) => WasmF32
 ```
 
 ### WasmF32.**demoteF64**
 
 ```grain
-demoteF64 : (int: WasmF64) => WasmF32
+demoteF64 : (num: WasmF64) => WasmF32
 ```
 

--- a/stdlib/runtime/unsafe/wasmf32.md
+++ b/stdlib/runtime/unsafe/wasmf32.md
@@ -9,168 +9,168 @@ Functions and constants included in the WasmF32 module.
 ### WasmF32.**load**
 
 ```grain
-load : (WasmI32, WasmI32) => WasmF32
+load : (ptr: WasmI32, offset: WasmI32) => WasmF32
 ```
 
 ### WasmF32.**store**
 
 ```grain
-store : (WasmI32, WasmF32, WasmI32) => Void
+store : (ptr: WasmI32, value: WasmF32, offset: WasmI32) => Void
 ```
 
 ### WasmF32.**neg**
 
 ```grain
-neg : WasmF32 => WasmF32
+neg : (int: WasmF32) => WasmF32
 ```
 
 ### WasmF32.**abs**
 
 ```grain
-abs : WasmF32 => WasmF32
+abs : (int: WasmF32) => WasmF32
 ```
 
 ### WasmF32.**ceil**
 
 ```grain
-ceil : WasmF32 => WasmF32
+ceil : (int: WasmF32) => WasmF32
 ```
 
 ### WasmF32.**floor**
 
 ```grain
-floor : WasmF32 => WasmF32
+floor : (int: WasmF32) => WasmF32
 ```
 
 ### WasmF32.**trunc**
 
 ```grain
-trunc : WasmF32 => WasmF32
+trunc : (int: WasmF32) => WasmF32
 ```
 
 ### WasmF32.**nearest**
 
 ```grain
-nearest : WasmF32 => WasmF32
+nearest : (int: WasmF32) => WasmF32
 ```
 
 ### WasmF32.**sqrt**
 
 ```grain
-sqrt : WasmF32 => WasmF32
+sqrt : (int: WasmF32) => WasmF32
 ```
 
 ### WasmF32.**(+)**
 
 ```grain
-(+) : (WasmF32, WasmF32) => WasmF32
+(+) : (value1: WasmF32, value2: WasmF32) => WasmF32
 ```
 
 ### WasmF32.**(-)**
 
 ```grain
-(-) : (WasmF32, WasmF32) => WasmF32
+(-) : (value1: WasmF32, value2: WasmF32) => WasmF32
 ```
 
 ### WasmF32.**(*)**
 
 ```grain
-(*) : (WasmF32, WasmF32) => WasmF32
+(*) : (value1: WasmF32, value2: WasmF32) => WasmF32
 ```
 
 ### WasmF32.**(/)**
 
 ```grain
-(/) : (WasmF32, WasmF32) => WasmF32
+(/) : (value1: WasmF32, value2: WasmF32) => WasmF32
 ```
 
 ### WasmF32.**copySign**
 
 ```grain
-copySign : (WasmF32, WasmF32) => WasmF32
+copySign : (value1: WasmF32, value2: WasmF32) => WasmF32
 ```
 
 ### WasmF32.**min**
 
 ```grain
-min : (WasmF32, WasmF32) => WasmF32
+min : (value1: WasmF32, value2: WasmF32) => WasmF32
 ```
 
 ### WasmF32.**max**
 
 ```grain
-max : (WasmF32, WasmF32) => WasmF32
+max : (value1: WasmF32, value2: WasmF32) => WasmF32
 ```
 
 ### WasmF32.**(==)**
 
 ```grain
-(==) : (WasmF32, WasmF32) => Bool
+(==) : (value1: WasmF32, value2: WasmF32) => Bool
 ```
 
 ### WasmF32.**(!=)**
 
 ```grain
-(!=) : (WasmF32, WasmF32) => Bool
+(!=) : (value1: WasmF32, value2: WasmF32) => Bool
 ```
 
 ### WasmF32.**(<)**
 
 ```grain
-(<) : (WasmF32, WasmF32) => Bool
+(<) : (value1: WasmF32, value2: WasmF32) => Bool
 ```
 
 ### WasmF32.**(<=)**
 
 ```grain
-(<=) : (WasmF32, WasmF32) => Bool
+(<=) : (value1: WasmF32, value2: WasmF32) => Bool
 ```
 
 ### WasmF32.**(>)**
 
 ```grain
-(>) : (WasmF32, WasmF32) => Bool
+(>) : (value1: WasmF32, value2: WasmF32) => Bool
 ```
 
 ### WasmF32.**(>=)**
 
 ```grain
-(>=) : (WasmF32, WasmF32) => Bool
+(>=) : (value1: WasmF32, value2: WasmF32) => Bool
 ```
 
 ### WasmF32.**reinterpretI32**
 
 ```grain
-reinterpretI32 : WasmI32 => WasmF32
+reinterpretI32 : (int: WasmI32) => WasmF32
 ```
 
 ### WasmF32.**convertI32S**
 
 ```grain
-convertI32S : WasmI32 => WasmF32
+convertI32S : (int: WasmI32) => WasmF32
 ```
 
 ### WasmF32.**convertI32U**
 
 ```grain
-convertI32U : WasmI32 => WasmF32
+convertI32U : (int: WasmI32) => WasmF32
 ```
 
 ### WasmF32.**convertI64S**
 
 ```grain
-convertI64S : WasmI64 => WasmF32
+convertI64S : (int: WasmI64) => WasmF32
 ```
 
 ### WasmF32.**convertI64U**
 
 ```grain
-convertI64U : WasmI64 => WasmF32
+convertI64U : (int: WasmI64) => WasmF32
 ```
 
 ### WasmF32.**demoteF64**
 
 ```grain
-demoteF64 : WasmF64 => WasmF32
+demoteF64 : (int: WasmF64) => WasmF32
 ```
 

--- a/stdlib/runtime/unsafe/wasmf64.md
+++ b/stdlib/runtime/unsafe/wasmf64.md
@@ -9,168 +9,168 @@ Functions and constants included in the WasmF64 module.
 ### WasmF64.**load**
 
 ```grain
-load : (WasmI32, WasmI32) => WasmF64
+load : (ptr: WasmI32, offset: WasmI32) => WasmF64
 ```
 
 ### WasmF64.**store**
 
 ```grain
-store : (WasmI32, WasmF64, WasmI32) => Void
+store : (ptr: WasmI32, value: WasmF64, offset: WasmI32) => Void
 ```
 
 ### WasmF64.**neg**
 
 ```grain
-neg : WasmF64 => WasmF64
+neg : (int: WasmF64) => WasmF64
 ```
 
 ### WasmF64.**abs**
 
 ```grain
-abs : WasmF64 => WasmF64
+abs : (int: WasmF64) => WasmF64
 ```
 
 ### WasmF64.**ceil**
 
 ```grain
-ceil : WasmF64 => WasmF64
+ceil : (int: WasmF64) => WasmF64
 ```
 
 ### WasmF64.**floor**
 
 ```grain
-floor : WasmF64 => WasmF64
+floor : (int: WasmF64) => WasmF64
 ```
 
 ### WasmF64.**trunc**
 
 ```grain
-trunc : WasmF64 => WasmF64
+trunc : (int: WasmF64) => WasmF64
 ```
 
 ### WasmF64.**nearest**
 
 ```grain
-nearest : WasmF64 => WasmF64
+nearest : (int: WasmF64) => WasmF64
 ```
 
 ### WasmF64.**sqrt**
 
 ```grain
-sqrt : WasmF64 => WasmF64
+sqrt : (int: WasmF64) => WasmF64
 ```
 
 ### WasmF64.**(+)**
 
 ```grain
-(+) : (WasmF64, WasmF64) => WasmF64
+(+) : (value1: WasmF64, value2: WasmF64) => WasmF64
 ```
 
 ### WasmF64.**(-)**
 
 ```grain
-(-) : (WasmF64, WasmF64) => WasmF64
+(-) : (value1: WasmF64, value2: WasmF64) => WasmF64
 ```
 
 ### WasmF64.**(*)**
 
 ```grain
-(*) : (WasmF64, WasmF64) => WasmF64
+(*) : (value1: WasmF64, value2: WasmF64) => WasmF64
 ```
 
 ### WasmF64.**(/)**
 
 ```grain
-(/) : (WasmF64, WasmF64) => WasmF64
+(/) : (value1: WasmF64, value2: WasmF64) => WasmF64
 ```
 
 ### WasmF64.**copySign**
 
 ```grain
-copySign : (WasmF64, WasmF64) => WasmF64
+copySign : (value1: WasmF64, value2: WasmF64) => WasmF64
 ```
 
 ### WasmF64.**min**
 
 ```grain
-min : (WasmF64, WasmF64) => WasmF64
+min : (value1: WasmF64, value2: WasmF64) => WasmF64
 ```
 
 ### WasmF64.**max**
 
 ```grain
-max : (WasmF64, WasmF64) => WasmF64
+max : (value1: WasmF64, value2: WasmF64) => WasmF64
 ```
 
 ### WasmF64.**(==)**
 
 ```grain
-(==) : (WasmF64, WasmF64) => Bool
+(==) : (value1: WasmF64, value2: WasmF64) => Bool
 ```
 
 ### WasmF64.**(!=)**
 
 ```grain
-(!=) : (WasmF64, WasmF64) => Bool
+(!=) : (value1: WasmF64, value2: WasmF64) => Bool
 ```
 
 ### WasmF64.**(<)**
 
 ```grain
-(<) : (WasmF64, WasmF64) => Bool
+(<) : (value1: WasmF64, value2: WasmF64) => Bool
 ```
 
 ### WasmF64.**(<=)**
 
 ```grain
-(<=) : (WasmF64, WasmF64) => Bool
+(<=) : (value1: WasmF64, value2: WasmF64) => Bool
 ```
 
 ### WasmF64.**(>)**
 
 ```grain
-(>) : (WasmF64, WasmF64) => Bool
+(>) : (value1: WasmF64, value2: WasmF64) => Bool
 ```
 
 ### WasmF64.**(>=)**
 
 ```grain
-(>=) : (WasmF64, WasmF64) => Bool
+(>=) : (value1: WasmF64, value2: WasmF64) => Bool
 ```
 
 ### WasmF64.**reinterpretI64**
 
 ```grain
-reinterpretI64 : WasmI64 => WasmF64
+reinterpretI64 : (int: WasmI64) => WasmF64
 ```
 
 ### WasmF64.**convertI32S**
 
 ```grain
-convertI32S : WasmI32 => WasmF64
+convertI32S : (int: WasmI32) => WasmF64
 ```
 
 ### WasmF64.**convertI32U**
 
 ```grain
-convertI32U : WasmI32 => WasmF64
+convertI32U : (int: WasmI32) => WasmF64
 ```
 
 ### WasmF64.**convertI64S**
 
 ```grain
-convertI64S : WasmI64 => WasmF64
+convertI64S : (int: WasmI64) => WasmF64
 ```
 
 ### WasmF64.**convertI64U**
 
 ```grain
-convertI64U : WasmI64 => WasmF64
+convertI64U : (int: WasmI64) => WasmF64
 ```
 
 ### WasmF64.**promoteF32**
 
 ```grain
-promoteF32 : WasmF32 => WasmF64
+promoteF32 : (int: WasmF32) => WasmF64
 ```
 

--- a/stdlib/runtime/unsafe/wasmf64.md
+++ b/stdlib/runtime/unsafe/wasmf64.md
@@ -21,156 +21,156 @@ store : (ptr: WasmI32, value: WasmF64, offset: WasmI32) => Void
 ### WasmF64.**neg**
 
 ```grain
-neg : (int: WasmF64) => WasmF64
+neg : (num: WasmF64) => WasmF64
 ```
 
 ### WasmF64.**abs**
 
 ```grain
-abs : (int: WasmF64) => WasmF64
+abs : (num: WasmF64) => WasmF64
 ```
 
 ### WasmF64.**ceil**
 
 ```grain
-ceil : (int: WasmF64) => WasmF64
+ceil : (num: WasmF64) => WasmF64
 ```
 
 ### WasmF64.**floor**
 
 ```grain
-floor : (int: WasmF64) => WasmF64
+floor : (num: WasmF64) => WasmF64
 ```
 
 ### WasmF64.**trunc**
 
 ```grain
-trunc : (int: WasmF64) => WasmF64
+trunc : (num: WasmF64) => WasmF64
 ```
 
 ### WasmF64.**nearest**
 
 ```grain
-nearest : (int: WasmF64) => WasmF64
+nearest : (num: WasmF64) => WasmF64
 ```
 
 ### WasmF64.**sqrt**
 
 ```grain
-sqrt : (int: WasmF64) => WasmF64
+sqrt : (num: WasmF64) => WasmF64
 ```
 
 ### WasmF64.**(+)**
 
 ```grain
-(+) : (value1: WasmF64, value2: WasmF64) => WasmF64
+(+) : (left: WasmF64, right: WasmF64) => WasmF64
 ```
 
 ### WasmF64.**(-)**
 
 ```grain
-(-) : (value1: WasmF64, value2: WasmF64) => WasmF64
+(-) : (left: WasmF64, right: WasmF64) => WasmF64
 ```
 
 ### WasmF64.**(*)**
 
 ```grain
-(*) : (value1: WasmF64, value2: WasmF64) => WasmF64
+(*) : (left: WasmF64, right: WasmF64) => WasmF64
 ```
 
 ### WasmF64.**(/)**
 
 ```grain
-(/) : (value1: WasmF64, value2: WasmF64) => WasmF64
+(/) : (left: WasmF64, right: WasmF64) => WasmF64
 ```
 
 ### WasmF64.**copySign**
 
 ```grain
-copySign : (value1: WasmF64, value2: WasmF64) => WasmF64
+copySign : (left: WasmF64, right: WasmF64) => WasmF64
 ```
 
 ### WasmF64.**min**
 
 ```grain
-min : (value1: WasmF64, value2: WasmF64) => WasmF64
+min : (left: WasmF64, right: WasmF64) => WasmF64
 ```
 
 ### WasmF64.**max**
 
 ```grain
-max : (value1: WasmF64, value2: WasmF64) => WasmF64
+max : (left: WasmF64, right: WasmF64) => WasmF64
 ```
 
 ### WasmF64.**(==)**
 
 ```grain
-(==) : (value1: WasmF64, value2: WasmF64) => Bool
+(==) : (left: WasmF64, right: WasmF64) => Bool
 ```
 
 ### WasmF64.**(!=)**
 
 ```grain
-(!=) : (value1: WasmF64, value2: WasmF64) => Bool
+(!=) : (left: WasmF64, right: WasmF64) => Bool
 ```
 
 ### WasmF64.**(<)**
 
 ```grain
-(<) : (value1: WasmF64, value2: WasmF64) => Bool
+(<) : (left: WasmF64, right: WasmF64) => Bool
 ```
 
 ### WasmF64.**(<=)**
 
 ```grain
-(<=) : (value1: WasmF64, value2: WasmF64) => Bool
+(<=) : (left: WasmF64, right: WasmF64) => Bool
 ```
 
 ### WasmF64.**(>)**
 
 ```grain
-(>) : (value1: WasmF64, value2: WasmF64) => Bool
+(>) : (left: WasmF64, right: WasmF64) => Bool
 ```
 
 ### WasmF64.**(>=)**
 
 ```grain
-(>=) : (value1: WasmF64, value2: WasmF64) => Bool
+(>=) : (left: WasmF64, right: WasmF64) => Bool
 ```
 
 ### WasmF64.**reinterpretI64**
 
 ```grain
-reinterpretI64 : (int: WasmI64) => WasmF64
+reinterpretI64 : (num: WasmI64) => WasmF64
 ```
 
 ### WasmF64.**convertI32S**
 
 ```grain
-convertI32S : (int: WasmI32) => WasmF64
+convertI32S : (num: WasmI32) => WasmF64
 ```
 
 ### WasmF64.**convertI32U**
 
 ```grain
-convertI32U : (int: WasmI32) => WasmF64
+convertI32U : (num: WasmI32) => WasmF64
 ```
 
 ### WasmF64.**convertI64S**
 
 ```grain
-convertI64S : (int: WasmI64) => WasmF64
+convertI64S : (num: WasmI64) => WasmF64
 ```
 
 ### WasmF64.**convertI64U**
 
 ```grain
-convertI64U : (int: WasmI64) => WasmF64
+convertI64U : (num: WasmI64) => WasmF64
 ```
 
 ### WasmF64.**promoteF32**
 
 ```grain
-promoteF32 : (int: WasmF32) => WasmF64
+promoteF32 : (num: WasmF32) => WasmF64
 ```
 

--- a/stdlib/runtime/unsafe/wasmi32.md
+++ b/stdlib/runtime/unsafe/wasmi32.md
@@ -57,223 +57,223 @@ store16 : (ptr: WasmI32, value: WasmI32, offset: WasmI32) => Void
 ### WasmI32.**clz**
 
 ```grain
-clz : (int: WasmI32) => WasmI32
+clz : (num: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**ctz**
 
 ```grain
-ctz : (int: WasmI32) => WasmI32
+ctz : (num: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**popcnt**
 
 ```grain
-popcnt : (int: WasmI32) => WasmI32
+popcnt : (num: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**eqz**
 
 ```grain
-eqz : (int: WasmI32) => Bool
+eqz : (num: WasmI32) => Bool
 ```
 
 ### WasmI32.**(+)**
 
 ```grain
-(+) : (value1: WasmI32, value2: WasmI32) => WasmI32
+(+) : (left: WasmI32, right: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**(-)**
 
 ```grain
-(-) : (value1: WasmI32, value2: WasmI32) => WasmI32
+(-) : (left: WasmI32, right: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**(*)**
 
 ```grain
-(*) : (value1: WasmI32, value2: WasmI32) => WasmI32
+(*) : (left: WasmI32, right: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**(/)**
 
 ```grain
-(/) : (value1: WasmI32, value2: WasmI32) => WasmI32
+(/) : (left: WasmI32, right: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**divU**
 
 ```grain
-divU : (value1: WasmI32, value2: WasmI32) => WasmI32
+divU : (left: WasmI32, right: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**remS**
 
 ```grain
-remS : (value1: WasmI32, value2: WasmI32) => WasmI32
+remS : (left: WasmI32, right: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**remU**
 
 ```grain
-remU : (value1: WasmI32, value2: WasmI32) => WasmI32
+remU : (left: WasmI32, right: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**(&)**
 
 ```grain
-(&) : (value1: WasmI32, value2: WasmI32) => WasmI32
+(&) : (left: WasmI32, right: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**(|)**
 
 ```grain
-(|) : (value1: WasmI32, value2: WasmI32) => WasmI32
+(|) : (left: WasmI32, right: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**(^)**
 
 ```grain
-(^) : (value1: WasmI32, value2: WasmI32) => WasmI32
+(^) : (left: WasmI32, right: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**(<<)**
 
 ```grain
-(<<) : (value1: WasmI32, value2: WasmI32) => WasmI32
+(<<) : (left: WasmI32, right: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**(>>)**
 
 ```grain
-(>>) : (value1: WasmI32, value2: WasmI32) => WasmI32
+(>>) : (left: WasmI32, right: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**(>>>)**
 
 ```grain
-(>>>) : (value1: WasmI32, value2: WasmI32) => WasmI32
+(>>>) : (left: WasmI32, right: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**rotl**
 
 ```grain
-rotl : (value1: WasmI32, value2: WasmI32) => WasmI32
+rotl : (left: WasmI32, right: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**rotr**
 
 ```grain
-rotr : (value1: WasmI32, value2: WasmI32) => WasmI32
+rotr : (left: WasmI32, right: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**(==)**
 
 ```grain
-(==) : (value1: WasmI32, value2: WasmI32) => Bool
+(==) : (left: WasmI32, right: WasmI32) => Bool
 ```
 
 ### WasmI32.**(!=)**
 
 ```grain
-(!=) : (value1: WasmI32, value2: WasmI32) => Bool
+(!=) : (left: WasmI32, right: WasmI32) => Bool
 ```
 
 ### WasmI32.**(<)**
 
 ```grain
-(<) : (value1: WasmI32, value2: WasmI32) => Bool
+(<) : (left: WasmI32, right: WasmI32) => Bool
 ```
 
 ### WasmI32.**ltU**
 
 ```grain
-ltU : (value1: WasmI32, value2: WasmI32) => Bool
+ltU : (left: WasmI32, right: WasmI32) => Bool
 ```
 
 ### WasmI32.**(<=)**
 
 ```grain
-(<=) : (value1: WasmI32, value2: WasmI32) => Bool
+(<=) : (left: WasmI32, right: WasmI32) => Bool
 ```
 
 ### WasmI32.**leU**
 
 ```grain
-leU : (value1: WasmI32, value2: WasmI32) => Bool
+leU : (left: WasmI32, right: WasmI32) => Bool
 ```
 
 ### WasmI32.**(>)**
 
 ```grain
-(>) : (value1: WasmI32, value2: WasmI32) => Bool
+(>) : (left: WasmI32, right: WasmI32) => Bool
 ```
 
 ### WasmI32.**gtU**
 
 ```grain
-gtU : (value1: WasmI32, value2: WasmI32) => Bool
+gtU : (left: WasmI32, right: WasmI32) => Bool
 ```
 
 ### WasmI32.**(>=)**
 
 ```grain
-(>=) : (value1: WasmI32, value2: WasmI32) => Bool
+(>=) : (left: WasmI32, right: WasmI32) => Bool
 ```
 
 ### WasmI32.**geU**
 
 ```grain
-geU : (value1: WasmI32, value2: WasmI32) => Bool
+geU : (left: WasmI32, right: WasmI32) => Bool
 ```
 
 ### WasmI32.**wrapI64**
 
 ```grain
-wrapI64 : (int: WasmI64) => WasmI32
+wrapI64 : (num: WasmI64) => WasmI32
 ```
 
 ### WasmI32.**truncF32S**
 
 ```grain
-truncF32S : (int: WasmF32) => WasmI32
+truncF32S : (num: WasmF32) => WasmI32
 ```
 
 ### WasmI32.**truncF32U**
 
 ```grain
-truncF32U : (int: WasmF32) => WasmI32
+truncF32U : (num: WasmF32) => WasmI32
 ```
 
 ### WasmI32.**truncF64S**
 
 ```grain
-truncF64S : (int: WasmF64) => WasmI32
+truncF64S : (num: WasmF64) => WasmI32
 ```
 
 ### WasmI32.**truncF64U**
 
 ```grain
-truncF64U : (int: WasmF64) => WasmI32
+truncF64U : (num: WasmF64) => WasmI32
 ```
 
 ### WasmI32.**reinterpretF32**
 
 ```grain
-reinterpretF32 : (int: WasmF32) => WasmI32
+reinterpretF32 : (num: WasmF32) => WasmI32
 ```
 
 ### WasmI32.**extendS8**
 
 ```grain
-extendS8 : (int: WasmI32) => WasmI32
+extendS8 : (num: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**extendS16**
 
 ```grain
-extendS16 : (int: WasmI32) => WasmI32
+extendS16 : (num: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**fromGrain**

--- a/stdlib/runtime/unsafe/wasmi32.md
+++ b/stdlib/runtime/unsafe/wasmi32.md
@@ -9,282 +9,282 @@ Functions and constants included in the WasmI32 module.
 ### WasmI32.**load**
 
 ```grain
-load : (WasmI32, WasmI32) => WasmI32
+load : (ptr: WasmI32, offset: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**load8S**
 
 ```grain
-load8S : (WasmI32, WasmI32) => WasmI32
+load8S : (ptr: WasmI32, offset: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**load8U**
 
 ```grain
-load8U : (WasmI32, WasmI32) => WasmI32
+load8U : (ptr: WasmI32, offset: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**load16S**
 
 ```grain
-load16S : (WasmI32, WasmI32) => WasmI32
+load16S : (ptr: WasmI32, offset: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**load16U**
 
 ```grain
-load16U : (WasmI32, WasmI32) => WasmI32
+load16U : (ptr: WasmI32, offset: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**store**
 
 ```grain
-store : (WasmI32, WasmI32, WasmI32) => Void
+store : (ptr: WasmI32, value: WasmI32, offset: WasmI32) => Void
 ```
 
 ### WasmI32.**store8**
 
 ```grain
-store8 : (WasmI32, WasmI32, WasmI32) => Void
+store8 : (ptr: WasmI32, value: WasmI32, offset: WasmI32) => Void
 ```
 
 ### WasmI32.**store16**
 
 ```grain
-store16 : (WasmI32, WasmI32, WasmI32) => Void
+store16 : (ptr: WasmI32, value: WasmI32, offset: WasmI32) => Void
 ```
 
 ### WasmI32.**clz**
 
 ```grain
-clz : WasmI32 => WasmI32
+clz : (int: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**ctz**
 
 ```grain
-ctz : WasmI32 => WasmI32
+ctz : (int: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**popcnt**
 
 ```grain
-popcnt : WasmI32 => WasmI32
+popcnt : (int: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**eqz**
 
 ```grain
-eqz : WasmI32 => Bool
+eqz : (int: WasmI32) => Bool
 ```
 
 ### WasmI32.**(+)**
 
 ```grain
-(+) : (WasmI32, WasmI32) => WasmI32
+(+) : (value1: WasmI32, value2: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**(-)**
 
 ```grain
-(-) : (WasmI32, WasmI32) => WasmI32
+(-) : (value1: WasmI32, value2: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**(*)**
 
 ```grain
-(*) : (WasmI32, WasmI32) => WasmI32
+(*) : (value1: WasmI32, value2: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**(/)**
 
 ```grain
-(/) : (WasmI32, WasmI32) => WasmI32
+(/) : (value1: WasmI32, value2: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**divU**
 
 ```grain
-divU : (WasmI32, WasmI32) => WasmI32
+divU : (value1: WasmI32, value2: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**remS**
 
 ```grain
-remS : (WasmI32, WasmI32) => WasmI32
+remS : (value1: WasmI32, value2: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**remU**
 
 ```grain
-remU : (WasmI32, WasmI32) => WasmI32
+remU : (value1: WasmI32, value2: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**(&)**
 
 ```grain
-(&) : (WasmI32, WasmI32) => WasmI32
+(&) : (value1: WasmI32, value2: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**(|)**
 
 ```grain
-(|) : (WasmI32, WasmI32) => WasmI32
+(|) : (value1: WasmI32, value2: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**(^)**
 
 ```grain
-(^) : (WasmI32, WasmI32) => WasmI32
+(^) : (value1: WasmI32, value2: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**(<<)**
 
 ```grain
-(<<) : (WasmI32, WasmI32) => WasmI32
+(<<) : (value1: WasmI32, value2: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**(>>)**
 
 ```grain
-(>>) : (WasmI32, WasmI32) => WasmI32
+(>>) : (value1: WasmI32, value2: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**(>>>)**
 
 ```grain
-(>>>) : (WasmI32, WasmI32) => WasmI32
+(>>>) : (value1: WasmI32, value2: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**rotl**
 
 ```grain
-rotl : (WasmI32, WasmI32) => WasmI32
+rotl : (value1: WasmI32, value2: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**rotr**
 
 ```grain
-rotr : (WasmI32, WasmI32) => WasmI32
+rotr : (value1: WasmI32, value2: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**(==)**
 
 ```grain
-(==) : (WasmI32, WasmI32) => Bool
+(==) : (value1: WasmI32, value2: WasmI32) => Bool
 ```
 
 ### WasmI32.**(!=)**
 
 ```grain
-(!=) : (WasmI32, WasmI32) => Bool
+(!=) : (value1: WasmI32, value2: WasmI32) => Bool
 ```
 
 ### WasmI32.**(<)**
 
 ```grain
-(<) : (WasmI32, WasmI32) => Bool
+(<) : (value1: WasmI32, value2: WasmI32) => Bool
 ```
 
 ### WasmI32.**ltU**
 
 ```grain
-ltU : (WasmI32, WasmI32) => Bool
+ltU : (value1: WasmI32, value2: WasmI32) => Bool
 ```
 
 ### WasmI32.**(<=)**
 
 ```grain
-(<=) : (WasmI32, WasmI32) => Bool
+(<=) : (value1: WasmI32, value2: WasmI32) => Bool
 ```
 
 ### WasmI32.**leU**
 
 ```grain
-leU : (WasmI32, WasmI32) => Bool
+leU : (value1: WasmI32, value2: WasmI32) => Bool
 ```
 
 ### WasmI32.**(>)**
 
 ```grain
-(>) : (WasmI32, WasmI32) => Bool
+(>) : (value1: WasmI32, value2: WasmI32) => Bool
 ```
 
 ### WasmI32.**gtU**
 
 ```grain
-gtU : (WasmI32, WasmI32) => Bool
+gtU : (value1: WasmI32, value2: WasmI32) => Bool
 ```
 
 ### WasmI32.**(>=)**
 
 ```grain
-(>=) : (WasmI32, WasmI32) => Bool
+(>=) : (value1: WasmI32, value2: WasmI32) => Bool
 ```
 
 ### WasmI32.**geU**
 
 ```grain
-geU : (WasmI32, WasmI32) => Bool
+geU : (value1: WasmI32, value2: WasmI32) => Bool
 ```
 
 ### WasmI32.**wrapI64**
 
 ```grain
-wrapI64 : WasmI64 => WasmI32
+wrapI64 : (int: WasmI64) => WasmI32
 ```
 
 ### WasmI32.**truncF32S**
 
 ```grain
-truncF32S : WasmF32 => WasmI32
+truncF32S : (int: WasmF32) => WasmI32
 ```
 
 ### WasmI32.**truncF32U**
 
 ```grain
-truncF32U : WasmF32 => WasmI32
+truncF32U : (int: WasmF32) => WasmI32
 ```
 
 ### WasmI32.**truncF64S**
 
 ```grain
-truncF64S : WasmF64 => WasmI32
+truncF64S : (int: WasmF64) => WasmI32
 ```
 
 ### WasmI32.**truncF64U**
 
 ```grain
-truncF64U : WasmF64 => WasmI32
+truncF64U : (int: WasmF64) => WasmI32
 ```
 
 ### WasmI32.**reinterpretF32**
 
 ```grain
-reinterpretF32 : WasmF32 => WasmI32
+reinterpretF32 : (int: WasmF32) => WasmI32
 ```
 
 ### WasmI32.**extendS8**
 
 ```grain
-extendS8 : WasmI32 => WasmI32
+extendS8 : (int: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**extendS16**
 
 ```grain
-extendS16 : WasmI32 => WasmI32
+extendS16 : (int: WasmI32) => WasmI32
 ```
 
 ### WasmI32.**fromGrain**
 
 ```grain
-fromGrain : a => WasmI32
+fromGrain : (value: a) => WasmI32
 ```
 
 ### WasmI32.**toGrain**
 
 ```grain
-toGrain : WasmI32 => a
+toGrain : (value: WasmI32) => a
 ```
 

--- a/stdlib/runtime/unsafe/wasmi64.md
+++ b/stdlib/runtime/unsafe/wasmi64.md
@@ -9,300 +9,300 @@ Functions and constants included in the WasmI64 module.
 ### WasmI64.**load**
 
 ```grain
-load : (WasmI32, WasmI32) => WasmI64
+load : (ptr: WasmI32, offset: WasmI32) => WasmI64
 ```
 
 ### WasmI64.**load8S**
 
 ```grain
-load8S : (WasmI32, WasmI32) => WasmI64
+load8S : (ptr: WasmI32, offset: WasmI32) => WasmI64
 ```
 
 ### WasmI64.**load8U**
 
 ```grain
-load8U : (WasmI32, WasmI32) => WasmI64
+load8U : (ptr: WasmI32, offset: WasmI32) => WasmI64
 ```
 
 ### WasmI64.**load16S**
 
 ```grain
-load16S : (WasmI32, WasmI32) => WasmI64
+load16S : (ptr: WasmI32, offset: WasmI32) => WasmI64
 ```
 
 ### WasmI64.**load16U**
 
 ```grain
-load16U : (WasmI32, WasmI32) => WasmI64
+load16U : (ptr: WasmI32, offset: WasmI32) => WasmI64
 ```
 
 ### WasmI64.**load32S**
 
 ```grain
-load32S : (WasmI32, WasmI32) => WasmI64
+load32S : (ptr: WasmI32, offset: WasmI32) => WasmI64
 ```
 
 ### WasmI64.**load32U**
 
 ```grain
-load32U : (WasmI32, WasmI32) => WasmI64
+load32U : (ptr: WasmI32, offset: WasmI32) => WasmI64
 ```
 
 ### WasmI64.**store**
 
 ```grain
-store : (WasmI32, WasmI64, WasmI32) => Void
+store : (ptr: WasmI32, value: WasmI64, offset: WasmI32) => Void
 ```
 
 ### WasmI64.**store8**
 
 ```grain
-store8 : (WasmI32, WasmI64, WasmI32) => Void
+store8 : (ptr: WasmI32, value: WasmI64, offset: WasmI32) => Void
 ```
 
 ### WasmI64.**store16**
 
 ```grain
-store16 : (WasmI32, WasmI64, WasmI32) => Void
+store16 : (ptr: WasmI32, value: WasmI64, offset: WasmI32) => Void
 ```
 
 ### WasmI64.**store32**
 
 ```grain
-store32 : (WasmI32, WasmI64, WasmI32) => Void
+store32 : (ptr: WasmI32, value: WasmI64, offset: WasmI32) => Void
 ```
 
 ### WasmI64.**clz**
 
 ```grain
-clz : WasmI64 => WasmI64
+clz : (int: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**ctz**
 
 ```grain
-ctz : WasmI64 => WasmI64
+ctz : (int: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**popcnt**
 
 ```grain
-popcnt : WasmI64 => WasmI64
+popcnt : (int: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**eqz**
 
 ```grain
-eqz : WasmI64 => Bool
+eqz : (int: WasmI64) => Bool
 ```
 
 ### WasmI64.**(+)**
 
 ```grain
-(+) : (WasmI64, WasmI64) => WasmI64
+(+) : (value1: WasmI64, value2: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**(-)**
 
 ```grain
-(-) : (WasmI64, WasmI64) => WasmI64
+(-) : (value1: WasmI64, value2: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**(*)**
 
 ```grain
-(*) : (WasmI64, WasmI64) => WasmI64
+(*) : (value1: WasmI64, value2: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**(/)**
 
 ```grain
-(/) : (WasmI64, WasmI64) => WasmI64
+(/) : (value1: WasmI64, value2: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**divU**
 
 ```grain
-divU : (WasmI64, WasmI64) => WasmI64
+divU : (value1: WasmI64, value2: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**remS**
 
 ```grain
-remS : (WasmI64, WasmI64) => WasmI64
+remS : (value1: WasmI64, value2: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**remU**
 
 ```grain
-remU : (WasmI64, WasmI64) => WasmI64
+remU : (value1: WasmI64, value2: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**(&)**
 
 ```grain
-(&) : (WasmI64, WasmI64) => WasmI64
+(&) : (value1: WasmI64, value2: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**(|)**
 
 ```grain
-(|) : (WasmI64, WasmI64) => WasmI64
+(|) : (value1: WasmI64, value2: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**(^)**
 
 ```grain
-(^) : (WasmI64, WasmI64) => WasmI64
+(^) : (value1: WasmI64, value2: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**(<<)**
 
 ```grain
-(<<) : (WasmI64, WasmI64) => WasmI64
+(<<) : (value1: WasmI64, value2: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**(>>>)**
 
 ```grain
-(>>>) : (WasmI64, WasmI64) => WasmI64
+(>>>) : (value1: WasmI64, value2: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**(>>)**
 
 ```grain
-(>>) : (WasmI64, WasmI64) => WasmI64
+(>>) : (value1: WasmI64, value2: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**rotl**
 
 ```grain
-rotl : (WasmI64, WasmI64) => WasmI64
+rotl : (value1: WasmI64, value2: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**rotr**
 
 ```grain
-rotr : (WasmI64, WasmI64) => WasmI64
+rotr : (value1: WasmI64, value2: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**(==)**
 
 ```grain
-(==) : (WasmI64, WasmI64) => Bool
+(==) : (value1: WasmI64, value2: WasmI64) => Bool
 ```
 
 ### WasmI64.**(!=)**
 
 ```grain
-(!=) : (WasmI64, WasmI64) => Bool
+(!=) : (value1: WasmI64, value2: WasmI64) => Bool
 ```
 
 ### WasmI64.**(<)**
 
 ```grain
-(<) : (WasmI64, WasmI64) => Bool
+(<) : (value1: WasmI64, value2: WasmI64) => Bool
 ```
 
 ### WasmI64.**ltU**
 
 ```grain
-ltU : (WasmI64, WasmI64) => Bool
+ltU : (value1: WasmI64, value2: WasmI64) => Bool
 ```
 
 ### WasmI64.**(<=)**
 
 ```grain
-(<=) : (WasmI64, WasmI64) => Bool
+(<=) : (value1: WasmI64, value2: WasmI64) => Bool
 ```
 
 ### WasmI64.**leU**
 
 ```grain
-leU : (WasmI64, WasmI64) => Bool
+leU : (value1: WasmI64, value2: WasmI64) => Bool
 ```
 
 ### WasmI64.**(>)**
 
 ```grain
-(>) : (WasmI64, WasmI64) => Bool
+(>) : (value1: WasmI64, value2: WasmI64) => Bool
 ```
 
 ### WasmI64.**gtU**
 
 ```grain
-gtU : (WasmI64, WasmI64) => Bool
+gtU : (value1: WasmI64, value2: WasmI64) => Bool
 ```
 
 ### WasmI64.**(>=)**
 
 ```grain
-(>=) : (WasmI64, WasmI64) => Bool
+(>=) : (value1: WasmI64, value2: WasmI64) => Bool
 ```
 
 ### WasmI64.**geU**
 
 ```grain
-geU : (WasmI64, WasmI64) => Bool
+geU : (value1: WasmI64, value2: WasmI64) => Bool
 ```
 
 ### WasmI64.**extendI32S**
 
 ```grain
-extendI32S : WasmI32 => WasmI64
+extendI32S : (int: WasmI32) => WasmI64
 ```
 
 ### WasmI64.**extendI32U**
 
 ```grain
-extendI32U : WasmI32 => WasmI64
+extendI32U : (int: WasmI32) => WasmI64
 ```
 
 ### WasmI64.**truncF32S**
 
 ```grain
-truncF32S : WasmF32 => WasmI64
+truncF32S : (int: WasmF32) => WasmI64
 ```
 
 ### WasmI64.**truncF32U**
 
 ```grain
-truncF32U : WasmF32 => WasmI64
+truncF32U : (int: WasmF32) => WasmI64
 ```
 
 ### WasmI64.**truncF64S**
 
 ```grain
-truncF64S : WasmF64 => WasmI64
+truncF64S : (int: WasmF64) => WasmI64
 ```
 
 ### WasmI64.**truncF64U**
 
 ```grain
-truncF64U : WasmF64 => WasmI64
+truncF64U : (int: WasmF64) => WasmI64
 ```
 
 ### WasmI64.**reinterpretF64**
 
 ```grain
-reinterpretF64 : WasmF64 => WasmI64
+reinterpretF64 : (int: WasmF64) => WasmI64
 ```
 
 ### WasmI64.**extendS8**
 
 ```grain
-extendS8 : WasmI64 => WasmI64
+extendS8 : (int: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**extendS16**
 
 ```grain
-extendS16 : WasmI64 => WasmI64
+extendS16 : (int: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**extendS32**
 
 ```grain
-extendS32 : WasmI64 => WasmI64
+extendS32 : (int: WasmI64) => WasmI64
 ```
 

--- a/stdlib/runtime/unsafe/wasmi64.md
+++ b/stdlib/runtime/unsafe/wasmi64.md
@@ -75,234 +75,234 @@ store32 : (ptr: WasmI32, value: WasmI64, offset: WasmI32) => Void
 ### WasmI64.**clz**
 
 ```grain
-clz : (int: WasmI64) => WasmI64
+clz : (num: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**ctz**
 
 ```grain
-ctz : (int: WasmI64) => WasmI64
+ctz : (num: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**popcnt**
 
 ```grain
-popcnt : (int: WasmI64) => WasmI64
+popcnt : (num: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**eqz**
 
 ```grain
-eqz : (int: WasmI64) => Bool
+eqz : (num: WasmI64) => Bool
 ```
 
 ### WasmI64.**(+)**
 
 ```grain
-(+) : (value1: WasmI64, value2: WasmI64) => WasmI64
+(+) : (left: WasmI64, right: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**(-)**
 
 ```grain
-(-) : (value1: WasmI64, value2: WasmI64) => WasmI64
+(-) : (left: WasmI64, right: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**(*)**
 
 ```grain
-(*) : (value1: WasmI64, value2: WasmI64) => WasmI64
+(*) : (left: WasmI64, right: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**(/)**
 
 ```grain
-(/) : (value1: WasmI64, value2: WasmI64) => WasmI64
+(/) : (left: WasmI64, right: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**divU**
 
 ```grain
-divU : (value1: WasmI64, value2: WasmI64) => WasmI64
+divU : (left: WasmI64, right: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**remS**
 
 ```grain
-remS : (value1: WasmI64, value2: WasmI64) => WasmI64
+remS : (left: WasmI64, right: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**remU**
 
 ```grain
-remU : (value1: WasmI64, value2: WasmI64) => WasmI64
+remU : (left: WasmI64, right: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**(&)**
 
 ```grain
-(&) : (value1: WasmI64, value2: WasmI64) => WasmI64
+(&) : (left: WasmI64, right: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**(|)**
 
 ```grain
-(|) : (value1: WasmI64, value2: WasmI64) => WasmI64
+(|) : (left: WasmI64, right: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**(^)**
 
 ```grain
-(^) : (value1: WasmI64, value2: WasmI64) => WasmI64
+(^) : (left: WasmI64, right: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**(<<)**
 
 ```grain
-(<<) : (value1: WasmI64, value2: WasmI64) => WasmI64
+(<<) : (left: WasmI64, right: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**(>>>)**
 
 ```grain
-(>>>) : (value1: WasmI64, value2: WasmI64) => WasmI64
+(>>>) : (left: WasmI64, right: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**(>>)**
 
 ```grain
-(>>) : (value1: WasmI64, value2: WasmI64) => WasmI64
+(>>) : (left: WasmI64, right: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**rotl**
 
 ```grain
-rotl : (value1: WasmI64, value2: WasmI64) => WasmI64
+rotl : (left: WasmI64, right: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**rotr**
 
 ```grain
-rotr : (value1: WasmI64, value2: WasmI64) => WasmI64
+rotr : (left: WasmI64, right: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**(==)**
 
 ```grain
-(==) : (value1: WasmI64, value2: WasmI64) => Bool
+(==) : (left: WasmI64, right: WasmI64) => Bool
 ```
 
 ### WasmI64.**(!=)**
 
 ```grain
-(!=) : (value1: WasmI64, value2: WasmI64) => Bool
+(!=) : (left: WasmI64, right: WasmI64) => Bool
 ```
 
 ### WasmI64.**(<)**
 
 ```grain
-(<) : (value1: WasmI64, value2: WasmI64) => Bool
+(<) : (left: WasmI64, right: WasmI64) => Bool
 ```
 
 ### WasmI64.**ltU**
 
 ```grain
-ltU : (value1: WasmI64, value2: WasmI64) => Bool
+ltU : (left: WasmI64, right: WasmI64) => Bool
 ```
 
 ### WasmI64.**(<=)**
 
 ```grain
-(<=) : (value1: WasmI64, value2: WasmI64) => Bool
+(<=) : (left: WasmI64, right: WasmI64) => Bool
 ```
 
 ### WasmI64.**leU**
 
 ```grain
-leU : (value1: WasmI64, value2: WasmI64) => Bool
+leU : (left: WasmI64, right: WasmI64) => Bool
 ```
 
 ### WasmI64.**(>)**
 
 ```grain
-(>) : (value1: WasmI64, value2: WasmI64) => Bool
+(>) : (left: WasmI64, right: WasmI64) => Bool
 ```
 
 ### WasmI64.**gtU**
 
 ```grain
-gtU : (value1: WasmI64, value2: WasmI64) => Bool
+gtU : (left: WasmI64, right: WasmI64) => Bool
 ```
 
 ### WasmI64.**(>=)**
 
 ```grain
-(>=) : (value1: WasmI64, value2: WasmI64) => Bool
+(>=) : (left: WasmI64, right: WasmI64) => Bool
 ```
 
 ### WasmI64.**geU**
 
 ```grain
-geU : (value1: WasmI64, value2: WasmI64) => Bool
+geU : (left: WasmI64, right: WasmI64) => Bool
 ```
 
 ### WasmI64.**extendI32S**
 
 ```grain
-extendI32S : (int: WasmI32) => WasmI64
+extendI32S : (num: WasmI32) => WasmI64
 ```
 
 ### WasmI64.**extendI32U**
 
 ```grain
-extendI32U : (int: WasmI32) => WasmI64
+extendI32U : (num: WasmI32) => WasmI64
 ```
 
 ### WasmI64.**truncF32S**
 
 ```grain
-truncF32S : (int: WasmF32) => WasmI64
+truncF32S : (num: WasmF32) => WasmI64
 ```
 
 ### WasmI64.**truncF32U**
 
 ```grain
-truncF32U : (int: WasmF32) => WasmI64
+truncF32U : (num: WasmF32) => WasmI64
 ```
 
 ### WasmI64.**truncF64S**
 
 ```grain
-truncF64S : (int: WasmF64) => WasmI64
+truncF64S : (num: WasmF64) => WasmI64
 ```
 
 ### WasmI64.**truncF64U**
 
 ```grain
-truncF64U : (int: WasmF64) => WasmI64
+truncF64U : (num: WasmF64) => WasmI64
 ```
 
 ### WasmI64.**reinterpretF64**
 
 ```grain
-reinterpretF64 : (int: WasmF64) => WasmI64
+reinterpretF64 : (num: WasmF64) => WasmI64
 ```
 
 ### WasmI64.**extendS8**
 
 ```grain
-extendS8 : (int: WasmI64) => WasmI64
+extendS8 : (num: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**extendS16**
 
 ```grain
-extendS16 : (int: WasmI64) => WasmI64
+extendS16 : (num: WasmI64) => WasmI64
 ```
 
 ### WasmI64.**extendS32**
 
 ```grain
-extendS32 : (int: WasmI64) => WasmI64
+extendS32 : (num: WasmI64) => WasmI64
 ```
 


### PR DESCRIPTION
This pr adds labels to the primitive compiler types which allows for better documentation.


Notes:
* I removed the `prim_type_labeled` and just made `prim_type` take the labels to prevent unlabeled functions in the future.


Closes: #1981 