### PR TITLE
fix(compiler): Ensure refcounts are maintained when tail calls use arguments multiple times

### DIFF
--- a/compiler/src/codegen/mashtree.re
+++ b/compiler/src/codegen/mashtree.re
@@ -334,6 +334,7 @@ and immediate_analyses = {mutable last_usage}
 
 and last_usage =
   | Last
+  | TailCallLast
   | NotLast
   | Unknown;
 

--- a/compiler/test/suites/gc.re
+++ b/compiler/test/suites/gc.re
@@ -188,4 +188,12 @@ describe("garbage collection", ({test, testSkip}) => {
     print("4")|},
     "4\n",
   );
+  assertRun(
+    "no_tailcall_double_decref",
+    {|
+      let isNaN = x => x != x
+      print(isNaN(NaN))
+    |},
+    "true\n",
+  );
 });


### PR DESCRIPTION
In a tail call such as `let isNaN = x => x != x` where `x` is passed to `!=` twice, we would over-optimize by not `incRef`ing `x` since it would be `decRef`ed by `!=`; however as the argument is passed twice, it is `decRef`ed twice. This PR ensures we handle this case properly by only doing this optimization on the _last_ time the argument is passed to the tail call.