### PR TITLE
fix(stdlib): Ensure consistent marshal representation

### DIFF
--- a/compiler/test/stdlib/marshal.test.gr
+++ b/compiler/test/stdlib/marshal.test.gr
@@ -91,3 +91,5 @@ let truncatedRecord = Bytes.slice(
   )
 )
 assert Result.isErr(unmarshal(truncatedRecord))
+
+assert Marshal.marshal("🌾") == Marshal.marshal("🌾")

--- a/stdlib/marshal.gr
+++ b/stdlib/marshal.gr
@@ -24,6 +24,7 @@ module Marshal
 include "runtime/unsafe/wasmi32"
 use WasmI32.{
   (+),
+  (-),
   (*),
   (&),
   (==),
@@ -196,6 +197,7 @@ let rec marshalHeap = (heapPtr, buf, offset, valuesSeen) => {
     t when t == Tags._GRAIN_STRING_HEAP_TAG || t == Tags._GRAIN_BYTES_HEAP_TAG => {
       let size = 8n + load(heapPtr, 4n)
       Memory.copy(buf + offset, heapPtr, size)
+      Memory.fill(buf + offset + size, 0n, roundTo8(size) - size)
       roundTo8(offset + size)
     },
     t when t == Tags._GRAIN_ADT_HEAP_TAG => {
@@ -426,6 +428,7 @@ provide let marshal = value => {
   let valuePtr = fromGrain(value)
   let buf = allocateBytes(size(valuePtr))
   marshal(valuePtr, buf + 8n)
+  ignore(value)
   toGrain(buf): Bytes
 }
 

--- a/stdlib/marshal.gr
+++ b/stdlib/marshal.gr
@@ -24,7 +24,6 @@ module Marshal
 from "runtime/unsafe/wasmi32" include WasmI32
 use WasmI32.{
   (+),
-  (-),
   (*),
   (&),
   (==),

--- a/stdlib/marshal.gr
+++ b/stdlib/marshal.gr
@@ -196,7 +196,6 @@ let rec marshalHeap = (heapPtr, buf, offset, valuesSeen) => {
     t when t == Tags._GRAIN_STRING_HEAP_TAG || t == Tags._GRAIN_BYTES_HEAP_TAG => {
       let size = 8n + load(heapPtr, 4n)
       Memory.copy(buf + offset, heapPtr, size)
-      Memory.fill(buf + offset + size, 0n, roundTo8(size) - size)
       roundTo8(offset + size)
     },
     t when t == Tags._GRAIN_ADT_HEAP_TAG => {
@@ -425,7 +424,9 @@ let marshal = (value, buf) => {
 @unsafe
 provide let marshal = value => {
   let valuePtr = fromGrain(value)
-  let buf = allocateBytes(size(valuePtr))
+  let size = size(valuePtr)
+  let buf = allocateBytes(size)
+  Memory.fill(buf + 8n, 0n, size)
   marshal(valuePtr, buf + 8n)
   ignore(value)
   toGrain(buf): Bytes


### PR DESCRIPTION
This makes sure that the marshaled representation is always consistent.