### PR TITLE
fix(compiler): Ensure the extension is chopped in the case of module name error

### DIFF
--- a/compiler/src/typed/module_resolution.re
+++ b/compiler/src/typed/module_resolution.re
@@ -236,11 +236,13 @@ let try_locate_module =
         | exception Not_found => error(No_module_file(loc, name, None))
         | _ =>
           let name = !is_relpath(name) ? no_extension : name;
+          // The filepath might have come in as `.gr.gr` so we need to chop again
+          let module_name = chop_suffix(no_extension, ".gr");
           error(
             No_module_file(
               loc,
               name,
-              Some("did you mean \"" ++ no_extension ++ "\"?"),
+              Some("did you mean \"" ++ module_name ++ "\"?"),
             ),
           );
         };


### PR DESCRIPTION
In working on #2059, I noticed that the error message was wrong when I wrote `"runtime/atof/common.gr"` so I fixed it.