### PR TITLE
chore(docs): Add examples to the `Float64` module

### DIFF
--- a/stdlib/float64.gr
+++ b/stdlib/float64.gr
@@ -27,7 +27,7 @@ from Numbers use {
 
 /**
  * Infinity represented as a Float64 value.
- * This is equivalent to `Infinityd`.
+ * This is an alternative to the `Infinityd` literal.
  *
  * @since v0.4.0
  */
@@ -36,7 +36,7 @@ provide let infinity = Infinityd
 
 /**
  * NaN (Not a Number) represented as a Float64 value.
- * This is equivalent to `NaNd`.
+ * This is an alternative to the `NaNd` literal.
  *
  * @since v0.4.0
  */

--- a/stdlib/float64.gr
+++ b/stdlib/float64.gr
@@ -3,6 +3,11 @@
  *
  * @example include "float64"
  *
+ * @example 5.0d
+ * @example -5.0d
+ * @example Infinityd
+ * @example NaNd
+ *
  * @since v0.2.0
  */
 
@@ -22,6 +27,7 @@ from Numbers use {
 
 /**
  * Infinity represented as a Float64 value.
+ * This is equivalent to `Infinityd`.
  *
  * @since v0.4.0
  */
@@ -30,6 +36,7 @@ provide let infinity = Infinityd
 
 /**
  * NaN (Not a Number) represented as a Float64 value.
+ * This is equivalent to `NaNd`.
  *
  * @since v0.4.0
  */
@@ -66,6 +73,10 @@ provide { fromNumber, toNumber }
  * @param y: The second operand
  * @returns The sum of the two operands
  *
+ * @example
+ * from Float64 use { (+) }
+ * assert 1.0d + 1.0d == 2.0d
+ *
  * @since v0.6.0
  * @history v0.2.0: Originally named `add`
  */
@@ -83,6 +94,10 @@ provide let (+) = (x: Float64, y: Float64) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The difference of the two operands
+ *
+ * @example
+ * from Float64 use { (-) }
+ * assert 5.0d - 4.0d == 1.0d
  *
  * @since v0.6.0
  * @history v0.2.0: Originally named `sub`
@@ -102,6 +117,10 @@ provide let (-) = (x: Float64, y: Float64) => {
  * @param y: The second operand
  * @returns The product of the two operands
  *
+ * @example
+ * from Float64 use { (*) }
+ * assert -5.0d * 4.0d == -20.0d
+ *
  * @since v0.6.0
  * @history v0.2.0: Originally named `mul`
  */
@@ -119,6 +138,10 @@ provide let (*) = (x: Float64, y: Float64) => {
  * @param x: The first operand
  * @param y: The second operand
  * @returns The quotient of the two operands
+ *
+ * @example
+ * from Float64 use { (/) }
+ * assert 25.0d / 4.0d == 6.25d
  *
  * @since v0.6.0
  * @history v0.2.0: Originally named `div`
@@ -138,6 +161,10 @@ provide let (/) = (x: Float64, y: Float64) => {
  * @param y: The second value
  * @returns `true` if the first value is less than the second value or `false` otherwise
  *
+ * @example
+ * from Float64 use { (<) }
+ * assert -5.0d < 5.0d
+ *
  * @since v0.6.0
  * @history v0.2.0: Originally named `lt`
  */
@@ -154,6 +181,10 @@ provide let (<) = (x: Float64, y: Float64) => {
  * @param x: The first value
  * @param y: The second value
  * @returns `true` if the first value is greater than the second value or `false` otherwise
+ *
+ * @example
+ * from Float64 use { (>) }
+ * assert 6.0d > 5.0d
  *
  * @since v0.6.0
  * @history v0.2.0: Originally named `gt`
@@ -172,6 +203,14 @@ provide let (>) = (x: Float64, y: Float64) => {
  * @param y: The second value
  * @returns `true` if the first value is less than or equal to the second value or `false` otherwise
  *
+ * @example
+ * from Float64 use { (<=) }
+ * assert 1.0d <= 2.0d
+ *
+ * @example
+ * from Float64 use { (<=) }
+ * assert 2.0d <= 2.0d
+ *
  * @since v0.6.0
  * @history v0.2.0: Originally named `lte`
  */
@@ -188,6 +227,14 @@ provide let (<=) = (x: Float64, y: Float64) => {
  * @param x: The first value
  * @param y: The second value
  * @returns `true` if the first value is greater than or equal to the second value or `false` otherwise
+ *
+ * @example
+ * from Float64 use { (>=) }
+ * assert 5.0d >= 2.0d
+ *
+ * @example
+ * from Float64 use { (>=) }
+ * assert -1.0d >= -1.0d
  *
  * @since v0.6.0
  * @history v0.2.0: Originally named `gte`

--- a/stdlib/float64.md
+++ b/stdlib/float64.md
@@ -45,7 +45,7 @@ infinity : Float64
 ```
 
 Infinity represented as a Float64 value.
-This is equivalent to `Infinityd`.
+This is an alternative to the `Infinityd` literal.
 
 ### Float64.**nan**
 
@@ -59,7 +59,7 @@ nan : Float64
 ```
 
 NaN (Not a Number) represented as a Float64 value.
-This is equivalent to `NaNd`.
+This is an alternative to the `NaNd` literal.
 
 ### Float64.**pi**
 

--- a/stdlib/float64.md
+++ b/stdlib/float64.md
@@ -13,6 +13,22 @@ No other changes yet.
 include "float64"
 ```
 
+```grain
+5.0d
+```
+
+```grain
+-5.0d
+```
+
+```grain
+Infinityd
+```
+
+```grain
+NaNd
+```
+
 ## Values
 
 Functions and constants included in the Float64 module.
@@ -29,6 +45,7 @@ infinity : Float64
 ```
 
 Infinity represented as a Float64 value.
+This is equivalent to `Infinityd`.
 
 ### Float64.**nan**
 
@@ -42,6 +59,7 @@ nan : Float64
 ```
 
 NaN (Not a Number) represented as a Float64 value.
+This is equivalent to `NaNd`.
 
 ### Float64.**pi**
 
@@ -165,6 +183,13 @@ Returns:
 |----|-----------|
 |`Float64`|The sum of the two operands|
 
+Examples:
+
+```grain
+from Float64 use { (+) }
+assert 1.0d + 1.0d == 2.0d
+```
+
 ### Float64.**(-)**
 
 <details>
@@ -197,6 +222,13 @@ Returns:
 |type|description|
 |----|-----------|
 |`Float64`|The difference of the two operands|
+
+Examples:
+
+```grain
+from Float64 use { (-) }
+assert 5.0d - 4.0d == 1.0d
+```
 
 ### Float64.**(*)**
 
@@ -231,6 +263,13 @@ Returns:
 |----|-----------|
 |`Float64`|The product of the two operands|
 
+Examples:
+
+```grain
+from Float64 use { (*) }
+assert -5.0d * 4.0d == -20.0d
+```
+
 ### Float64.**(/)**
 
 <details>
@@ -263,6 +302,13 @@ Returns:
 |type|description|
 |----|-----------|
 |`Float64`|The quotient of the two operands|
+
+Examples:
+
+```grain
+from Float64 use { (/) }
+assert 25.0d / 4.0d == 6.25d
+```
 
 ### Float64.**(<)**
 
@@ -297,6 +343,13 @@ Returns:
 |----|-----------|
 |`Bool`|`true` if the first value is less than the second value or `false` otherwise|
 
+Examples:
+
+```grain
+from Float64 use { (<) }
+assert -5.0d < 5.0d
+```
+
 ### Float64.**(>)**
 
 <details>
@@ -329,6 +382,13 @@ Returns:
 |type|description|
 |----|-----------|
 |`Bool`|`true` if the first value is greater than the second value or `false` otherwise|
+
+Examples:
+
+```grain
+from Float64 use { (>) }
+assert 6.0d > 5.0d
+```
 
 ### Float64.**(<=)**
 
@@ -363,6 +423,18 @@ Returns:
 |----|-----------|
 |`Bool`|`true` if the first value is less than or equal to the second value or `false` otherwise|
 
+Examples:
+
+```grain
+from Float64 use { (<=) }
+assert 1.0d <= 2.0d
+```
+
+```grain
+from Float64 use { (<=) }
+assert 2.0d <= 2.0d
+```
+
 ### Float64.**(>=)**
 
 <details>
@@ -395,4 +467,16 @@ Returns:
 |type|description|
 |----|-----------|
 |`Bool`|`true` if the first value is greater than or equal to the second value or `false` otherwise|
+
+Examples:
+
+```grain
+from Float64 use { (>=) }
+assert 5.0d >= 2.0d
+```
+
+```grain
+from Float64 use { (>=) }
+assert -1.0d >= -1.0d
+```
 


### PR DESCRIPTION
This improves the docs in the `Float64` module, It adds examples for the float64 syntax to the top following the pattern ive been using in other libs, Adds example to all the functions. and updates the documentation for `Float64.infinity` and `Float64.nan` to mention the alternative syntax.