### PR TITLE
chore(docs): Add examples to `Float32` module

### DIFF
--- a/stdlib/float32.gr
+++ b/stdlib/float32.gr
@@ -30,7 +30,7 @@ let _VALUE_OFFSET = 4n
 
 /**
  * Infinity represented as a Float32 value.
- * This is equivalent to `Infinityf`.
+ * This is an alternative to the `Infinityf` literal.
  *
  * @since v0.4.0
  */
@@ -39,7 +39,7 @@ provide let infinity = Infinityf
 
 /**
  * NaN (Not a Number) represented as a Float32 value.
- * This is equivalent to `NaNf`.
+ * This is an alternative to the `NaNf` literal.
  *
  * @since v0.4.0
  */

--- a/stdlib/float32.gr
+++ b/stdlib/float32.gr
@@ -3,6 +3,10 @@
  *
  * @example include "float32"
  *
+ * @example 4.0f
+ * @example Infinityf
+ * @example NaNf
+ *
  * @since v0.2.0
  */
 
@@ -25,6 +29,7 @@ let _VALUE_OFFSET = 4n
 
 /**
  * Infinity represented as a Float32 value.
+ * This is equivalent to `Infinityf`.
  *
  * @since v0.4.0
  */
@@ -33,6 +38,7 @@ provide let infinity = Infinityf
 
 /**
  * NaN (Not a Number) represented as a Float32 value.
+ * This is equivalent to `NaNf`.
  *
  * @since v0.4.0
  */
@@ -69,6 +75,10 @@ provide { fromNumber, toNumber }
  * @param y: The second operand
  * @returns The sum of the two operands
  *
+ * @example
+ * from Float32 use { (+) }
+ * assert 1.0f + 1.0f == 2.0f
+ *
  * @since v0.6.0
  * @history v0.2.0: Originally named `add`
  */
@@ -86,6 +96,10 @@ provide let (+) = (x: Float32, y: Float32) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The difference of the two operands
+ *
+ * @example
+ * from Float32 use { (-) }
+ * assert 1.0f - 1.0f == 0.0f
  *
  * @since v0.6.0
  * @history v0.2.0: Originally named `sub`
@@ -105,6 +119,10 @@ provide let (-) = (x: Float32, y: Float32) => {
  * @param y: The second operand
  * @returns The product of the two operands
  *
+ * @example
+ * from Float32 use { (*) }
+ * assert 2.0f * 2.0f == 4.0f
+ *
  * @since v0.6.0
  * @history v0.2.0: Originally named `mul`
  */
@@ -122,6 +140,10 @@ provide let (*) = (x: Float32, y: Float32) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The quotient of the two operands
+ *
+ * @example
+ * from Float32 use { (/) }
+ * assert 10.0f / 4.0f == 2.5f
  *
  * @since v0.6.0
  * @history v0.2.0: Originally named `div`
@@ -141,6 +163,10 @@ provide let (/) = (x: Float32, y: Float32) => {
  * @param y: The second value
  * @returns `true` if the first value is less than the second value or `false` otherwise
  *
+ * @example
+ * from Float32 use { (<) }
+ * assert 1.0f < 2.0f
+ *
  * @since v0.6.0
  * @history v0.2.0: Originally named `lt`
  */
@@ -157,6 +183,10 @@ provide let (<) = (x: Float32, y: Float32) => {
  * @param x: The first value
  * @param y: The second value
  * @returns `true` if the first value is greater than the second value or `false` otherwise
+ *
+ * @example
+ * from Float32 use { (>) }
+ * assert 2.0f > 1.0f
  *
  * @since v0.6.0
  * @history v0.2.0: Originally named `gt`
@@ -175,6 +205,14 @@ provide let (>) = (x: Float32, y: Float32) => {
  * @param y: The second value
  * @returns `true` if the first value is less than or equal to the second value or `false` otherwise
  *
+ * @example
+ * from Float32 use { (<=) }
+ * assert -1.0f <= 1.0f
+ *
+ * @example
+ * from Float32 use { (<=) }
+ * assert -2.0f <= -2.0f
+ *
  * @since v0.6.0
  * @history v0.2.0: Originally named `lte`
  */
@@ -191,6 +229,14 @@ provide let (<=) = (x: Float32, y: Float32) => {
  * @param x: The first value
  * @param y: The second value
  * @returns `true` if the first value is greater than or equal to the second value or `false` otherwise
+ *
+ * @example
+ * from Float32 use { (>=) }
+ * assert 4.0f >= 1.0f
+ *
+ * @example
+ * from Float32 use { (>=) }
+ * assert 3.0f >= 3.0f
  *
  * @since v0.6.0
  * @history v0.2.0: Originally named `gte`

--- a/stdlib/float32.gr
+++ b/stdlib/float32.gr
@@ -4,6 +4,7 @@
  * @example include "float32"
  *
  * @example 4.0f
+ * @example -4.0f
  * @example Infinityf
  * @example NaNf
  *

--- a/stdlib/float32.md
+++ b/stdlib/float32.md
@@ -18,6 +18,10 @@ include "float32"
 ```
 
 ```grain
+-4.0f
+```
+
+```grain
 Infinityf
 ```
 

--- a/stdlib/float32.md
+++ b/stdlib/float32.md
@@ -45,7 +45,7 @@ infinity : Float32
 ```
 
 Infinity represented as a Float32 value.
-This is equivalent to `Infinityf`.
+This is an alternative to the `Infinityf` literal.
 
 ### Float32.**nan**
 
@@ -59,7 +59,7 @@ nan : Float32
 ```
 
 NaN (Not a Number) represented as a Float32 value.
-This is equivalent to `NaNf`.
+This is an alternative to the `NaNf` literal.
 
 ### Float32.**pi**
 

--- a/stdlib/float32.md
+++ b/stdlib/float32.md
@@ -13,6 +13,18 @@ No other changes yet.
 include "float32"
 ```
 
+```grain
+4.0f
+```
+
+```grain
+Infinityf
+```
+
+```grain
+NaNf
+```
+
 ## Values
 
 Functions and constants included in the Float32 module.
@@ -29,6 +41,7 @@ infinity : Float32
 ```
 
 Infinity represented as a Float32 value.
+This is equivalent to `Infinityf`.
 
 ### Float32.**nan**
 
@@ -42,6 +55,7 @@ nan : Float32
 ```
 
 NaN (Not a Number) represented as a Float32 value.
+This is equivalent to `NaNf`.
 
 ### Float32.**pi**
 
@@ -165,6 +179,13 @@ Returns:
 |----|-----------|
 |`Float32`|The sum of the two operands|
 
+Examples:
+
+```grain
+from Float32 use { (+) }
+assert 1.0f + 1.0f == 2.0f
+```
+
 ### Float32.**(-)**
 
 <details>
@@ -197,6 +218,13 @@ Returns:
 |type|description|
 |----|-----------|
 |`Float32`|The difference of the two operands|
+
+Examples:
+
+```grain
+from Float32 use { (-) }
+assert 1.0f - 1.0f == 0.0f
+```
 
 ### Float32.**(*)**
 
@@ -231,6 +259,13 @@ Returns:
 |----|-----------|
 |`Float32`|The product of the two operands|
 
+Examples:
+
+```grain
+from Float32 use { (*) }
+assert 2.0f * 2.0f == 4.0f
+```
+
 ### Float32.**(/)**
 
 <details>
@@ -263,6 +298,13 @@ Returns:
 |type|description|
 |----|-----------|
 |`Float32`|The quotient of the two operands|
+
+Examples:
+
+```grain
+from Float32 use { (/) }
+assert 10.0f / 4.0f == 2.5f
+```
 
 ### Float32.**(<)**
 
@@ -297,6 +339,13 @@ Returns:
 |----|-----------|
 |`Bool`|`true` if the first value is less than the second value or `false` otherwise|
 
+Examples:
+
+```grain
+from Float32 use { (<) }
+assert 1.0f < 2.0f
+```
+
 ### Float32.**(>)**
 
 <details>
@@ -329,6 +378,13 @@ Returns:
 |type|description|
 |----|-----------|
 |`Bool`|`true` if the first value is greater than the second value or `false` otherwise|
+
+Examples:
+
+```grain
+from Float32 use { (>) }
+assert 2.0f > 1.0f
+```
 
 ### Float32.**(<=)**
 
@@ -363,6 +419,18 @@ Returns:
 |----|-----------|
 |`Bool`|`true` if the first value is less than or equal to the second value or `false` otherwise|
 
+Examples:
+
+```grain
+from Float32 use { (<=) }
+assert -1.0f <= 1.0f
+```
+
+```grain
+from Float32 use { (<=) }
+assert -2.0f <= -2.0f
+```
+
 ### Float32.**(>=)**
 
 <details>
@@ -395,4 +463,16 @@ Returns:
 |type|description|
 |----|-----------|
 |`Bool`|`true` if the first value is greater than or equal to the second value or `false` otherwise|
+
+Examples:
+
+```grain
+from Float32 use { (>=) }
+assert 4.0f >= 1.0f
+```
+
+```grain
+from Float32 use { (>=) }
+assert 3.0f >= 3.0f
+```
 


### PR DESCRIPTION
This improves the docs in the `Float32` module, It adds examples for the float32 syntax to the top following the pattern ive been using in other libs, Adds example to all the functions. and updates the documentation for `Float32.infinity` and `Float32.nan` to mention the alternative syntax.