### PR TITLE
fix(stdlib)!: Add a lookup table to `Numbr.sin` to improve trig accuracy

### DIFF
--- a/compiler/test/stdlib/number.test.gr
+++ b/compiler/test/stdlib/number.test.gr
@@ -661,7 +661,7 @@ assert Number.sin(1) > 0.84147 && Number.sin(1) < 0.84148
 assert Number.sin(-1) < -0.84147 && Number.sin(-1) > -0.84148
 assert Number.sin(20) > 0.91294 && Number.sin(20) < 0.91295
 assert Number.sin(1/2) > 0.4794 && Number.sin(1/2) < 0.4795
-// TODO(#1478): Update this test when sin is unbounded
+// TODO(#1478): Update this test when trig functions are fixed
 assert Number.sin(9223372036854775809) == 0.0
 assert Number.isNaN(Number.sin(Infinity))
 assert Number.isNaN(Number.sin(NaN))
@@ -671,7 +671,7 @@ assert Number.cos(1) > 0.5403 && Number.cos(1) < 0.5404
 assert Number.cos(-1) > 0.5403 && Number.cos(-1) < 0.5404
 assert Number.cos(15) < -0.7596 && Number.cos(15) > -0.7597
 assert Number.cos(1/2) > 0.8775 && Number.cos(1/2) < 0.8776
-// TODO(#1478): Update this test when sin is unbounded
+// TODO(#1478): Update this test when trig functions are fixed
 assert Number.cos(9223372036854775809) == 0.0
 assert Number.isNaN(Number.cos(Infinity))
 assert Number.isNaN(Number.cos(NaN))
@@ -681,7 +681,7 @@ assert Number.tan(1) > 1.5574 && Number.tan(1) < 1.5575
 assert Number.tan(-1) > -1.5575 && Number.tan(-1) < -1.5574
 assert Number.tan(15) < -0.8559 && Number.tan(15) > -0.8560
 assert Number.tan(1/2) > 0.5463 && Number.tan(1/2) < 0.5464
-// TODO(#1478): Update this test when sin is unbounded
+// TODO(#1478): Update this test when trig functions are fixed
 assert Number.isNaN(Number.tan(9223372036854775809))
 assert Number.isNaN(Number.tan(Infinity))
 assert Number.isNaN(Number.tan(NaN))

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -569,8 +569,8 @@ provide let sin = (radians: Number) => {
   } else {
     let quot = reduceToPiBound(radians)
     let bounded = radians - pi * quot
-    match (bounded) {
-      0 => 1,
+    let result = match (bounded) {
+      0 => 0,
       _ when bounded == pi / 6 => 0.5,
       _ when bounded == pi / 4 => sqrt(2) / 2,
       _ when bounded == pi / 3 => sqrt(3) / 2,
@@ -579,14 +579,10 @@ provide let sin = (radians: Number) => {
       _ when bounded == 3 * pi / 4 => sqrt(2) / 2,
       _ when bounded == 5 * pi / 6 => 0.5,
       _ when bounded == pi => 0,
-      _ => {
-        if (quot % 2 == 0) {
-          chebyshevSine(bounded)
-        } else {
-          neg(chebyshevSine(bounded))
-        }
-      },
+      _ => chebyshevSine(bounded),
     }
+    let result = if (quot % 2 == 0) result else neg(result)
+    result
   }
 }
 
@@ -619,7 +615,8 @@ provide let tan = (radians: Number) => {
   if (isNaN(radians) || isInfinite(radians)) {
     NaN
   } else {
-    sin(radians) / cos(radians)
+    let denominator = cos(radians)
+    if (denominator == 0) NaN else sin(radians) / denominator
   }
 }
 

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -569,10 +569,23 @@ provide let sin = (radians: Number) => {
   } else {
     let quot = reduceToPiBound(radians)
     let bounded = radians - pi * quot
-    if (quot % 2 == 0) {
-      chebyshevSine(bounded)
-    } else {
-      neg(chebyshevSine(bounded))
+    match (bounded) {
+      0 => 1,
+      _ when bounded == pi / 6 => 0.5,
+      _ when bounded == pi / 4 => sqrt(2) / 2,
+      _ when bounded == pi / 3 => sqrt(3) / 2,
+      _ when bounded == pi / 2 => 1,
+      _ when bounded == 2 * pi / 3 => sqrt(3) / 2,
+      _ when bounded == 3 * pi / 4 => sqrt(2) / 2,
+      _ when bounded == 5 * pi / 6 => 0.5,
+      _ when bounded == pi => 0,
+      _ => {
+        if (quot % 2 == 0) {
+          chebyshevSine(bounded)
+        } else {
+          neg(chebyshevSine(bounded))
+        }
+      },
     }
   }
 }


### PR DESCRIPTION
This pr adds a lookup table to the `sin` function which increases the accuracy of `sin`, `cos` and `tan` technically this is breaking as our results are going to be different.

This isn't a long term solution as if we are not using a special angle there is still some inaccuracy, especially as numbers get larger. 



work for: #1478 