### PR TITLE
fix(lsp): Prevent lsp crash when module cannot be found

### DIFF
--- a/compiler/src/language_server/hover.re
+++ b/compiler/src/language_server/hover.re
@@ -185,11 +185,15 @@ let process =
     | [Module({decl, loc}), ..._] =>
       send_hover(~id, ~range=Utils.loc_to_range(loc), module_lens(decl))
     | [Include({env, path, loc}), ..._] =>
-      send_hover(
-        ~id,
-        ~range=Utils.loc_to_range(loc),
-        include_lens(env, path),
-      )
+      try(
+        send_hover(
+          ~id,
+          ~range=Utils.loc_to_range(loc),
+          include_lens(env, path),
+        )
+      ) {
+      | exn => send_no_result(~id)
+      }
     | _ => send_no_result(~id)
     };
   };

--- a/compiler/src/language_server/hover.re
+++ b/compiler/src/language_server/hover.re
@@ -126,11 +126,21 @@ let declaration_lens = (ident: Ident.t, decl: Types.type_declaration) => {
 };
 
 let include_lens = (env: Env.t, path: Path.t) => {
-  let module_decl = Env.find_module(path, None, env);
-  markdown_join(
-    grain_code_block("module " ++ Path.name(path)),
-    module_lens(module_decl),
-  );
+  let header = grain_code_block("module " ++ Path.name(path));
+  let module_decl =
+    try({
+      let decl = Env.find_module(path, None, env);
+      switch (Modules.get_provides(decl)) {
+      | [_, ..._] => Some(module_lens(decl))
+      | [] => None
+      };
+    }) {
+    | Not_found => None
+    };
+  switch (module_decl) {
+  | Some(mod_sig) => markdown_join(header, mod_sig)
+  | None => header
+  };
 };
 
 let exception_declaration_lens =
@@ -184,16 +194,12 @@ let process =
       )
     | [Module({decl, loc}), ..._] =>
       send_hover(~id, ~range=Utils.loc_to_range(loc), module_lens(decl))
-    | [Include({env, path, loc}), ..._] =>
-      try(
-        send_hover(
-          ~id,
-          ~range=Utils.loc_to_range(loc),
-          include_lens(env, path),
-        )
-      ) {
-      | exn => send_no_result(~id)
-      }
+    | [Include({path, loc}), ..._] =>
+      send_hover(
+        ~id,
+        ~range=Utils.loc_to_range(loc),
+        include_lens(program.env, path),
+      )
     | _ => send_no_result(~id)
     };
   };

--- a/compiler/src/language_server/sourcetree.re
+++ b/compiler/src/language_server/sourcetree.re
@@ -170,7 +170,6 @@ module type Sourcetree = {
         definition: option(Location.t),
       })
     | Include({
-        env: Env.t,
         path: Path.t,
         loc: Location.t,
       });
@@ -260,7 +259,6 @@ module Sourcetree: Sourcetree = {
         definition: option(Location.t),
       })
     | Include({
-        env: Env.t,
         path: Path.t,
         loc: Location.t,
       });
@@ -534,11 +532,7 @@ module Sourcetree: Sourcetree = {
               [
                 (
                   loc_to_interval(stmt.ttop_loc),
-                  Include({
-                    env: stmt.ttop_env,
-                    path: inc.tinc_path,
-                    loc: stmt.ttop_loc,
-                  }),
+                  Include({path: inc.tinc_path, loc: stmt.ttop_loc}),
                 ),
                 ...segments^,
               ]


### PR DESCRIPTION
When #1963 was added we added support for hovering over the `include` tag to see the module signature. It looks like the function used for getting the signature can sometimes throw an exception this prevents the lsp from completely crashing in that case.

This has changed the env to be the program env as `include` is always going to be on the top level and a module is always going to imported into the programs env this makes it more reliable. In the case of failure we just provide the `module Header` so its still nice.