### PR TITLE
chore(docs): Add examples to `Hash` module

### DIFF
--- a/stdlib/hash.gr
+++ b/stdlib/hash.gr
@@ -3,6 +3,9 @@
  *
  * @example include "hash"
  *
+ * @example Hash.hash(1)
+ * @example Hash.hash("Hello World")
+ *
  * @since v0.1.0
  */
 
@@ -241,6 +244,9 @@ let rec hashOne = (val, depth) => {
  *
  * @param anything: The value to hash
  * @returns A hash for the given value
+ *
+ * @example assert Hash.hash(1) == Hash.hash(1)
+ * @example assert Hash.hash("Hello World") == Hash.hash("Hello World")
  *
  * @since v0.1.0
  */

--- a/stdlib/hash.md
+++ b/stdlib/hash.md
@@ -13,6 +13,14 @@ No other changes yet.
 include "hash"
 ```
 
+```grain
+Hash.hash(1)
+```
+
+```grain
+Hash.hash("Hello World")
+```
+
 ## Values
 
 Functions and constants included in the Hash module.
@@ -41,4 +49,14 @@ Returns:
 |type|description|
 |----|-----------|
 |`Number`|A hash for the given value|
+
+Examples:
+
+```grain
+assert Hash.hash(1) == Hash.hash(1)
+```
+
+```grain
+assert Hash.hash("Hello World") == Hash.hash("Hello World")
+```
 


### PR DESCRIPTION
This adds examples to the `Hash` module.