### PR TITLE
feat(lsp): Add hover for submodules

### DIFF
--- a/compiler/src/language_server/hover.re
+++ b/compiler/src/language_server/hover.re
@@ -182,7 +182,7 @@ let process =
         ~range=Utils.loc_to_range(loc),
         exception_declaration_lens(ident, ext),
       )
-    | [Module({path, decl, loc}), ..._] =>
+    | [Module({decl, loc}), ..._] =>
       send_hover(~id, ~range=Utils.loc_to_range(loc), module_lens(decl))
     | [Include({env, path, loc}), ..._] =>
       send_hover(

--- a/compiler/src/language_server/sourcetree.re
+++ b/compiler/src/language_server/sourcetree.re
@@ -526,6 +526,26 @@ module Sourcetree: Sourcetree = {
         };
         let enter_toplevel_stmt = stmt => {
           switch (stmt.ttop_desc) {
+          | TTopModule(decl) =>
+            let path = Path.PIdent(decl.tmod_id);
+            try({
+              let mod_decl = Env.find_module(path, None, stmt.ttop_env);
+              segments :=
+                [
+                  (
+                    loc_to_interval(stmt.ttop_loc),
+                    Module({
+                      path,
+                      decl: mod_decl,
+                      loc: stmt.ttop_loc,
+                      definition: None,
+                    }),
+                  ),
+                  ...segments^,
+                ];
+            }) {
+            | Not_found => ()
+            };
           | TTopInclude(inc) =>
             segments :=
               [


### PR DESCRIPTION
This PR adds hover lenses onto submodules, which makes it easier to see a submodule's signature at a glance without having to look through the entire submodule. This isn't as useful for modules where everything is provided. but in a module with a bunch of unprovided helpers, a summary can make understanding the code base a lot easier.

Demo Below:
![image](https://github.com/grain-lang/grain/assets/40705786/f24a055f-3b82-40f2-8d4f-b86c11e1b3bf)
