### PR TITLE
fix(stdlib): Error when `relativeTo` used on relative source and absolute dest

### DIFF
--- a/compiler/test/stdlib/path.test.gr
+++ b/compiler/test/stdlib/path.test.gr
@@ -253,6 +253,11 @@ let relativeToTests = [
     dest: "./a.txt",
     result: Err(Path.Incompatible(Path.DifferentBases)),
   },
+  {
+    source: "./a.txt",
+    dest: "/bin",
+    result: Err(Path.Incompatible(Path.DifferentBases)),
+  },
 ]
 
 List.forEach(({ source, dest, result }) => {

--- a/stdlib/path.gr
+++ b/stdlib/path.gr
@@ -571,7 +571,7 @@ provide let relativeTo = (source, dest) => {
   let pathInfo2 = pathInfo(dest)
   let (base2, _, _) = pathInfo2
   match ((base1, base2)) {
-    (Abs(_), Rel(_)) | (Abs(_), Rel(_)) => Err(Incompatible(DifferentBases)),
+    (Abs(_), Rel(_)) | (Rel(_), Abs(_)) => Err(Incompatible(DifferentBases)),
     _ => Result.map(toPath, relativeToHelper(pathInfo1, pathInfo2)),
   }
 }


### PR DESCRIPTION
Properly handles case where first argument is absolute and second argument is relative to the `Path.relativeTo` function