### PR TITLE
chore(stdlib): Cleanup unnecessary `mut` and `rec`

### DIFF
--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -24,7 +24,7 @@ include "runtime/numbers"
 from Numbers use { coerceNumberToWasmI32 }
 
 @unsafe
-let mut _ARRAY_START_OFFSET = 8n
+let _ARRAY_START_OFFSET = 8n
 
 @unsafe
 let checkLength = length => {

--- a/stdlib/buffer.gr
+++ b/stdlib/buffer.gr
@@ -32,10 +32,10 @@ abstract record Buffer {
 }
 
 @unsafe
-let mut _SIZE_OFFSET = 4n
+let _SIZE_OFFSET = 4n
 
 @unsafe
-let mut _VALUE_OFFSET = 8n
+let _VALUE_OFFSET = 8n
 
 let _8BIT_LEN = 1
 

--- a/stdlib/pervasives.gr
+++ b/stdlib/pervasives.gr
@@ -237,7 +237,7 @@ provide primitive unbox = "@unbox"
 // Setup exception printing
 primitive elideTypeInfo = "@meta.elide_type_info"
 @unsafe
-let rec setupExceptions = () => {
+let setupExceptions = () => {
   Exception.dangerouslyRegisterPrinter(e => {
     match (e) {
       Failure(msg) => Some("Failure: " ++ msg),

--- a/stdlib/string.gr
+++ b/stdlib/string.gr
@@ -139,7 +139,7 @@ provide let indexOf = (search: String, string: String) => {
   }
   let mut idx = 0n
   let mut ptr = string + 8n
-  let mut pptr = search + 8n
+  let pptr = search + 8n
   let end = ptr + size - psize + 1n
 
   while (ptr < end) {
@@ -2093,12 +2093,12 @@ provide let trim = (string: String) => {
 
 /**
  * Converts all ASCII uppercase characters in the string to lowercase.
- * 
+ *
  * @param string: The string to convert
  * @returns The lowercased string
- * 
+ *
  * @example assert String.toAsciiLowercase("aBc123") == "abc123"
- * 
+ *
  * @since v0.6.0
  */
 provide let toAsciiLowercase = string => {
@@ -2112,12 +2112,12 @@ provide let toAsciiLowercase = string => {
 
 /**
  * Converts all ASCII lowercase characters in the string to uppercase.
- * 
+ *
  * @param string: The string to convert
  * @returns The uppercased string
- * 
+ *
  * @example assert String.toAsciiUppercase("aBc123") == "ABC123"
- * 
+ *
  * @since v0.6.0
  */
 provide let toAsciiUppercase = string => {


### PR DESCRIPTION
This pr cleans up some use cases of `let mut` and `let rec` that were unnecessary. 