### PR TITLE
chore(ci): Conditionally commit regenerated documentation

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -44,5 +44,5 @@ jobs:
         run: |
           ./grain doc stdlib -o stdlib --current-version=$(./grain -v)
           git add stdlib
-          git commit -m 'chore(stdlib): Regenerate markdown documentation'
+          git diff --staged --quiet || git commit -m 'chore(stdlib): Regenerate markdown documentation'
           git push


### PR DESCRIPTION
Docgen is failing because it's trying to commit no changes (because we did a release and all the changes got merged!). This only does the commit if there are changes.