### PR TITLE
chore: Supress warnings when testing fromNumber

### DIFF
--- a/compiler/test/stdlib/rational.test.gr
+++ b/compiler/test/stdlib/rational.test.gr
@@ -15,6 +15,9 @@ use Rational.{
 }
 
 // Rational.fromNumber
+// Operations Tests
+// Suppress warnings about using `fromNumber` on constants, since that's what we want to test.
+let fromNumber = fromNumber
 assert fromNumber(1/2) == 1/2r
 assert fromNumber(0) == 0/1r
 assert fromNumber(1/1) == 1/1r

--- a/compiler/test/suites/numbers.re
+++ b/compiler/test/suites/numbers.re
@@ -179,12 +179,22 @@ describe("numbers", ({test, testSkip}) => {
   );
   assertRunError(
     "shortnum_err1",
-    {|from "uint8" include Uint8; print(Uint8.fromNumber(-1))|},
+    {|
+    from "uint8" include Uint8;
+    // Suppress warnings about using `fromNumber` on constants, since that's what we want to test.
+    let fromNumber = Uint8.fromNumber
+    print(fromNumber(-1))
+    |},
     "Overflow: Number overflow",
   );
   assertRunError(
     "shortnum_err2",
-    {|from "uint8" include Uint8; print(Uint8.fromNumber(256))|},
+    {|
+    from "uint8" include Uint8;
+    // Suppress warnings about using `fromNumber` on constants, since that's what we want to test.
+    let fromNumber = Uint8.fromNumber
+    print(fromNumber(256))
+    |},
     "Overflow: Number overflow",
   );
   assertCompileError(


### PR DESCRIPTION
I ran the suite locally with @spotandjake's changes and got a bunch of warnings. This uses the same trick as everywhere else to avoid them.