### PR TITLE
feat(lsp): Allow goto definition on `include` statements

### DIFF
--- a/compiler/src/language_server/definition.re
+++ b/compiler/src/language_server/definition.re
@@ -72,12 +72,12 @@ let process =
     | [Type({definition}), ..._]
     | [Declaration({definition}), ..._]
     | [Exception({definition}), ..._]
-    | [Module({definition}), ..._] =>
+    | [Module({definition}), ..._]
+    | [Include({definition}), ..._] =>
       switch (definition) {
       | None => send_no_result(~id)
       | Some(loc) =>
         let uri = Utils.filename_to_uri(loc.loc_start.pos_fname);
-
         send_definition(
           ~id,
           ~range=Utils.loc_to_range(loc),

--- a/compiler/src/language_server/sourcetree.re
+++ b/compiler/src/language_server/sourcetree.re
@@ -173,6 +173,7 @@ module type Sourcetree = {
         env: Env.t,
         path: Path.t,
         loc: Location.t,
+        definition: option(Location.t),
       });
 
   type sourcetree = t(node);
@@ -263,6 +264,7 @@ module Sourcetree: Sourcetree = {
         env: Env.t,
         path: Path.t,
         loc: Location.t,
+        definition: option(Location.t),
       });
 
   type sourcetree = t(node);
@@ -535,6 +537,7 @@ module Sourcetree: Sourcetree = {
                     env: stmt.ttop_env,
                     path: inc.tinc_path,
                     loc: stmt.ttop_loc,
+                    definition: Some(inc.tinc_src),
                   }),
                 ),
                 ...segments^,

--- a/compiler/src/parsing/location.re
+++ b/compiler/src/parsing/location.re
@@ -151,7 +151,7 @@ type t =
   };
 
 let in_file = name => {
-  let loc = {pos_fname: name, pos_lnum: 1, pos_bol: 0, pos_cnum: (-1)};
+  let loc = {pos_fname: name, pos_lnum: 1, pos_bol: 0, pos_cnum: 0};
   {loc_start: loc, loc_end: loc, loc_ghost: true};
 };
 

--- a/compiler/src/typed/env.re
+++ b/compiler/src/typed/env.re
@@ -907,7 +907,8 @@ let find_pers_struct = (~loc, check, filepath) => {
 };
 
 let load_pers_struct = (~loc, filepath) => {
-  find_pers_struct(~loc, false, filepath).ps_name;
+  let { ps_name, ps_filename } = find_pers_struct(~loc, false, filepath);
+  (ps_name, ps_filename)
 };
 
 /* Emits a warning if there is no valid cmi for name */

--- a/compiler/src/typed/env.rei
+++ b/compiler/src/typed/env.rei
@@ -86,7 +86,7 @@ let normalize_path_prefix: (option(Location.t), t, Path.t) => Path.t;
 
 let has_local_constraints: t => bool;
 
-let load_pers_struct: (~loc: Location.t, string) => string;
+let load_pers_struct: (~loc: Location.t, string) => (string, string);
 
 /* By-identifier lookups */
 /** Looks up the value associated with the given identifier. */

--- a/compiler/src/typed/typedtree.re
+++ b/compiler/src/typed/typedtree.re
@@ -543,6 +543,8 @@ and match_branch = {
 type include_declaration = {
   tinc_path: Path.t,
   [@sexp_drop_if sexp_locs_disabled]
+  tinc_src: Location.t,
+  [@sexp_drop_if sexp_locs_disabled]
   tinc_loc: Location.t,
 };
 

--- a/compiler/src/typed/typedtree.rei
+++ b/compiler/src/typed/typedtree.rei
@@ -505,6 +505,7 @@ and match_branch = {
 [@deriving sexp]
 type include_declaration = {
   tinc_path: Path.t,
+  tinc_src: Location.t,
   tinc_loc: Location.t,
 };
 

--- a/compiler/src/typed/typemod.re
+++ b/compiler/src/typed/typemod.re
@@ -76,7 +76,8 @@ let extract_sig_open = (env, loc, mty) =>
 
 let include_module = (env, sod) => {
   let include_path = sod.pinc_path.txt;
-  let mod_name = Env.load_pers_struct(~loc=sod.pinc_loc, include_path);
+  let (mod_name, mod_file) =
+    Env.load_pers_struct(~loc=sod.pinc_loc, include_path);
   let mod_name =
     switch (sod.pinc_alias) {
     | Some({txt: alias}) => alias
@@ -94,7 +95,15 @@ let include_module = (env, sod) => {
     );
   let newenv = Env.include_module(mod_name, sod, env);
 
-  let od = {tinc_path: path, tinc_loc: sod.pinc_loc};
+  let mod_file =
+    if (String.ends_with(~suffix=".wasm", mod_file)) {
+      String.sub(mod_file, 0, String.length(mod_file) - 5);
+    } else {
+      mod_file;
+    };
+  let tinc_src = Location.in_file(mod_file);
+
+  let od = {tinc_path: path, tinc_src, tinc_loc: sod.pinc_loc};
 
   (path, newenv, od);
 };


### PR DESCRIPTION
This pr allows for you to use `go to definition` on `Include` statements.

Work for: #1624

Note: 
As we did not reference the source module from the include statement before this change required adding that `attr`, The best way I could find to do it was when we got the module name. An alternative approach would have been to pass the `sod.pinc_path.txt` on in `include_module` but this would lead to inconsistencies with the `include` format.