### PR TITLE
chore(stdlib): Update license year

### DIFF
--- a/stdlib/LICENSE
+++ b/stdlib/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-2023 Oscar Spencer <oscar@grain-lang.org> and Philip Blair <philip@grain-lang.org>
+Copyright (c) 2017-2024 Oscar Spencer <oscar@grain-lang.org> and Philip Blair <philip@grain-lang.org>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
I noticed we forgot to update the `stdlib` license year to 2024.