### PR TITLE
fix(grainfmt): Fix formatting of `default` argument types

### DIFF
--- a/compiler/src/formatting/fmt.re
+++ b/compiler/src/formatting/fmt.re
@@ -2538,9 +2538,20 @@ let print_parsed_type_argument = (fmt, arg) => {
   (
     switch (arg.ptyp_arg_label) {
     | Unlabeled => empty
-    | Labeled({txt: label, loc: label_loc})
-    | Default({txt: label, loc: label_loc}) =>
+    | Labeled({txt: label, loc: label_loc}) =>
       string(label)
+      ++ string(":")
+      ++ fmt.print_comment_range(
+           fmt,
+           ~none=space,
+           ~lead=space,
+           ~trail=space,
+           label_loc,
+           arg.ptyp_arg_type.ptyp_loc,
+         )
+    | Default({txt: label, loc: label_loc}) =>
+      string("?")
+      ++ string(label)
       ++ string(":")
       ++ fmt.print_comment_range(
            fmt,

--- a/compiler/test/grainfmt/function_params.expected.gr
+++ b/compiler/test/grainfmt/function_params.expected.gr
@@ -39,3 +39,5 @@ let stringTailMatcher = (toMatch, len) =>
   }
 
 let f: Number => (Number, Number) => Number = a => (b, c) => a + b + c
+
+let namedArg: (?suffix: String) => String = (suffix="") => suffix

--- a/compiler/test/grainfmt/function_params.input.gr
+++ b/compiler/test/grainfmt/function_params.input.gr
@@ -34,3 +34,5 @@ let stringTailMatcher =  (toMatch, len) =>
   }
 
 let f: Number -> (Number, Number) -> Number = a => (b, c) => a + b + c
+
+let namedArg: (?suffix: String) => String = (suffix="") => suffix


### PR DESCRIPTION
I noticed that the formatter was formatting `(?suffix: String) => void` into `(suffix: String) => void` this pr fix's this and adds a regression test.