### PR TITLE
feat(compiler): Improve warning when omitting fields in record pattern

### DIFF
--- a/compiler/src/utils/warnings.re
+++ b/compiler/src/utils/warnings.re
@@ -126,7 +126,9 @@ let message =
       msg,
     )
   | NonClosedRecordPattern(s) =>
-    "the following fields are missing from the record pattern: " ++ s
+    "the following fields are missing from the record pattern: "
+    ++ s
+    ++ ", if this is intentional you can use `, _` to ignore them."
   | FuncWasmUnsafe(func, f, m) =>
     "it looks like you are using "
     ++ func

--- a/compiler/src/utils/warnings.re
+++ b/compiler/src/utils/warnings.re
@@ -128,7 +128,7 @@ let message =
   | NonClosedRecordPattern(s) =>
     "the following fields are missing from the record pattern: "
     ++ s
-    ++ ", if this is intentional you can use `, _` to ignore them."
+    ++ "\nUse `_` to ignore unused fields."
   | FuncWasmUnsafe(func, f, m) =>
     "it looks like you are using "
     ++ func

--- a/compiler/test/suites/records.re
+++ b/compiler/test/suites/records.re
@@ -255,7 +255,7 @@ describe("records", ({test, testSkip}) => {
       (x: B) => x.field
     |},
   );
-  // well_formdness field omission warning
+  // well_formedness field omission warning
   assertWarning(
     "record_field_omit_1",
     "record Rec {foo: Number, bar: Number}; let a = {foo: 1, bar: 2}; match (a) { { foo } => void, _ => void }",

--- a/compiler/test/suites/records.re
+++ b/compiler/test/suites/records.re
@@ -230,7 +230,6 @@ describe("records", ({test, testSkip}) => {
     "record Rec {foo: Number, bar: Number}; let a = {foo: 1, bar: 2}; let b = {...a, foo: 2, bar: 3}",
     Warnings.UselessRecordSpread,
   );
-
   assertWarning(
     "disambiguation_1",
     {|
@@ -255,5 +254,16 @@ describe("records", ({test, testSkip}) => {
       record B { field: Number }
       (x: B) => x.field
     |},
+  );
+  // well_formdness field omission warning
+  assertWarning(
+    "record_field_omit_1",
+    "record Rec {foo: Number, bar: Number}; let a = {foo: 1, bar: 2}; match (a) { { foo } => void, _ => void }",
+    Warnings.NonClosedRecordPattern("bar"),
+  );
+  assertWarning(
+    "record_field_omit_2",
+    "record Rec {foo: Number, bar: Number, bar2: Number}; let a = {foo: 1, bar: 2, bar2: 3}; match (a) { { foo } => void, _ => void }",
+    Warnings.NonClosedRecordPattern("bar, bar2"),
   );
 });


### PR DESCRIPTION
When you omit record fields in a record pattern we currently just tell you, that you need them. The warning has been improved to let you know that if you meant to omit the fields you can use `, _` syntax, This helps the compiler better document and inform users about our language features.