### PR TITLE
fix(cli): Show correct error when module traps

### DIFF
--- a/cli/bin/grainrun.js
+++ b/cli/bin/grainrun.js
@@ -35,7 +35,8 @@ async function run(filename) {
     bytes = await readFile(filename);
   } catch (err) {
     console.error(`Unable to read file: ${filename}`);
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   let wasm;
@@ -53,16 +54,26 @@ async function run(filename) {
       console.error(`Unable to compile WebAssembly module.`);
       console.error(err.stack);
     }
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
+  let instance;
   try {
-    const instance = await WebAssembly.instantiate(wasm, importObject);
-    wasi.start(instance);
+    instance = await WebAssembly.instantiate(wasm, importObject);
   } catch (err) {
     console.error(`Unable to instantiate WebAssembly module.`);
     console.error(err.stack);
-    process.exit(1);
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    wasi.start(instance);
+  } catch (err) {
+    console.error(err.stack);
+    process.exitCode = 1;
+    return;
   }
 }
 


### PR DESCRIPTION
If an assertion fails, we show `Unable to instantiate WebAssembly module` which is incorrect. This ensures that message only shows when the module failed to instantiate.