### PR TITLE
chore(graindoc): Start param count at 1

### DIFF
--- a/compiler/graindoc/docblock.re
+++ b/compiler/graindoc/docblock.re
@@ -126,10 +126,17 @@ let () =
       Some(msg);
     | MissingUnlabeledParamType({idx}) =>
       let msg =
-        Printf.sprintf(
-          "Unable to find a type for parameter at index %d. Make sure a parameter exists at this index in the parameter list.",
-          idx,
-        );
+        if (idx == 0) {
+          Printf.sprintf(
+            "Unable to find a type for parameter at index %d. Please note that parameter count starts at 1.",
+            idx,
+          );
+        } else {
+          Printf.sprintf(
+            "Unable to find a type for parameter at index %d. Make sure a parameter exists at this index in the parameter list.",
+            idx,
+          );
+        };
       Some(msg);
     | MissingReturnType =>
       let msg = "Unable to find a return type. Please file an issue!";
@@ -414,12 +421,16 @@ let for_value_description =
           let (param_id, param_type) =
             switch (param_id) {
             | PositionalParam(idx) =>
-              switch (lookup_type_expr(~idx, args)) {
-              | Some((_, typ)) => (
-                  string_of_int(idx),
-                  Printtyp.string_of_type_sch(typ),
-                )
-              | None => raise(MissingUnlabeledParamType({idx: idx}))
+              if (idx <= 0) {
+                raise(MissingUnlabeledParamType({idx: idx}));
+              } else {
+                switch (lookup_type_expr(~idx=idx - 1, args)) {
+                | Some((_, typ)) => (
+                    string_of_int(idx),
+                    Printtyp.string_of_type_sch(typ),
+                  )
+                | None => raise(MissingUnlabeledParamType({idx: idx}))
+                };
               }
             | LabeledParam(name) =>
               switch (lookup_arg_by_label(name, args)) {

--- a/stdlib/runtime/wasi.gr
+++ b/stdlib/runtime/wasi.gr
@@ -77,10 +77,10 @@ provide foreign wasm fd_prestat_dir_name: (
 /**
  * Invokes the `fd_write` system call.
  *
- * @param 0: The file descriptor to write to
- * @param 1: The pointer to the array of iovs to write
- * @param 2: The length of the array of iovs
- * @param 3: Where to store the number of bytes written
+ * @param 1: The file descriptor to write to
+ * @param 2: The pointer to the array of iovs to write
+ * @param 3: The length of the array of iovs
+ * @param 4: Where to store the number of bytes written
  * @returns The number of bytes written
  */
 provide foreign wasm fd_write: (

--- a/stdlib/runtime/wasi.md
+++ b/stdlib/runtime/wasi.md
@@ -104,10 +104,10 @@ Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`0`|`WasmI32`|The file descriptor to write to|
-|`1`|`WasmI32`|The pointer to the array of iovs to write|
-|`2`|`WasmI32`|The length of the array of iovs|
-|`3`|`WasmI32`|Where to store the number of bytes written|
+|`1`|`WasmI32`|The file descriptor to write to|
+|`2`|`WasmI32`|The pointer to the array of iovs to write|
+|`3`|`WasmI32`|The length of the array of iovs|
+|`4`|`WasmI32`|Where to store the number of bytes written|
 
 Returns:
 


### PR DESCRIPTION
This pr makes the `graindoc` indexed parameter count start at `1`. I think this will make the documentation more constistent compared to the labels. Such as in a case like:
```
/**
  * Adds the first parameter to the second parameter.
  * @param 1: The first param
  * @param 2: The second param
  */
let add = (a, b) => a + b
```
When refereing to the params by number you wouldnt say the `zeroith param to the first param` you would say the `first param to the second param`.


This closes: #1996 