### PR TITLE
feat(grainfmt): Support converting `binops` to `infix` on array assignments

### DIFF
--- a/compiler/src/formatting/fmt.re
+++ b/compiler/src/formatting/fmt.re
@@ -1999,6 +1999,58 @@ let print_expression = (fmt, ~infix_wrap=d => group(indent(d)), expr) => {
            )
            ++ break,
          )
+    | PExpArraySet(
+        {pexp_desc: PExpId({txt: IdentName({txt: name})})} as arr,
+        {
+          pexp_desc:
+            PExpConstant(PConstNumber(PConstNumberInt({txt: elem_val}))) |
+            PExpId({txt: IdentName({txt: elem_val})}),
+        } as elem,
+        {
+          pexp_desc:
+            PExpApp(
+              _,
+              [
+                {
+                  paa_expr: {
+                    pexp_desc:
+                      PExpArrayGet(
+                        {
+                          pexp_desc:
+                            PExpId({txt: IdentName({txt: new_name})}),
+                        },
+                        {
+                          pexp_desc:
+                            PExpConstant(
+                              PConstNumber(
+                                PConstNumberInt({txt: new_elem_val}),
+                              ),
+                            ) |
+                            PExpId({txt: IdentName({txt: new_elem_val})}),
+                        },
+                      ),
+                  },
+                },
+                _,
+              ],
+            ),
+        } as new_value,
+      )
+        when name == new_name && elem_val == new_elem_val =>
+      fmt.print_grouped_access_expression(fmt, arr)
+      ++ fmt.print_comment_range(fmt, arr.pexp_loc, elem.pexp_loc)
+      ++ list_brackets(
+           indent(
+             break ++ fmt.print_expression(fmt, ~infix_wrap=Fun.id, elem),
+           )
+           ++ break,
+         )
+      ++ fmt.print_assignment(
+           fmt,
+           ~collapsible=true,
+           ~lhs_loc=elem.pexp_loc,
+           new_value,
+         )
     | PExpArraySet(arr, elem, new_value) =>
       fmt.print_grouped_access_expression(fmt, arr)
       ++ fmt.print_comment_range(fmt, arr.pexp_loc, elem.pexp_loc)

--- a/compiler/test/grainfmt/arrays.expected.gr
+++ b/compiler/test/grainfmt/arrays.expected.gr
@@ -41,3 +41,22 @@ let addRepeatedGroup = (groupN, state, pos, n, backAmt, callback) => {
 
 provide let getBefore = (array, index) =>
   if (array == [>]) "nope" else array[index - 1]
+
+let arr1 = [> 1, 2, 3]
+let arr2 = [> 4, 5, 6]
+let i = 0
+let n = 0
+
+arr1[0] += 1
+arr1[0] += arr1[0]
+arr1[0] -= 1
+arr1[0] *= 2
+arr1[i] += 1
+arr1[n] += 1
+
+arr1[0] = arr2[0] + 2
+arr2[0] = arr1[0] + 2
+arr2[0] = arr1[1] + 2
+arr2[1] = arr1[0] + 2
+arr1[n] = arr1[t] + 1
+arr1[t] = arr1[n] + 1

--- a/compiler/test/grainfmt/arrays.input.gr
+++ b/compiler/test/grainfmt/arrays.input.gr
@@ -41,3 +41,22 @@ let addRepeatedGroup = (groupN, state, pos, n, backAmt, callback) => {
 }
 
 provide let getBefore = (array, index) => if (array == [>]) "nope" else array[index - 1]
+
+let arr1 = [> 1, 2, 3]
+let arr2 = [> 4, 5, 6]
+let i = 0
+let n = 0
+
+arr1[0] = arr1[0] + 1
+arr1[0] = arr1[0] + arr1[0]
+arr1[0] = arr1[0] - 1
+arr1[0] = arr1[0] * 2
+arr1[i] = arr1[i] + 1
+arr1[n] = arr1[n] + 1
+
+arr1[0] = arr2[0] + 2
+arr2[0] = arr1[0] + 2
+arr2[0] = arr1[1] + 2
+arr2[1] = arr1[0] + 2
+arr1[n] = arr1[t] + 1
+arr1[t] = arr1[n] + 1


### PR DESCRIPTION
This pr makes the formatter convert `arr[0] = arr[0] + 1` to `arr[0] += 1` as is done with normal and record assignments.

This supports `constants` for the elem index and `idents` I didn't add support for `arr[test.index] = arr[test.index] + 1` as from my understanding that would be rather complex, I can try and add support if we feel its neccessairy though.

I hope I got the formatting functions correct and handled comments correctly I used the `RecordSet` as my template when building this.



closes: #1988 