### PR TITLE
chore(stdlib): Convert all relative filepath includes to module includes

### DIFF
--- a/stdlib/runtime/atof/common.gr
+++ b/stdlib/runtime/atof/common.gr
@@ -36,7 +36,7 @@ from "runtime/dataStructures" include DataStructures
 use DataStructures.{ newInt32, newInt64, newFloat64 }
 from "runtime/numberUtils" include NumberUtils
 use NumberUtils.{ get_POWERS10 }
-from "./table.gr" include Table
+from "runtime/atof/table" include Table
 use Table.{ get_F64_POWERS10_FAST_PATH, get_POWERS5 }
 
 primitive (&&) = "@and"

--- a/stdlib/runtime/atof/decimal.gr
+++ b/stdlib/runtime/atof/decimal.gr
@@ -35,7 +35,7 @@ from "runtime/unsafe/memory" include Memory
 from "runtime/dataStructures" include DataStructures
 use DataStructures.{ newInt32, allocateBytes }
 
-from "./common.gr" include Common
+from "runtime/atof/common" include Common
 use Common.{
   _CHAR_CODE_UNDERSCORE,
   _CHAR_CODE_PLUS,

--- a/stdlib/runtime/atof/lemire.gr
+++ b/stdlib/runtime/atof/lemire.gr
@@ -34,10 +34,10 @@ from "runtime/unsafe/wasmi64" include WasmI64
 
 from "runtime/dataStructures" include DataStructures
 use DataStructures.{ newInt32, newInt64, newFloat64 }
-from "./table.gr" include Table
+from "runtime/atof/table" include Table
 use Table.{ get_POWERS5 }
 
-from "./common.gr" include Common
+from "runtime/atof/common" include Common
 use Common.{
   _SMALLEST_POWER_OF_FIVE,
   _LARGEST_POWER_OF_FIVE,

--- a/stdlib/runtime/atof/parse.gr
+++ b/stdlib/runtime/atof/parse.gr
@@ -34,7 +34,7 @@ from "runtime/unsafe/wasmf64" include WasmF64
 from "runtime/dataStructures" include DataStructures
 use DataStructures.{ newInt32, newInt64, newFloat64 }
 
-from "./common.gr" include Common
+from "runtime/atof/common" include Common
 use Common.{
   _CHAR_CODE_UNDERSCORE,
   _CHAR_CODE_PLUS,
@@ -63,9 +63,9 @@ use Common.{
   fpInf,
 }
 
-from "./lemire.gr" include Lemire
+from "runtime/atof/lemire" include Lemire
 use Lemire.{ computeFloat }
-from "./slow.gr" include Slow
+from "runtime/atof/slow" include Slow
 use Slow.{ parseLongMantissa }
 
 // Try to parse 8 digits at a time:

--- a/stdlib/runtime/atof/slow.gr
+++ b/stdlib/runtime/atof/slow.gr
@@ -36,7 +36,7 @@ from "runtime/unsafe/memory" include Memory
 from "runtime/dataStructures" include DataStructures
 use DataStructures.{ newInt32, newInt64 }
 
-from "./common.gr" include Common
+from "runtime/atof/common" include Common
 use Common.{
   type BiasedFp,
   fpZero,
@@ -47,7 +47,7 @@ use Common.{
   _MANTISSA_EXPLICIT_BITS_32,
   _MANTISSA_EXPLICIT_BITS_64,
 }
-from "./decimal.gr" include Decimal
+from "runtime/atof/decimal" include Decimal
 use Decimal.{ parseDecimal, _DECIMAL_POINT_RANGE }
 
 @unsafe


### PR DESCRIPTION
Not sure if we care about this. I thought it might matter for some of our optimizations but nothing changed in the snapshots.