### PR TITLE
feat(lsp): Add Inlay types

### DIFF
--- a/compiler/src/language_server/inlayhint.re
+++ b/compiler/src/language_server/inlayhint.re
@@ -33,6 +33,11 @@ let send_no_result = (~id: Protocol.message_id) => {
   Protocol.response(~id, `Null);
 };
 
+let build_hint =
+    (position: Protocol.position, message: string): ResponseResult.inlay_hint => {
+  {label: ": " ++ message, position};
+};
+
 let find_hints = program => {
   let hints = ref([]);
   open Typedtree;
@@ -52,12 +57,26 @@ let find_hints = program => {
             line: stmt_end.pos_lnum - 1,
             character: stmt_end.pos_cnum - stmt_end.pos_bol + 1 + 1,
           };
+          hints := [build_hint(p, name), ...hints^];
+        | _ => ()
+        };
+      };
 
-          let r: ResponseResult.inlay_hint = {
-            label: ": " ++ name,
-            position: p,
-          };
-          hints := [r, ...hints^];
+      let enter_binding = ({vb_pat}: value_binding) => {
+        switch (vb_pat.pat_extra) {
+        | [] =>
+          switch (vb_pat.pat_desc) {
+          | TPatVar(_, {loc}) =>
+            let bind_end = loc.loc_end;
+            let p: Protocol.position = {
+              line: bind_end.pos_lnum - 1,
+              character: bind_end.pos_cnum - bind_end.pos_bol,
+            };
+            let typeSignature =
+              Printtyp.string_of_type_scheme(vb_pat.pat_type);
+            hints := [build_hint(p, typeSignature), ...hints^];
+          | _ => ()
+          }
         | _ => ()
         };
       };


### PR DESCRIPTION
This pr adds inlay types which closes #1359.

This pr is marked as a draft as there is still some work that needs to be done:
* We probably want to simplify some of the type signatures (i.e function types can get very complex, might be better to just say `Function`, and show the return type and param types on the actual lambda)
* We probably want to add a config to the vscode extension to toggle inlay types, as you might want inlay hints like the module hints but not the types.
* We should probably decide if we want to enable inlays on `Tuple patterns`, `record patterns`, `constructor patterns`

Current Demo Below:
![image](https://github.com/grain-lang/grain/assets/40705786/935d62e4-41ff-4343-9de3-5d1707a48863)
