### PR TITLE
feat(compiler): Allow non-block bodies with loops

### DIFF
--- a/compiler/src/parsing/parser.messages
+++ b/compiler/src/parsing/parser.messages
@@ -1279,21 +1279,6 @@ program: MODULE UIDENT EOL WASMI64 INFIX_70 EOL UNDERSCORE
 ## In state 3, spurious reduction of production nonempty_list(eol) -> EOL
 ## In state 5, spurious reduction of production eols -> nonempty_list(eol)
 ##
-program: MODULE UIDENT EOL WHILE LPAREN WASMI64 RPAREN LBRACE UNDERSCORE
-##
-## Ends in an error in state: 669.
-##
-## block -> lbrace . block_body rbrace [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON ]
-##
-## The known suffix of the stack is as follows:
-## lbrace
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 21, spurious reduction of production lbrace -> LBRACE
-##
 program: MODULE UIDENT EOL MATCH LPAREN FLOAT32 RPAREN LBRACE NUMBER_INT WHEN FLOAT32 THICKARROW WHEN
 ##
 ## Ends in an error in state: 773.
@@ -1412,6 +1397,448 @@ program: MODULE UIDENT EOL FUN LPAREN NUMBER_INT EQUAL YIELD
 ##
 ## The known suffix of the stack is as follows:
 ## EQUAL
+##
+program: MODULE UIDENT EOL FOR LPAREN SEMI SEMI RPAREN YIELD
+##
+## Ends in an error in state: 607.
+##
+## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr SEMI for_inner_expr rparen . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr SEMI for_inner_expr rparen . eols expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## FOR lparen option(block_body_expr) SEMI for_inner_expr SEMI for_inner_expr rparen
+##
+program: MODULE UIDENT EOL FOR LPAREN SEMI SEMI RPAREN EOL YIELD
+##
+## Ends in an error in state: 609.
+##
+## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr SEMI for_inner_expr rparen eols . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## FOR lparen option(block_body_expr) SEMI for_inner_expr SEMI for_inner_expr rparen eols
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 1, spurious reduction of production nonempty_list(eol) -> EOL
+## In state 5, spurious reduction of production eols -> nonempty_list(eol)
+##
+program: MODULE UIDENT EOL FOR LPAREN SEMI SEMI EOL RPAREN YIELD
+##
+## Ends in an error in state: 614.
+##
+## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr SEMI eols for_inner_expr rparen . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr SEMI eols for_inner_expr rparen . eols expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## FOR lparen option(block_body_expr) SEMI for_inner_expr SEMI eols for_inner_expr rparen
+##
+program: MODULE UIDENT EOL FOR LPAREN SEMI SEMI EOL RPAREN EOL YIELD
+##
+## Ends in an error in state: 616.
+##
+## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr SEMI eols for_inner_expr rparen eols . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## FOR lparen option(block_body_expr) SEMI for_inner_expr SEMI eols for_inner_expr rparen eols
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 1, spurious reduction of production nonempty_list(eol) -> EOL
+## In state 5, spurious reduction of production eols -> nonempty_list(eol)
+##
+program: MODULE UIDENT EOL FOR LPAREN SEMI UIDENT EOL SEMI RPAREN YIELD
+##
+## Ends in an error in state: 621.
+##
+## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr eols SEMI for_inner_expr rparen . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr eols SEMI for_inner_expr rparen . eols expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## FOR lparen option(block_body_expr) SEMI for_inner_expr eols SEMI for_inner_expr rparen
+##
+program: MODULE UIDENT EOL FOR LPAREN SEMI UIDENT EOL SEMI RPAREN EOL YIELD
+##
+## Ends in an error in state: 623.
+##
+## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr eols SEMI for_inner_expr rparen eols . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## FOR lparen option(block_body_expr) SEMI for_inner_expr eols SEMI for_inner_expr rparen eols
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 1, spurious reduction of production nonempty_list(eol) -> EOL
+## In state 5, spurious reduction of production eols -> nonempty_list(eol)
+##
+program: MODULE UIDENT EOL FOR LPAREN SEMI UIDENT EOL SEMI EOL RPAREN YIELD
+##
+## Ends in an error in state: 627.
+##
+## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr eols SEMI eols for_inner_expr rparen . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr eols SEMI eols for_inner_expr rparen . eols expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## FOR lparen option(block_body_expr) SEMI for_inner_expr eols SEMI eols for_inner_expr rparen
+##
+program: MODULE UIDENT EOL FOR LPAREN SEMI UIDENT EOL SEMI EOL RPAREN EOL YIELD
+##
+## Ends in an error in state: 629.
+##
+## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr eols SEMI eols for_inner_expr rparen eols . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## FOR lparen option(block_body_expr) SEMI for_inner_expr eols SEMI eols for_inner_expr rparen eols
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 1, spurious reduction of production nonempty_list(eol) -> EOL
+## In state 5, spurious reduction of production eols -> nonempty_list(eol)
+##
+program: MODULE UIDENT EOL FOR LPAREN SEMI EOL SEMI RPAREN YIELD
+##
+## Ends in an error in state: 635.
+##
+## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr SEMI for_inner_expr rparen . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr SEMI for_inner_expr rparen . eols expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## FOR lparen option(block_body_expr) SEMI eols for_inner_expr SEMI for_inner_expr rparen
+##
+program: MODULE UIDENT EOL FOR LPAREN SEMI EOL SEMI RPAREN EOL YIELD
+##
+## Ends in an error in state: 637.
+##
+## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr SEMI for_inner_expr rparen eols . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## FOR lparen option(block_body_expr) SEMI eols for_inner_expr SEMI for_inner_expr rparen eols
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 1, spurious reduction of production nonempty_list(eol) -> EOL
+## In state 5, spurious reduction of production eols -> nonempty_list(eol)
+##
+program: MODULE UIDENT EOL FOR LPAREN SEMI EOL SEMI EOL RPAREN YIELD
+##
+## Ends in an error in state: 641.
+##
+## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr SEMI eols for_inner_expr rparen . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr SEMI eols for_inner_expr rparen . eols expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## FOR lparen option(block_body_expr) SEMI eols for_inner_expr SEMI eols for_inner_expr rparen
+##
+program: MODULE UIDENT EOL FOR LPAREN SEMI EOL SEMI EOL RPAREN EOL YIELD
+##
+## Ends in an error in state: 643.
+##
+## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr SEMI eols for_inner_expr rparen eols . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## FOR lparen option(block_body_expr) SEMI eols for_inner_expr SEMI eols for_inner_expr rparen eols
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 1, spurious reduction of production nonempty_list(eol) -> EOL
+## In state 5, spurious reduction of production eols -> nonempty_list(eol)
+##
+program: MODULE UIDENT EOL FOR LPAREN SEMI EOL UIDENT EOL SEMI RPAREN YIELD
+##
+## Ends in an error in state: 648.
+##
+## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr eols SEMI for_inner_expr rparen . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr eols SEMI for_inner_expr rparen . eols expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## FOR lparen option(block_body_expr) SEMI eols for_inner_expr eols SEMI for_inner_expr rparen
+##
+program: MODULE UIDENT EOL FOR LPAREN SEMI EOL UIDENT EOL SEMI RPAREN EOL YIELD
+##
+## Ends in an error in state: 650.
+##
+## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr eols SEMI for_inner_expr rparen eols . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## FOR lparen option(block_body_expr) SEMI eols for_inner_expr eols SEMI for_inner_expr rparen eols
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 1, spurious reduction of production nonempty_list(eol) -> EOL
+## In state 5, spurious reduction of production eols -> nonempty_list(eol)
+##
+program: MODULE UIDENT EOL FOR LPAREN SEMI EOL UIDENT EOL SEMI EOL RPAREN YIELD
+##
+## Ends in an error in state: 654.
+##
+## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr eols SEMI eols for_inner_expr rparen . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr eols SEMI eols for_inner_expr rparen . eols expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## FOR lparen option(block_body_expr) SEMI eols for_inner_expr eols SEMI eols for_inner_expr rparen
+##
+program: MODULE UIDENT EOL FOR LPAREN SEMI EOL UIDENT EOL SEMI EOL RPAREN EOL YIELD
+##
+## Ends in an error in state: 656.
+##
+## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr eols SEMI eols for_inner_expr rparen eols . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## FOR lparen option(block_body_expr) SEMI eols for_inner_expr eols SEMI eols for_inner_expr rparen eols
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 1, spurious reduction of production nonempty_list(eol) -> EOL
+## In state 5, spurious reduction of production eols -> nonempty_list(eol)
+##
+program: MODULE UIDENT EOL FOR LPAREN UIDENT EOL SEMI SEMI RPAREN YIELD
+##
+## Ends in an error in state: 663.
+##
+## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr SEMI for_inner_expr rparen . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr SEMI for_inner_expr rparen . eols expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## FOR lparen option(block_body_expr) eols SEMI for_inner_expr SEMI for_inner_expr rparen
+##
+program: MODULE UIDENT EOL FOR LPAREN UIDENT EOL SEMI SEMI RPAREN EOL YIELD
+##
+## Ends in an error in state: 665.
+##
+## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr SEMI for_inner_expr rparen eols . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## FOR lparen option(block_body_expr) eols SEMI for_inner_expr SEMI for_inner_expr rparen eols
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 1, spurious reduction of production nonempty_list(eol) -> EOL
+## In state 5, spurious reduction of production eols -> nonempty_list(eol)
+##
+program: MODULE UIDENT EOL FOR LPAREN UIDENT EOL SEMI SEMI EOL RPAREN YIELD
+##
+## Ends in an error in state: 669.
+##
+## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr SEMI eols for_inner_expr rparen . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr SEMI eols for_inner_expr rparen . eols expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## FOR lparen option(block_body_expr) eols SEMI for_inner_expr SEMI eols for_inner_expr rparen
+##
+program: MODULE UIDENT EOL FOR LPAREN UIDENT EOL SEMI SEMI EOL RPAREN EOL YIELD
+##
+## Ends in an error in state: 671.
+##
+## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr SEMI eols for_inner_expr rparen eols . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## FOR lparen option(block_body_expr) eols SEMI for_inner_expr SEMI eols for_inner_expr rparen eols
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 1, spurious reduction of production nonempty_list(eol) -> EOL
+## In state 5, spurious reduction of production eols -> nonempty_list(eol)
+##
+program: MODULE UIDENT EOL FOR LPAREN UIDENT EOL SEMI UIDENT EOL SEMI RPAREN YIELD
+##
+## Ends in an error in state: 676.
+##
+## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr eols SEMI for_inner_expr rparen . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr eols SEMI for_inner_expr rparen . eols expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## FOR lparen option(block_body_expr) eols SEMI for_inner_expr eols SEMI for_inner_expr rparen
+##
+program: MODULE UIDENT EOL FOR LPAREN UIDENT EOL SEMI UIDENT EOL SEMI RPAREN EOL YIELD
+##
+## Ends in an error in state: 678.
+##
+## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr eols SEMI for_inner_expr rparen eols . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## FOR lparen option(block_body_expr) eols SEMI for_inner_expr eols SEMI for_inner_expr rparen eols
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 1, spurious reduction of production nonempty_list(eol) -> EOL
+## In state 5, spurious reduction of production eols -> nonempty_list(eol)
+##
+program: MODULE UIDENT EOL FOR LPAREN UIDENT EOL SEMI UIDENT EOL SEMI EOL RPAREN YIELD
+##
+## Ends in an error in state: 682.
+##
+## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr eols SEMI eols for_inner_expr rparen . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr eols SEMI eols for_inner_expr rparen . eols expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## FOR lparen option(block_body_expr) eols SEMI for_inner_expr eols SEMI eols for_inner_expr rparen
+##
+program: MODULE UIDENT EOL FOR LPAREN UIDENT EOL SEMI UIDENT EOL SEMI EOL RPAREN EOL YIELD
+##
+## Ends in an error in state: 684.
+##
+## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr eols SEMI eols for_inner_expr rparen eols . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## FOR lparen option(block_body_expr) eols SEMI for_inner_expr eols SEMI eols for_inner_expr rparen eols
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 1, spurious reduction of production nonempty_list(eol) -> EOL
+## In state 5, spurious reduction of production eols -> nonempty_list(eol)
+##
+program: MODULE UIDENT EOL FOR LPAREN UIDENT EOL SEMI EOL SEMI RPAREN YIELD
+##
+## Ends in an error in state: 690.
+##
+## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr SEMI for_inner_expr rparen . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr SEMI for_inner_expr rparen . eols expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr SEMI for_inner_expr rparen
+##
+program: MODULE UIDENT EOL FOR LPAREN UIDENT EOL SEMI EOL SEMI RPAREN EOL YIELD
+##
+## Ends in an error in state: 692.
+##
+## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr SEMI for_inner_expr rparen eols . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr SEMI for_inner_expr rparen eols
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 1, spurious reduction of production nonempty_list(eol) -> EOL
+## In state 5, spurious reduction of production eols -> nonempty_list(eol)
+##
+program: MODULE UIDENT EOL FOR LPAREN UIDENT EOL SEMI EOL SEMI EOL RPAREN YIELD
+##
+## Ends in an error in state: 696.
+##
+## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr SEMI eols for_inner_expr rparen . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr SEMI eols for_inner_expr rparen . eols expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr SEMI eols for_inner_expr rparen
+##
+program: MODULE UIDENT EOL FOR LPAREN UIDENT EOL SEMI EOL SEMI EOL RPAREN EOL YIELD
+##
+## Ends in an error in state: 698.
+##
+## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr SEMI eols for_inner_expr rparen eols . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr SEMI eols for_inner_expr rparen eols
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 1, spurious reduction of production nonempty_list(eol) -> EOL
+## In state 5, spurious reduction of production eols -> nonempty_list(eol)
+##
+program: MODULE UIDENT EOL FOR LPAREN UIDENT EOL SEMI EOL UIDENT EOL SEMI RPAREN YIELD
+##
+## Ends in an error in state: 703.
+##
+## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr eols SEMI for_inner_expr rparen . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr eols SEMI for_inner_expr rparen . eols expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr eols SEMI for_inner_expr rparen
+##
+program: MODULE UIDENT EOL FOR LPAREN UIDENT EOL SEMI EOL UIDENT EOL SEMI RPAREN EOL YIELD
+##
+## Ends in an error in state: 705.
+##
+## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr eols SEMI for_inner_expr rparen eols . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr eols SEMI for_inner_expr rparen eols
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 1, spurious reduction of production nonempty_list(eol) -> EOL
+## In state 5, spurious reduction of production eols -> nonempty_list(eol)
+##
+program: MODULE UIDENT EOL FOR LPAREN UIDENT EOL SEMI EOL UIDENT EOL SEMI EOL RPAREN YIELD
+##
+## Ends in an error in state: 709.
+##
+## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr eols SEMI eols for_inner_expr rparen . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr eols SEMI eols for_inner_expr rparen . eols expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr eols SEMI eols for_inner_expr rparen
+##
+program: MODULE UIDENT EOL FOR LPAREN UIDENT EOL SEMI EOL UIDENT EOL SEMI EOL RPAREN EOL YIELD
+##
+## Ends in an error in state: 711.
+##
+## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr eols SEMI eols for_inner_expr rparen eols . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr eols SEMI eols for_inner_expr rparen eols
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 1, spurious reduction of production nonempty_list(eol) -> EOL
+## In state 5, spurious reduction of production eols -> nonempty_list(eol)
+##
+program: MODULE UIDENT EOL WHILE LPAREN UIDENT RPAREN YIELD
+##
+## Ends in an error in state: 768.
+##
+## while_expr -> WHILE lparen expr rparen . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+## while_expr -> WHILE lparen expr rparen . eols expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## WHILE lparen expr rparen
+##
+program: MODULE UIDENT EOL WHILE LPAREN UIDENT RPAREN EOL YIELD
+##
+## Ends in an error in state: 770.
+##
+## while_expr -> WHILE lparen expr rparen eols . expr [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON AND ]
+##
+## The known suffix of the stack is as follows:
+## WHILE lparen expr rparen eols
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 1, spurious reduction of production nonempty_list(eol) -> EOL
+## In state 5, spurious reduction of production eols -> nonempty_list(eol)
 ##
 
 Expected an expression.
@@ -1771,153 +2198,6 @@ program: MODULE UIDENT EOL FAIL WHEN
 ##
 
 Expected the `fail` keyword followed by an expression.
-
-program: MODULE UIDENT EOL FOR LPAREN SEMI EOL SEMI EOL RPAREN WHILE
-##
-## Ends in an error in state: 695.
-##
-## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr SEMI eols for_inner_expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON ]
-##
-## The known suffix of the stack is as follows:
-## FOR lparen option(block_body_expr) SEMI eols for_inner_expr SEMI eols for_inner_expr rparen
-##
-program: MODULE UIDENT EOL FOR LPAREN SEMI EOL SEMI RPAREN WHILE
-##
-## Ends in an error in state: 691.
-##
-## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr SEMI for_inner_expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON ]
-##
-## The known suffix of the stack is as follows:
-## FOR lparen option(block_body_expr) SEMI eols for_inner_expr SEMI for_inner_expr rparen
-##
-program: MODULE UIDENT EOL FOR LPAREN SEMI EOL WASMI64 EOL SEMI EOL RPAREN WHILE
-##
-## Ends in an error in state: 704.
-##
-## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr eols SEMI eols for_inner_expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON ]
-##
-## The known suffix of the stack is as follows:
-## FOR lparen option(block_body_expr) SEMI eols for_inner_expr eols SEMI eols for_inner_expr rparen
-##
-program: MODULE UIDENT EOL FOR LPAREN SEMI EOL WASMI64 EOL SEMI RPAREN WHILE
-##
-## Ends in an error in state: 700.
-##
-## for_expr -> FOR lparen option(block_body_expr) SEMI eols for_inner_expr eols SEMI for_inner_expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON ]
-##
-## The known suffix of the stack is as follows:
-## FOR lparen option(block_body_expr) SEMI eols for_inner_expr eols SEMI for_inner_expr rparen
-##
-program: MODULE UIDENT EOL FOR LPAREN SEMI SEMI EOL RPAREN WHILE
-##
-## Ends in an error in state: 676.
-##
-## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr SEMI eols for_inner_expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON ]
-##
-## The known suffix of the stack is as follows:
-## FOR lparen option(block_body_expr) SEMI for_inner_expr SEMI eols for_inner_expr rparen
-##
-program: MODULE UIDENT EOL FOR LPAREN SEMI SEMI RPAREN WHILE
-##
-## Ends in an error in state: 668.
-##
-## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr SEMI for_inner_expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON ]
-##
-## The known suffix of the stack is as follows:
-## FOR lparen option(block_body_expr) SEMI for_inner_expr SEMI for_inner_expr rparen
-##
-program: MODULE UIDENT EOL FOR LPAREN SEMI WASMI64 EOL SEMI EOL RPAREN WHILE
-##
-## Ends in an error in state: 685.
-##
-## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr eols SEMI eols for_inner_expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON ]
-##
-## The known suffix of the stack is as follows:
-## FOR lparen option(block_body_expr) SEMI for_inner_expr eols SEMI eols for_inner_expr rparen
-##
-program: MODULE UIDENT EOL FOR LPAREN SEMI WASMI64 EOL SEMI RPAREN WHILE
-##
-## Ends in an error in state: 681.
-##
-## for_expr -> FOR lparen option(block_body_expr) SEMI for_inner_expr eols SEMI for_inner_expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON ]
-##
-## The known suffix of the stack is as follows:
-## FOR lparen option(block_body_expr) SEMI for_inner_expr eols SEMI for_inner_expr rparen
-##
-program: MODULE UIDENT EOL FOR LPAREN WASMI64 EOL SEMI EOL SEMI EOL RPAREN WHILE
-##
-## Ends in an error in state: 734.
-##
-## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr SEMI eols for_inner_expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON ]
-##
-## The known suffix of the stack is as follows:
-## FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr SEMI eols for_inner_expr rparen
-##
-program: MODULE UIDENT EOL FOR LPAREN WASMI64 EOL SEMI EOL SEMI RPAREN WHILE
-##
-## Ends in an error in state: 730.
-##
-## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr SEMI for_inner_expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON ]
-##
-## The known suffix of the stack is as follows:
-## FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr SEMI for_inner_expr rparen
-##
-program: MODULE UIDENT EOL FOR LPAREN WASMI64 EOL SEMI EOL WASMI64 EOL SEMI EOL RPAREN WHILE
-##
-## Ends in an error in state: 743.
-##
-## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr eols SEMI eols for_inner_expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON ]
-##
-## The known suffix of the stack is as follows:
-## FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr eols SEMI eols for_inner_expr rparen
-##
-program: MODULE UIDENT EOL FOR LPAREN WASMI64 EOL SEMI EOL WASMI64 EOL SEMI RPAREN WHILE
-##
-## Ends in an error in state: 739.
-##
-## for_expr -> FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr eols SEMI for_inner_expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON ]
-##
-## The known suffix of the stack is as follows:
-## FOR lparen option(block_body_expr) eols SEMI eols for_inner_expr eols SEMI for_inner_expr rparen
-##
-program: MODULE UIDENT EOL FOR LPAREN WASMI64 EOL SEMI SEMI EOL RPAREN WHILE
-##
-## Ends in an error in state: 715.
-##
-## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr SEMI eols for_inner_expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON ]
-##
-## The known suffix of the stack is as follows:
-## FOR lparen option(block_body_expr) eols SEMI for_inner_expr SEMI eols for_inner_expr rparen
-##
-program: MODULE UIDENT EOL FOR LPAREN WASMI64 EOL SEMI SEMI RPAREN WHILE
-##
-## Ends in an error in state: 711.
-##
-## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr SEMI for_inner_expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON ]
-##
-## The known suffix of the stack is as follows:
-## FOR lparen option(block_body_expr) eols SEMI for_inner_expr SEMI for_inner_expr rparen
-##
-program: MODULE UIDENT EOL FOR LPAREN WASMI64 EOL SEMI WASMI64 EOL SEMI EOL RPAREN WHILE
-##
-## Ends in an error in state: 724.
-##
-## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr eols SEMI eols for_inner_expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON ]
-##
-## The known suffix of the stack is as follows:
-## FOR lparen option(block_body_expr) eols SEMI for_inner_expr eols SEMI eols for_inner_expr rparen
-##
-program: MODULE UIDENT EOL FOR LPAREN WASMI64 EOL SEMI WASMI64 EOL SEMI RPAREN WHILE
-##
-## Ends in an error in state: 720.
-##
-## for_expr -> FOR lparen option(block_body_expr) eols SEMI for_inner_expr eols SEMI for_inner_expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON ]
-##
-## The known suffix of the stack is as follows:
-## FOR lparen option(block_body_expr) eols SEMI for_inner_expr eols SEMI for_inner_expr rparen
-##
-
-Expected `{` to start a block.
 
 program: MODULE UIDENT EOL FOR LPAREN SEMI EOL SEMI EOL WASMI64 RBRACK
 ##
@@ -2825,15 +3105,6 @@ program: MODULE UIDENT EOL FUN LIDENT THICKARROW WHEN
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 27, spurious reduction of production thickarrow -> THICKARROW
-##
-program: MODULE UIDENT EOL WHILE LPAREN WASMI64 RPAREN WHILE
-##
-## Ends in an error in state: 789.
-##
-## while_expr -> WHILE lparen expr rparen . block [ THICKARROW STAR SLASH SEMI RPAREN RCARET RBRACK RBRACE PIPE LCARET INFIX_90 INFIX_80 INFIX_70 INFIX_60 INFIX_50 INFIX_40 INFIX_30 INFIX_120 INFIX_110 INFIX_100 EOL EOF ELSE DASH COMMA COLON ]
-##
-## The known suffix of the stack is as follows:
-## WHILE lparen expr rparen
 ##
 
 Expected an expression or `{` to start a block.

--- a/compiler/src/parsing/parser.mly
+++ b/compiler/src/parsing/parser.mly
@@ -532,9 +532,6 @@ braced_expr:
   | lbrace block_body rbrace { Expression.block ~loc:(to_loc $loc) ~core_loc:(to_loc $loc) $2 }
   | lbrace record_exprs rbrace { Expression.record_fields ~loc:(to_loc $loc) ~core_loc:(to_loc $loc) $2 }
 
-block:
-  | lbrace block_body rbrace { Expression.block ~loc:(to_loc $loc) ~core_loc:(to_loc $loc) $2 }
-
 arg_default:
   | EQUAL non_stmt_expr { $2 }
 
@@ -573,14 +570,14 @@ if_expr:
   | IF lparen expr rparen opt_eols expr ioption(else_expr) %prec _if { Expression.if_ ~loc:(to_loc $loc) ~core_loc:(to_loc $loc) $3 $6 $7 }
 
 while_expr:
-  | WHILE lparen expr rparen block { Expression.while_ ~loc:(to_loc $loc) ~core_loc:(to_loc $loc) $3 $5 }
+  | WHILE lparen expr rparen opt_eols expr { Expression.while_ ~loc:(to_loc $loc) ~core_loc:(to_loc $loc) $3 $6 }
 
 for_inner_expr:
   | %prec EOL { None }
   | expr { Some $1 }
 
 for_expr:
-  | FOR lparen block_body_expr? opt_eols SEMI opt_eols for_inner_expr opt_eols SEMI opt_eols for_inner_expr rparen block { Expression.for_ ~loc:(to_loc $loc) ~core_loc:(to_loc $loc) $3 $7 $11 $13 }
+  | FOR lparen block_body_expr? opt_eols SEMI opt_eols for_inner_expr opt_eols SEMI opt_eols for_inner_expr rparen opt_eols expr { Expression.for_ ~loc:(to_loc $loc) ~core_loc:(to_loc $loc) $3 $7 $11 $14 }
 
 when_guard:
   | opt_eols WHEN expr { $3 }

--- a/compiler/test/grainfmt/comments.expected.gr
+++ b/compiler/test/grainfmt/comments.expected.gr
@@ -490,6 +490,7 @@ while (true /* true */) {
 while (true /* true */) {
   void
 }
+while (true /* true */) void
 
 for (/* for */
   /* init */
@@ -531,6 +532,7 @@ for (/* for */
 for (;; /* for */ /* init */ /*cond*/ /*inc*/ /* more */ /* and more */) {
   void
 }
+for (;; /* for */ /* init */ /*cond*/ /*inc*/ /* more */ /* and more */) void
 
 match (/* match */ /*foo*/ foo /* post foo */ /* post foo 2 */) { /* mr branch */
   _ => /* void */ void, /* post void */

--- a/compiler/test/grainfmt/comments.input.gr
+++ b/compiler/test/grainfmt/comments.input.gr
@@ -406,12 +406,14 @@ while /* true */ (true) {void}
 while (/* true */ true) {void}
 while (true /* true */) {void}
 while (true) /* true */ {void}
+while (true) /* true */ void
 
 for /* for */ (/* init */ let mut i = 1; /*cond*/i < 1; /*inc*/ i += 1 /* more */ )/* and more */ {void}
 for /* for */ (/* init */ ; /*cond*/i < 1; /*inc*/ i += 1 /* more */ )/* and more */ {void}
 for /* for */ (/* init */ let mut i = 1; /*cond*/; /*inc*/ i += 1 /* more */ )/* and more */ {void}
 for /* for */ (/* init */ let mut i = 1; /*cond*/i < 1; /*inc*/  /* more */ )/* and more */ {void}
 for /* for */ (/* init */ ; /*cond*/; /*inc*/  /* more */ )/* and more */ {void}
+for /* for */ (/* init */ ; /*cond*/; /*inc*/  /* more */ )/* and more */ void
 
 match /* match */ (/*foo*/ foo /* post foo */) /* post foo 2 */ {/* mr branch */_=> /* void */void/* post void */}
 

--- a/compiler/test/grainfmt/for_loops.expected.gr
+++ b/compiler/test/grainfmt/for_loops.expected.gr
@@ -16,3 +16,5 @@ for (
   let strLength = 0
   print("Loop")
 }
+
+for (let mut i = 0; i < size; i += 1) print("Loop")

--- a/compiler/test/grainfmt/for_loops.input.gr
+++ b/compiler/test/grainfmt/for_loops.input.gr
@@ -12,3 +12,6 @@ let verylongvariablenameforcingalinebreakhereplease = 2
     let  strLength = 0
     print("Loop")
   }
+
+for (let mut i = 0; i < size; i += 1)
+  print("Loop")

--- a/compiler/test/grainfmt/while_loops.expected.gr
+++ b/compiler/test/grainfmt/while_loops.expected.gr
@@ -6,3 +6,5 @@ let size = 10
 while (i < size) {
   i += 1
 }
+
+while (i < size) i += 1

--- a/compiler/test/grainfmt/while_loops.input.gr
+++ b/compiler/test/grainfmt/while_loops.input.gr
@@ -6,3 +6,6 @@ module WhileLoops
   while (i < size) {
     i = i + 1
   }
+
+while (i < size)
+  i = i + 1


### PR DESCRIPTION
Allows `for` and `while` loops to be used without block bodies
```grain
for (let mut i = 0; i < 5; i += 1)
  print("Hello")
```