### PR TITLE
feat(compiler): Add warning for non-integer array indices

### DIFF
--- a/compiler/src/utils/warnings.re
+++ b/compiler/src/utils/warnings.re
@@ -173,7 +173,7 @@ let message =
     ++ typ
     ++ " from the `runtime/debugPrint` module instead."
   | ArrayIndexNonInteger(idx) =>
-    "Array index must be an integer, but found `" ++ idx ++ "`.";
+    "Array index should be an integer, but found `" ++ idx ++ "`.";
 
 let sub_locs =
   fun

--- a/compiler/src/utils/warnings.re
+++ b/compiler/src/utils/warnings.re
@@ -41,9 +41,10 @@ type t =
   | FromNumberLiteral(number_type, string, string)
   | UselessRecordSpread
   | PrintUnsafe(string)
-  | ToStringUnsafe(string);
+  | ToStringUnsafe(string)
+  | ArrayIndexNonInteger(string);
 
-let last_warning_number = 21;
+let last_warning_number = 22;
 
 let number =
   fun
@@ -67,7 +68,8 @@ let number =
   | FromNumberLiteral(_, _, _) => 18
   | UselessRecordSpread => 19
   | PrintUnsafe(_) => 20
-  | ToStringUnsafe(_) => last_warning_number;
+  | ToStringUnsafe(_) => 21
+  | ArrayIndexNonInteger(_) => last_warning_number;
 
 let message =
   fun
@@ -169,7 +171,9 @@ let message =
   | ToStringUnsafe(typ) =>
     "it looks like you are using `toString` on an unsafe Wasm value here.\nThis is generally unsafe and will cause errors. Use `DebugPrint.toString`"
     ++ typ
-    ++ " from the `runtime/debugPrint` module instead.";
+    ++ " from the `runtime/debugPrint` module instead."
+  | ArrayIndexNonInteger(idx) =>
+    "Array index must be an integer, but found `" ++ idx ++ "`.";
 
 let sub_locs =
   fun
@@ -216,6 +220,7 @@ let defaults = [
   UselessRecordSpread,
   PrintUnsafe(""),
   ToStringUnsafe(""),
+  ArrayIndexNonInteger(""),
 ];
 
 let _ = List.iter(x => current^.active[number(x)] = true, defaults);

--- a/compiler/src/utils/warnings.rei
+++ b/compiler/src/utils/warnings.rei
@@ -55,7 +55,8 @@ type t =
   | FromNumberLiteral(number_type, string, string)
   | UselessRecordSpread
   | PrintUnsafe(string)
-  | ToStringUnsafe(string);
+  | ToStringUnsafe(string)
+  | ArrayIndexNonInteger(string);
 
 let is_active: t => bool;
 let is_error: t => bool;

--- a/compiler/test/suites/arrays.re
+++ b/compiler/test/suites/arrays.re
@@ -2,6 +2,10 @@ open Grain_tests.TestFramework;
 open Grain_tests.Runner;
 open Grain_tests.Test_utils;
 open Grain_parsing.Location;
+open Grain_utils;
+
+let {describe} =
+  describeConfig |> withCustomMatchers(customMatchers) |> build;
 
 describe("arrays", ({test, testSkip}) => {
   let test_or_skip =
@@ -12,6 +16,7 @@ describe("arrays", ({test, testSkip}) => {
   let assertRun = makeRunner(test_or_skip);
   let assertRunError = makeErrorRunner(test_or_skip);
   let assertParse = makeParseRunner(test);
+  let assertWarning = makeWarningRunner(test);
 
   assertRun("array1", "print([> 1, 2, 3])", "[> 1, 2, 3]\n");
   assertRun("array2", "print([>])", "[> ]\n");
@@ -114,35 +119,35 @@ describe("arrays", ({test, testSkip}) => {
     "has type Void but",
   );
   // Ahead of time, float index detection
-  assertCompileError(
+  assertWarning(
     "array_float_get_index0",
     "let x = [> 1, 2, 3]; x[1.5]",
-    "Error: Array index must be an integer, but found `1.5`.",
+    Warnings.ArrayIndexNonInteger("1.5"),
   );
-  assertCompileError(
+  assertWarning(
     "array_float_get_index1",
     "let x = [> 1, 2, 3]; x[1.0]",
-    "Error: Array index must be an integer, but found `1.0`.",
+    Warnings.ArrayIndexNonInteger("1.0"),
   );
-  assertCompileError(
+  assertWarning(
     "array_float_get_index2",
     "let x = [> 1, 2, 3]; x[1/3]",
-    "Error: Array index must be an integer, but found `1/3`.",
+    Warnings.ArrayIndexNonInteger("1/3"),
   );
-  assertCompileError(
+  assertWarning(
     "array_float_set_index0",
     "let x = [> 1, 2, 3]; x[1.5] = 1",
-    "Error: Array index must be an integer, but found `1.5`.",
+    Warnings.ArrayIndexNonInteger("1.5"),
   );
-  assertCompileError(
+  assertWarning(
     "array_float_set_index1",
     "let x = [> 1, 2, 3]; x[1.0] = 1",
-    "Error: Array index must be an integer, but found `1.0`.",
+    Warnings.ArrayIndexNonInteger("1.0"),
   );
-  assertCompileError(
+  assertWarning(
     "array_float_set_index2",
     "let x = [> 1, 2, 3]; x[1/3] = 1",
-    "Error: Array index must be an integer, but found `1/3`.",
+    Warnings.ArrayIndexNonInteger("1/3"),
   );
   // trailing commas
   assertSnapshot("array1_trailing", "[> 1, 2, 3,]");

--- a/compiler/test/suites/arrays.re
+++ b/compiler/test/suites/arrays.re
@@ -45,12 +45,12 @@ describe("arrays", ({test, testSkip}) => {
   );
   assertRunError(
     "array_access_err5",
-    "let x = [> 1, 2, 3]; x[1.5]",
+    "let x = [> 1, 2, 3]; let i = 1.5; x[i]",
     "Index not an integer",
   );
   assertRunError(
     "array_access_err6",
-    "let x = [> 1, 2, 3]; x[1/3]",
+    "let x = [> 1, 2, 3]; let i = 1/3; x[i]",
     "Index not an integer",
   );
   assertRunError(
@@ -90,12 +90,12 @@ describe("arrays", ({test, testSkip}) => {
   );
   assertRunError(
     "array_set_err3",
-    "let x = [> 1, 2, 3]; x[1.5] = 4",
+    "let x = [> 1, 2, 3]; let i = 1.5; x[i] = 4",
     "Index not an integer",
   );
   assertRunError(
     "array_set_err4",
-    "let x = [> 1, 2, 3]; x[1/3] = 4",
+    "let x = [> 1, 2, 3]; let i = 1/3; x[i] = 4",
     "Index not an integer",
   );
   assertRunError(
@@ -112,6 +112,37 @@ describe("arrays", ({test, testSkip}) => {
     "array_type2",
     "let x = [> true, false, false]; (x[1] = true) + 3",
     "has type Void but",
+  );
+  // Ahead of time, float index detection
+  assertCompileError(
+    "array_float_get_index0",
+    "let x = [> 1, 2, 3]; x[1.5]",
+    "Error: Array index must be an integer, but found `1.5`.",
+  );
+  assertCompileError(
+    "array_float_get_index1",
+    "let x = [> 1, 2, 3]; x[1.0]",
+    "Error: Array index must be an integer, but found `1.0`.",
+  );
+  assertCompileError(
+    "array_float_get_index2",
+    "let x = [> 1, 2, 3]; x[1/3]",
+    "Error: Array index must be an integer, but found `1/3`.",
+  );
+  assertCompileError(
+    "array_float_set_index0",
+    "let x = [> 1, 2, 3]; x[1.5] = 1",
+    "Error: Array index must be an integer, but found `1.5`.",
+  );
+  assertCompileError(
+    "array_float_set_index1",
+    "let x = [> 1, 2, 3]; x[1.0] = 1",
+    "Error: Array index must be an integer, but found `1.0`.",
+  );
+  assertCompileError(
+    "array_float_set_index2",
+    "let x = [> 1, 2, 3]; x[1/3] = 1",
+    "Error: Array index must be an integer, but found `1/3`.",
   );
   // trailing commas
   assertSnapshot("array1_trailing", "[> 1, 2, 3,]");


### PR DESCRIPTION
This pr adds a basic warning for `arr[1.5]` and `arr[1.5] = 1` along with `rational` use cases. The purpose of this is to better catch instances where a user is indexing with floats ahead of time and prevent more runtime bugs. You can still achieve the runtime `Index not an integer` error by doing something like `let i = 1.5; arr[i]` though. The biggest place thing this helps to prevent is `arr[1.0]` where a user might assume we cast that to an `int like` number.