### PR TITLE
chore(cli): Hide node's stack trace

### DIFF
--- a/cli/bin/exec.js
+++ b/cli/bin/exec.js
@@ -2,6 +2,14 @@ const path = require("path");
 const { execSync } = require("child_process");
 const fs = require("fs");
 
+function grainExec(command, execOpts) {
+  try {
+    return execSync(command, execOpts);
+  } catch (err) {
+    return "";
+  }
+}
+
 function flagsFromOptions(program, options) {
   const flags = [];
   program.options.forEach((option) => {
@@ -35,7 +43,7 @@ function execGrainc(
 ) {
   const flags = flagsFromOptions(program, options);
 
-  return execSync(`${grainc} ${flags.join(" ")} ${commandOrFile}`, execOpts);
+  return grainExec(`${grainc} ${flags.join(" ")} ${commandOrFile}`, execOpts);
 }
 
 function getGraindoc() {
@@ -61,7 +69,7 @@ function execGraindoc(
 ) {
   const flags = flagsFromOptions(program, options);
 
-  return execSync(`${graindoc} ${flags.join(" ")} ${commandOrFile}`, execOpts);
+  return grainExec(`${graindoc} ${flags.join(" ")} ${commandOrFile}`, execOpts);
 }
 
 function getGrainformat() {
@@ -87,7 +95,7 @@ function execGrainformat(
 ) {
   const flags = flagsFromOptions(program, options);
 
-  return execSync(
+  return grainExec(
     `${grainformat} ${flags.join(" ")} ${commandOrFile}`,
     execOpts
   );
@@ -111,7 +119,7 @@ const grainlsp = getGrainlsp();
 function execGrainlsp(options, program, execOpts = { stdio: "inherit" }) {
   const flags = flagsFromOptions(program, options);
 
-  return execSync(`${grainlsp} ${flags.join(" ")}`, execOpts);
+  return grainExec(`${grainlsp} ${flags.join(" ")}`, execOpts);
 }
 
 function getGrainrun() {
@@ -149,7 +157,7 @@ function execGrainrun(
   };
 
   try {
-    execSync(`${grainrun} ${file} ${unprocessedArgs.join(" ")}`, {
+    grainExec(`${grainrun} ${file} ${unprocessedArgs.join(" ")}`, {
       ...execOpts,
       env,
     });

--- a/cli/bin/exec.js
+++ b/cli/bin/exec.js
@@ -4,9 +4,11 @@ const fs = require("fs");
 
 function exec(command, execOpts) {
   try {
-    return execSync(command, execOpts);
+    execSync(command, execOpts);
+    return true;
   } catch (err) {
-    process.exit(err.status);
+    process.exitCode = err.status;
+    return false;
   }
 }
 

--- a/cli/bin/exec.js
+++ b/cli/bin/exec.js
@@ -6,7 +6,7 @@ function grainExec(command, execOpts) {
   try {
     return execSync(command, execOpts);
   } catch (err) {
-    return "";
+    process.exit(err.status);
   }
 }
 

--- a/cli/bin/exec.js
+++ b/cli/bin/exec.js
@@ -97,10 +97,7 @@ function execGrainformat(
 ) {
   const flags = flagsFromOptions(program, options);
 
-  return exec(
-    `${grainformat} ${flags.join(" ")} ${commandOrFile}`,
-    execOpts
-  );
+  return exec(`${grainformat} ${flags.join(" ")} ${commandOrFile}`, execOpts);
 }
 
 function getGrainlsp() {

--- a/cli/bin/exec.js
+++ b/cli/bin/exec.js
@@ -2,7 +2,7 @@ const path = require("path");
 const { execSync } = require("child_process");
 const fs = require("fs");
 
-function grainExec(command, execOpts) {
+function exec(command, execOpts) {
   try {
     return execSync(command, execOpts);
   } catch (err) {
@@ -43,7 +43,7 @@ function execGrainc(
 ) {
   const flags = flagsFromOptions(program, options);
 
-  return grainExec(`${grainc} ${flags.join(" ")} ${commandOrFile}`, execOpts);
+  return exec(`${grainc} ${flags.join(" ")} ${commandOrFile}`, execOpts);
 }
 
 function getGraindoc() {
@@ -69,7 +69,7 @@ function execGraindoc(
 ) {
   const flags = flagsFromOptions(program, options);
 
-  return grainExec(`${graindoc} ${flags.join(" ")} ${commandOrFile}`, execOpts);
+  return exec(`${graindoc} ${flags.join(" ")} ${commandOrFile}`, execOpts);
 }
 
 function getGrainformat() {
@@ -95,7 +95,7 @@ function execGrainformat(
 ) {
   const flags = flagsFromOptions(program, options);
 
-  return grainExec(
+  return exec(
     `${grainformat} ${flags.join(" ")} ${commandOrFile}`,
     execOpts
   );
@@ -119,7 +119,7 @@ const grainlsp = getGrainlsp();
 function execGrainlsp(options, program, execOpts = { stdio: "inherit" }) {
   const flags = flagsFromOptions(program, options);
 
-  return grainExec(`${grainlsp} ${flags.join(" ")}`, execOpts);
+  return exec(`${grainlsp} ${flags.join(" ")}`, execOpts);
 }
 
 function getGrainrun() {
@@ -157,7 +157,7 @@ function execGrainrun(
   };
 
   try {
-    grainExec(`${grainrun} ${file} ${unprocessedArgs.join(" ")}`, {
+    exec(`${grainrun} ${file} ${unprocessedArgs.join(" ")}`, {
       ...execOpts,
       env,
     });

--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -181,8 +181,8 @@ program
   .version(pkgJson.version, "-v, --version", "output the current version")
   .forwardOption("-o <filename>", "output filename")
   .action(function (file, options, program) {
-    const compiled = exec.grainc(file, options, program);
-    if (compiled) {
+    const success = exec.grainc(file, options, program);
+    if (success) {
       const outFile = options.o ?? file.replace(/\.gr$/, ".gr.wasm");
       exec.grainrun(unprocessedArgs, outFile, options, program);
     }

--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -181,9 +181,11 @@ program
   .version(pkgJson.version, "-v, --version", "output the current version")
   .forwardOption("-o <filename>", "output filename")
   .action(function (file, options, program) {
-    exec.grainc(file, options, program);
-    const outFile = options.o ?? file.replace(/\.gr$/, ".gr.wasm");
-    exec.grainrun(unprocessedArgs, outFile, options, program);
+    const compiled = exec.grainc(file, options, program);
+    if (compiled) {
+      const outFile = options.o ?? file.replace(/\.gr$/, ".gr.wasm");
+      exec.grainrun(unprocessedArgs, outFile, options, program);
+    }
   });
 
 program


### PR DESCRIPTION
This pr hides the node stack trace when an error is thrown from the cli. 

This should help improve user experience as the stack trace was irrelevant to the error previously.