### PR TITLE
fix(compiler): Set maximum wasm table size

### DIFF
--- a/compiler/src/linking/link.re
+++ b/compiler/src/linking/link.re
@@ -692,7 +692,7 @@ let link_all = (linked_mod, dependencies, signature) => {
     linked_mod,
     Comp_utils.grain_global_function_table,
     table_offset^,
-    -1,
+    table_offset^,
     Type.funcref,
   );
 

--- a/compiler/test/suites/basic_functionality.re
+++ b/compiler/test/suites/basic_functionality.re
@@ -377,6 +377,6 @@ describe("basic functionality", ({test, testSkip}) => {
     ~config_fn=smallestFileConfig,
     "smallest_grain_program",
     "",
-    4768,
+    4769,
   );
 });


### PR DESCRIPTION
This pr makes the linker set the maximum wasm table size when generating code. 


[This issue was raised in discord](https://discord.com/channels/676306448594108416/778671397266128897/1214694527005229057)