### PR TITLE
fix(compiler): Allow proper disambiguation of enum variants

### DIFF
--- a/compiler/src/typed/typepat.re
+++ b/compiler/src/typed/typepat.re
@@ -819,10 +819,12 @@ and type_pat_aux =
         ([{ppat_desc: desc, ppat_loc: loc}], true);
       };
     let opath =
-      /*try
-          let (p0, p, _) = extract_concrete_variant !env expected_ty in
-            Some (p0, p, true)
-        with Not_found ->*/ None;
+      try({
+        let (p0, p, _) = extract_concrete_variant(env^, expected_ty);
+        Some((p0, p, true));
+      }) {
+      | Not_found => None
+      };
 
     let candidates =
       switch (lid.txt, constrs) {

--- a/compiler/test/suites/types.re
+++ b/compiler/test/suites/types.re
@@ -200,6 +200,26 @@ describe("aliased types", ({test, testSkip}) => {
     "expression was expected of type Aliases.Foo = Number",
   );
   assertRun(
+    "disambiguation_enum_1",
+    {|
+      enum A { V }
+      enum B { V }
+      let f = x => match (x) { V: A => print(true) }
+      f(V)
+    |},
+    "true\n",
+  );
+  assertRun(
+    "disambiguation_record_1",
+    {|
+      record A { v: Number }
+      record B { v: Number }
+      let f = x => match (x) { { v }: A => print(v) }
+      f({v: 5})
+    |},
+    "5\n",
+  );
+  assertRun(
     "regression_annotated_type_func_1",
     {|
       abstract type AddPrinter = (Number, Number) => Void


### PR DESCRIPTION
When multiple variants with the same name are in scope and one is used in a pattern match, the compiler would warn that the user should disambiguate, but when doing so for variants you'd get a type error. This resolves that issue.