### PR TITLE
feat(compiler): Enable debug info in binary output

### DIFF
--- a/compiler/src/codegen/emitmod.re
+++ b/compiler/src/codegen/emitmod.re
@@ -20,6 +20,10 @@ let emit_module = ({asm, signature}, outfile) => {
     output_string(oc, asm_string);
     close_out(oc);
   };
+  switch (Config.profile^) {
+  | Some(Release) => Binaryen.Settings.set_debug_info(false)
+  | _ => Binaryen.Settings.set_debug_info(true)
+  };
   let source_map_name =
     if (Config.source_map^) {
       Some(Filepath.String.basename(outfile) ++ ".map");


### PR DESCRIPTION
This helps address the issue raised in #2082.

Non-release builds of Grain will now include debug information which can at least provide the names of functions in stack traces. For example, with the program
```
module Playground

from "string" include String

String.charAt(7, "foo")
```

You get the following stack trace from the CLI:
```
Failure: Invalid offset: 7
RuntimeError: unreachable
    at panic_1163.linked.653 (wasm://wasm/00114abe:wasm-function[122]:0x2897)
    at throw_4472.linked.17966 (wasm://wasm/00114abe:wasm-function[558]:0x2e2c0)
    at fail_4474.linked.17967 (wasm://wasm/00114abe:wasm-function[559]:0x2e31b)
    at charAtHelp_1518.linked.18542 (wasm://wasm/00114abe:wasm-function[605]:0x3095d)
    at charAt_1532.linked.18544 (wasm://wasm/00114abe:wasm-function[607]:0x30cb2)
    at _start.linked.23251 (wasm://wasm/00114abe:wasm-function[646]:0x3ac60)
    at WASI.start (node:wasi:136:7)
    at run (/Users/oscar/Development/grain/cli/bin/grainrun.js:72:10)
```

This is the stack trace in wasmtime:
```
Failure: Invalid offset: 7Error: failed to run main module `test.gr.wasm`

Caused by:
    0: failed to invoke command default
    1: error while executing at wasm backtrace:
           0: 0x2897 - <unknown>!panic_1163.linked.653
           1: 0x2e2c0 - <unknown>!throw_4472.linked.17966
           2: 0x2e31b - <unknown>!fail_4474.linked.17967
           3: 0x3095d - <unknown>!charAtHelp_1518.linked.18542
           4: 0x30cb2 - <unknown>!charAt_1532.linked.18544
           5: 0x3ac60 - <unknown>!_start.linked.23251
    2: wasm trap: wasm `unreachable` instruction executed
```

Compared to execution without debug info:
```
Failure: Invalid offset: 7
RuntimeError: unreachable
    at wasm://wasm/000ebc02:wasm-function[122]:0x2897
    at wasm://wasm/000ebc02:wasm-function[558]:0x2e2c0
    at wasm://wasm/000ebc02:wasm-function[559]:0x2e31b
    at wasm://wasm/000ebc02:wasm-function[605]:0x3095d
    at wasm://wasm/000ebc02:wasm-function[607]:0x30cb2
    at wasm://wasm/000ebc02:wasm-function[646]:0x3ac60
    at WASI.start (node:wasi:136:7)
    at run (/Users/oscar/Development/grain/cli/bin/grainrun.js:72:10)
```

Closes #1812 