### PR TITLE
chore(stdlib): Make `Array.contains` use recursion

### DIFF
--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -659,6 +659,16 @@ provide let fromList = list => {
   init(listLength(list, 0), next)
 }
 
+let rec containsHelp = (search, i, len, array) => {
+  if (array[i] == search) {
+    true
+  } else if (i == len) {
+    false
+  } else {
+    containsHelp(search, i + 1, len, array)
+  }
+}
+
 /**
  * Checks if the value is an element of the input array.
  * Uses the generic `==` structural equality operator.
@@ -672,14 +682,8 @@ provide let fromList = list => {
  *
  * @since v0.2.0
  */
-provide let contains = (search, array) => {
-  // TODO(#189): This should be rewritten to use recursion and pattern matching
-  let len = length(array)
-  for (let mut i = 0; i < len; i += 1) {
-    if (array[i] == search) return true
-  }
-  return false
-}
+provide let contains = (search, array) =>
+  containsHelp(search, 0, length(array) - 1, array)
 
 /**
  * Finds the first element in an array that satisfies the given condition.


### PR DESCRIPTION
This rewrites `Array.contains` to use a recursive approach, I know the original idea was to use pattern matching similar to how it is done in the `list` library. but if we want a recursive approach this one would work well.


Some Notes:
* If we decide to merge this pr it would probably make sense to perform similar changes to `findIndex` and other iterative functions.
* Thinking about this from a performance standpoint, I don't know if the recursive approach is better here
* If we don't decide to merge this pr, I think we should close #189 as any indirection layer on pattern matching would likely be slower than the initial iterative approach or this split recursive approach.


Closes: #189 