### PR TITLE
chore(compiler): Add `fromNumber(<literal>)` warning for `short` types

### DIFF
--- a/compiler/src/typed/typed_well_formedness.re
+++ b/compiler/src/typed/typed_well_formedness.re
@@ -287,23 +287,7 @@ module WellFormednessArg: TypedtreeIter.IteratorArgument = {
               ),
           },
           _,
-          [
-            (
-              _,
-              {
-                exp_desc:
-                  TExpConstant(
-                    Const_number(
-                      (
-                        Const_number_int(_) | Const_number_float(_) |
-                        Const_number_rational(_) |
-                        Const_number_bigint(_)
-                      ) as n,
-                    ),
-                  ),
-              },
-            ),
-          ],
+          [(_, {exp_desc: TExpConstant(Const_number(n))})],
         )
           when
             modname == "Int8"

--- a/compiler/src/typed/typed_well_formedness.re
+++ b/compiler/src/typed/typed_well_formedness.re
@@ -276,7 +276,7 @@ module WellFormednessArg: TypedtreeIter.IteratorArgument = {
             Grain_parsing.Location.prerr_warning(exp_loc, warning);
           };
         }
-      // Check: Warn if using Int32.fromNumber(<literal>)
+      // Check: Warn if using XXXX.fromNumber(<literal>)
       | TExpApp(
           {
             exp_desc:
@@ -289,7 +289,7 @@ module WellFormednessArg: TypedtreeIter.IteratorArgument = {
           _,
           [
             (
-              Unlabeled,
+              _,
               {
                 exp_desc:
                   TExpConstant(
@@ -302,8 +302,12 @@ module WellFormednessArg: TypedtreeIter.IteratorArgument = {
           ],
         )
           when
-            modname == "Int32"
+            modname == "Int8"
+            || modname == "Int16"
+            || modname == "Int32"
             || modname == "Int64"
+            || modname == "Uint8"
+            || modname == "Uint16"
             || modname == "Uint32"
             || modname == "Uint64"
             || modname == "Float32"
@@ -315,16 +319,21 @@ module WellFormednessArg: TypedtreeIter.IteratorArgument = {
           | Const_number_float(nfloat) => Float.to_string(nfloat)
           | _ => failwith("Impossible")
           };
-        let warning =
+        let mod_type =
           switch (modname) {
-          | "Int32" => Grain_utils.Warnings.FromNumberLiteralI32(n_str)
-          | "Int64" => Grain_utils.Warnings.FromNumberLiteralI64(n_str)
-          | "Uint32" => Grain_utils.Warnings.FromNumberLiteralU32(n_str)
-          | "Uint64" => Grain_utils.Warnings.FromNumberLiteralU64(n_str)
-          | "Float32" => Grain_utils.Warnings.FromNumberLiteralF32(n_str)
-          | "Float64" => Grain_utils.Warnings.FromNumberLiteralF64(n_str)
+          | "Int8" => Grain_utils.Warnings.Int8
+          | "Int16" => Grain_utils.Warnings.Int16
+          | "Int32" => Grain_utils.Warnings.Int32
+          | "Int64" => Grain_utils.Warnings.Int64
+          | "Uint8" => Grain_utils.Warnings.Uint8
+          | "Uint16" => Grain_utils.Warnings.Uint16
+          | "Uint32" => Grain_utils.Warnings.Uint32
+          | "Uint64" => Grain_utils.Warnings.Uint64
+          | "Float32" => Grain_utils.Warnings.Float32
+          | "Float64" => Grain_utils.Warnings.Float64
           | _ => failwith("Impossible")
           };
+        let warning = Grain_utils.Warnings.FromNumberLiteral(mod_type, n_str);
         if (Grain_utils.Warnings.is_active(warning)) {
           Grain_parsing.Location.prerr_warning(exp_loc, warning);
         };

--- a/compiler/src/utils/warnings.rei
+++ b/compiler/src/utils/warnings.rei
@@ -30,7 +30,9 @@ type number_type =
   | Uint32
   | Uint64
   | Float32
-  | Float64;
+  | Float64
+  | Rational
+  | BigInt;
 
 type t =
   | LetRecNonFunction(string)
@@ -50,7 +52,7 @@ type t =
   | ShadowConstructor(string)
   | NoCmiFile(string, option(string))
   | FuncWasmUnsafe(string, string, string)
-  | FromNumberLiteral(number_type, string)
+  | FromNumberLiteral(number_type, string, string)
   | UselessRecordSpread;
 
 let is_active: t => bool;

--- a/compiler/src/utils/warnings.rei
+++ b/compiler/src/utils/warnings.rei
@@ -20,6 +20,18 @@ type loc = {
   loc_ghost: bool,
 };
 
+type number_type =
+  | Int8
+  | Int16
+  | Int32
+  | Int64
+  | Uint8
+  | Uint16
+  | Uint32
+  | Uint64
+  | Float32
+  | Float64;
+
 type t =
   | LetRecNonFunction(string)
   | AmbiguousName(list(string), list(string), bool)
@@ -38,12 +50,7 @@ type t =
   | ShadowConstructor(string)
   | NoCmiFile(string, option(string))
   | FuncWasmUnsafe(string, string, string)
-  | FromNumberLiteralI32(string)
-  | FromNumberLiteralI64(string)
-  | FromNumberLiteralU32(string)
-  | FromNumberLiteralU64(string)
-  | FromNumberLiteralF32(string)
-  | FromNumberLiteralF64(string)
+  | FromNumberLiteral(number_type, string)
   | UselessRecordSpread;
 
 let is_active: t => bool;

--- a/compiler/test/suites/numbers.re
+++ b/compiler/test/suites/numbers.re
@@ -200,32 +200,36 @@ describe("numbers", ({test, testSkip}) => {
 
   // well-formedness warnings
   test("float32_fromNumber_warn1", ({expect}) => {
-    expect.string(Warnings.message(FromNumberLiteralF32("5"))).toMatch(
+    expect.string(Warnings.message(FromNumberLiteral(Float32, "5"))).toMatch(
       "5.f",
     )
   });
   test("float32_fromNumber_warn2", ({expect}) => {
-    expect.string(Warnings.message(FromNumberLiteralF32("5."))).toMatch(
+    expect.string(Warnings.message(FromNumberLiteral(Float32, "5."))).
+      toMatch(
       "5.f",
     )
   });
   test("float32_fromNumber_warn3", ({expect}) => {
-    expect.string(Warnings.message(FromNumberLiteralF32("5.5"))).toMatch(
+    expect.string(Warnings.message(FromNumberLiteral(Float32, "5.5"))).
+      toMatch(
       "5.5f",
     )
   });
   test("float64_fromNumber_warn1", ({expect}) => {
-    expect.string(Warnings.message(FromNumberLiteralF64("5"))).toMatch(
+    expect.string(Warnings.message(FromNumberLiteral(Float64, "5"))).toMatch(
       "5.d",
     )
   });
   test("float64_fromNumber_warn2", ({expect}) => {
-    expect.string(Warnings.message(FromNumberLiteralF64("5."))).toMatch(
+    expect.string(Warnings.message(FromNumberLiteral(Float64, "5."))).
+      toMatch(
       "5.d",
     )
   });
   test("float64_fromNumber_warn3", ({expect}) => {
-    expect.string(Warnings.message(FromNumberLiteralF64("5.5"))).toMatch(
+    expect.string(Warnings.message(FromNumberLiteral(Float64, "5.5"))).
+      toMatch(
       "5.5d",
     )
   });

--- a/compiler/test/suites/numbers.re
+++ b/compiler/test/suites/numbers.re
@@ -200,35 +200,49 @@ describe("numbers", ({test, testSkip}) => {
 
   // well-formedness warnings
   test("float32_fromNumber_warn1", ({expect}) => {
-    expect.string(Warnings.message(FromNumberLiteral(Float32, "5"))).toMatch(
+    expect.string(
+      Warnings.message(FromNumberLiteral(Float32, "Float32", "5")),
+    ).
+      toMatch(
       "5.f",
     )
   });
   test("float32_fromNumber_warn2", ({expect}) => {
-    expect.string(Warnings.message(FromNumberLiteral(Float32, "5."))).
+    expect.string(
+      Warnings.message(FromNumberLiteral(Float32, "Float32", "5.")),
+    ).
       toMatch(
       "5.f",
     )
   });
   test("float32_fromNumber_warn3", ({expect}) => {
-    expect.string(Warnings.message(FromNumberLiteral(Float32, "5.5"))).
+    expect.string(
+      Warnings.message(FromNumberLiteral(Float32, "Float32", "5.5")),
+    ).
       toMatch(
       "5.5f",
     )
   });
   test("float64_fromNumber_warn1", ({expect}) => {
-    expect.string(Warnings.message(FromNumberLiteral(Float64, "5"))).toMatch(
+    expect.string(
+      Warnings.message(FromNumberLiteral(Float64, "Float64", "5")),
+    ).
+      toMatch(
       "5.d",
     )
   });
   test("float64_fromNumber_warn2", ({expect}) => {
-    expect.string(Warnings.message(FromNumberLiteral(Float64, "5."))).
+    expect.string(
+      Warnings.message(FromNumberLiteral(Float64, "Float64", "5.")),
+    ).
       toMatch(
       "5.d",
     )
   });
   test("float64_fromNumber_warn3", ({expect}) => {
-    expect.string(Warnings.message(FromNumberLiteral(Float64, "5.5"))).
+    expect.string(
+      Warnings.message(FromNumberLiteral(Float64, "Float64", "5.5")),
+    ).
       toMatch(
       "5.5d",
     )

--- a/compiler/test/suites/numbers.re
+++ b/compiler/test/suites/numbers.re
@@ -199,7 +199,61 @@ describe("numbers", ({test, testSkip}) => {
   );
 
   // well-formedness warnings
-  test("float32_fromNumber_warn1", ({expect}) => {
+  test("short_fromNumber_warn1", ({expect}) => {
+    expect.string(Warnings.message(FromNumberLiteral(Uint8, "Uint8", "2"))).
+      toMatch(
+      "2us",
+    )
+  });
+  test("short_fromNumber_warn2", ({expect}) => {
+    expect.string(
+      Warnings.message(FromNumberLiteral(Uint16, "Uint16", "2")),
+    ).
+      toMatch(
+      "2uS",
+    )
+  });
+  test("short_fromNumber_warn3", ({expect}) => {
+    expect.string(
+      Warnings.message(FromNumberLiteral(Uint32, "Uint32", "2")),
+    ).
+      toMatch(
+      "2ul",
+    )
+  });
+  test("short_fromNumber_warn4", ({expect}) => {
+    expect.string(
+      Warnings.message(FromNumberLiteral(Uint64, "Uint64", "2")),
+    ).
+      toMatch(
+      "2uL",
+    )
+  });
+  test("short_fromNumber_warn5", ({expect}) => {
+    expect.string(Warnings.message(FromNumberLiteral(Int8, "Int8", "2"))).
+      toMatch(
+      "2s",
+    )
+  });
+  test("short_fromNumber_warn6", ({expect}) => {
+    expect.string(Warnings.message(FromNumberLiteral(Int16, "Int16", "2"))).
+      toMatch(
+      "2S",
+    )
+  });
+  test("short_fromNumber_warn7", ({expect}) => {
+    expect.string(Warnings.message(FromNumberLiteral(Int32, "Int32", "2"))).
+      toMatch(
+      "2l",
+    )
+  });
+  test("short_fromNumber_warn8", ({expect}) => {
+    expect.string(Warnings.message(FromNumberLiteral(Int64, "Int64", "2"))).
+      toMatch(
+      "2L",
+    )
+  });
+  test("float32_fromNumber_warn9", ({expect}) => {
     expect.string(
       Warnings.message(FromNumberLiteral(Float32, "Float32", "5")),
     ).
@@ -245,6 +299,30 @@ describe("numbers", ({test, testSkip}) => {
     ).
       toMatch(
       "5.5d",
+    )
+  });
+  test("rational_fromNumber_warn1", ({expect}) => {
+    expect.string(
+      Warnings.message(FromNumberLiteral(Rational, "Rational", "2")),
+    ).
+      toMatch(
+      "2/1r",
+    )
+  });
+  test("rational_fromNumber_warn2", ({expect}) => {
+    expect.string(
+      Warnings.message(FromNumberLiteral(Rational, "Rational", "2/4")),
+    ).
+      toMatch(
+      "2/4r",
+    )
+  });
+  test("bigint_fromNumber_warn1", ({expect}) => {
+    expect.string(
+      Warnings.message(FromNumberLiteral(BigInt, "Bigint", "2")),
+    ).
+      toMatch(
+      "2t",
     )
   });
 });


### PR DESCRIPTION
This pr makes the `fromNumber(<literal>)` warning work on all types.

On a side note I think we broke the implementation of this check when we added default args and this pr also fixes that issue.

I merged the `FromNumberLiteralXXX` warnings into a single warning. I don't know if we want to make this a breaking change as the warning numbers have changed (I feel like we should consider it as one). 

closes: #2019 