### PR TITLE
fix(compiler): Stabilize CRC checks

### DIFF
--- a/compiler/grainc/grainc.re
+++ b/compiler/grainc/grainc.re
@@ -36,9 +36,6 @@ let compile_file = (name, outfile_arg) => {
         ~default=Compile.default_output_filename(name),
         outfile_arg,
       );
-    if (Grain_utils.Config.debug^) {
-      Compile.save_mashed(name, Compile.default_mashtree_filename(outfile));
-    };
     let hook =
       if (Grain_utils.Config.statically_link^) {
         Compile.stop_after_assembled;

--- a/compiler/src/compile.rei
+++ b/compiler/src/compile.rei
@@ -41,8 +41,6 @@ exception InlineFlagsError(Location.t, error);
 
 let default_output_filename: string => string;
 
-let default_mashtree_filename: string => string;
-
 let stop_after_parse: compilation_state => compilation_action;
 
 let stop_after_well_formed: compilation_state => compilation_action;
@@ -85,5 +83,3 @@ let compile_file:
     string
   ) =>
   compilation_state;
-
-let save_mashed: (string, string) => unit;

--- a/compiler/src/typed/cmi_format.rei
+++ b/compiler/src/typed/cmi_format.rei
@@ -28,7 +28,8 @@ type cmi_type_metadata = {
 type cmi_infos = {
   cmi_name: string,
   cmi_sign: list(Types.signature_item),
-  cmi_crcs: list((string, option(Digest.t))),
+  cmi_crcs: list((string, Digest.t)),
+  cmi_crc: Digest.t,
   cmi_flags: list(pers_flags),
   cmi_type_metadata,
   cmi_config_sum: string,
@@ -36,15 +37,7 @@ type cmi_infos = {
 
 let config_sum: unit => string;
 
-let build_full_cmi:
-  (
-    ~name: string,
-    ~sign: list(Types.signature_item),
-    ~crcs: list((string, option(Digest.t))),
-    ~flags: list(pers_flags),
-    ~type_metadata: cmi_type_metadata
-  ) =>
-  cmi_infos;
+let build_crc: (~name: string, Types.signature) => Digest.t;
 
 /* write the magic + the cmi information */
 let serialize_cmi: cmi_infos => bytes;
@@ -54,8 +47,6 @@ let input_cmi: in_channel => cmi_infos;
 
 /* read a cmi from a filename, checking the magic */
 let read_cmi: string => cmi_infos;
-
-let cmi_to_crc: cmi_infos => Digest.t;
 
 /* Error report */
 

--- a/compiler/src/typed/env.rei
+++ b/compiler/src/typed/env.rei
@@ -175,9 +175,6 @@ let use_full_signature: (Path.t, t) => t;
 
 let use_full_signature_of_initially_included_module: (Path.t, t) => t;
 
-/* Read, save a signature to/from a file */
-
-let read_signature: string => signature;
 /* Arguments: module name, file name. Results: signature. */
 let build_signature:
   (
@@ -195,7 +192,7 @@ let build_signature_with_imports:
     signature,
     string,
     string,
-    list((string, option(Digest.t))),
+    list((string, Digest.t)),
     Cmi_format.cmi_type_metadata
   ) =>
   Cmi_format.cmi_infos;
@@ -208,7 +205,7 @@ let crc_of_unit: string => Digest.t;
 
 /* Return the set of compilation units imported, with their CRC */
 
-let imports: unit => list((string, option(Digest.t)));
+let imports: unit => list((string, Digest.t));
 
 /* [is_imported_opaque md] returns true if [md] is an opaque imported module  */
 let is_imported_opaque: string => bool;

--- a/compiler/src/typed/module_resolution.rei
+++ b/compiler/src/typed/module_resolution.rei
@@ -1,3 +1,5 @@
+let get_output_name: string => string;
+
 let locate_module_file:
   (~loc: Grain_parsing.Location.t, ~disable_relpath: bool=?, string) => string;
 

--- a/compiler/src/typed/subst.rei
+++ b/compiler/src/typed/subst.rei
@@ -41,8 +41,11 @@ let add_type_function:
 let add_module: (Ident.t, Path.t, t) => t;
 let add_module_path: (Path.t, Path.t, t) => t;
 let add_modtype: (Ident.t, module_type, t) => t;
-let for_saving: t => t;
-let reset_for_saving: unit => unit;
+/* Configuration for saving to a CMI */
+let for_cmi: t => t;
+/* Like for_cmi, but suitable for reproducible CRCs */
+let for_crc: t => t;
+let with_reset_state: (unit => 'a) => 'a;
 
 let module_path: (t, Path.t) => Path.t;
 let type_path: (t, Path.t) => Path.t;

--- a/compiler/src/typed/typecore.re
+++ b/compiler/src/typed/typecore.re
@@ -2381,9 +2381,9 @@ and type_cases =
     };
   let ty_arg_check =
     if (do_init) {
-      /* Hack: use for_saving to copy variables too */
+      /* Hack: use for_cmi to copy variables too */
       Subst.type_expr(
-        Subst.for_saving(Subst.identity),
+        Subst.for_cmi(Subst.identity),
         ty_arg,
       );
     } else {

--- a/compiler/test/__snapshots__/arrays.0f9e7d37.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.0f9e7d37.0.snapshot
@@ -246,5 +246,5 @@ arrays › array_access
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/arrays.1deb7b51.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.1deb7b51.0.snapshot
@@ -261,5 +261,5 @@ arrays › array_access5
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/arrays.24453e6e.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.24453e6e.0.snapshot
@@ -61,5 +61,5 @@ arrays › array1_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/arrays.28fcc534.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.28fcc534.0.snapshot
@@ -246,5 +246,5 @@ arrays › array_access4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/arrays.4c8c9f91.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.4c8c9f91.0.snapshot
@@ -246,5 +246,5 @@ arrays › array_access2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/arrays.6eac4e1f.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.6eac4e1f.0.snapshot
@@ -246,5 +246,5 @@ arrays › array_access3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/arrays.74d79181.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.74d79181.0.snapshot
@@ -246,5 +246,5 @@ arrays › array_access5
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/arrays.9e17b4d1.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.9e17b4d1.0.snapshot
@@ -61,5 +61,5 @@ arrays › array3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/arrays.b85cb7fc.0.snapshot
+++ b/compiler/test/__snapshots__/arrays.b85cb7fc.0.snapshot
@@ -61,5 +61,5 @@ arrays › array1_trailing_space
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.00bcbc39.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.00bcbc39.0.snapshot
@@ -81,5 +81,5 @@ basic functionality › assignment1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.00cfdb2e.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.00cfdb2e.0.snapshot
@@ -31,5 +31,5 @@ basic functionality › binop2.4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.03de4778.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.03de4778.0.snapshot
@@ -31,5 +31,5 @@ basic functionality › neg
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.040643b3.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.040643b3.0.snapshot
@@ -63,5 +63,5 @@ basic functionality › comp5
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.06bd2a80.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.06bd2a80.0.snapshot
@@ -60,5 +60,5 @@ basic functionality › assignment1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.0996c5f7.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0996c5f7.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › modulo4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.0a230f18.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0a230f18.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › land4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.0a2e4afa.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0a2e4afa.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › lxor1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.0c0b170b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0c0b170b.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › lor1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.0c400bde.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0c400bde.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › modulo6
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.0e812a39.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0e812a39.0.snapshot
@@ -61,5 +61,5 @@ basic functionality › precedence1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.0f79ce35.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.0f79ce35.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › comp16
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.10dda088.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.10dda088.0.snapshot
@@ -63,5 +63,5 @@ basic functionality › comp3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.122e74b0.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.122e74b0.0.snapshot
@@ -108,5 +108,5 @@ basic functionality › print_line_ending1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.125626a9.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.125626a9.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › orshadow
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.13335202.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.13335202.0.snapshot
@@ -61,5 +61,5 @@ basic functionality › precedence2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.1ad0f349.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1ad0f349.0.snapshot
@@ -61,5 +61,5 @@ basic functionality › precedence3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.1ae16d82.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1ae16d82.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › binop4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.1b68c8db.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1b68c8db.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › lsl1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.1bf5759c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1bf5759c.0.snapshot
@@ -68,5 +68,5 @@ basic functionality › unsafe_wasm_globals
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 464
+ ;; custom section \"cmi\", size 509
 )

--- a/compiler/test/__snapshots__/basic_functionality.1d2ec323.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1d2ec323.0.snapshot
@@ -256,5 +256,5 @@ basic functionality › comp22
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.1e4b1f39.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1e4b1f39.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › land1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.1f787365.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.1f787365.0.snapshot
@@ -84,5 +84,5 @@ basic functionality › orshort2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.20f7581b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.20f7581b.0.snapshot
@@ -31,5 +31,5 @@ basic functionality › simple_min
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.240ef39e.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.240ef39e.0.snapshot
@@ -63,5 +63,5 @@ basic functionality › comp4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.2756b429.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.2756b429.0.snapshot
@@ -31,5 +31,5 @@ basic functionality › forty
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.27a7e2f7.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.27a7e2f7.0.snapshot
@@ -61,5 +61,5 @@ basic functionality › bigint_start_pos
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.28405f1f.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.28405f1f.0.snapshot
@@ -61,5 +61,5 @@ basic functionality › precedence4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.28bf4c9e.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.28bf4c9e.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › binop2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.2bcc447b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.2bcc447b.0.snapshot
@@ -182,5 +182,5 @@ basic functionality › assert2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.2cb30a54.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.2cb30a54.0.snapshot
@@ -61,5 +61,5 @@ basic functionality › bigint_start_neg
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.2d7e34cf.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.2d7e34cf.0.snapshot
@@ -31,5 +31,5 @@ basic functionality › and2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.2f2f8795.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.2f2f8795.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › lsl2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.2f53324c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.2f53324c.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › comp17
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.2f65c8cf.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.2f65c8cf.0.snapshot
@@ -31,5 +31,5 @@ basic functionality › fals
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.304ca65f.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.304ca65f.0.snapshot
@@ -31,5 +31,5 @@ basic functionality › oct_neg
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.31e0d562.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.31e0d562.0.snapshot
@@ -53,5 +53,5 @@ basic functionality › infinity
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.32a8c452.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.32a8c452.0.snapshot
@@ -98,5 +98,5 @@ basic functionality › complex2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.34dcfbdd.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.34dcfbdd.0.snapshot
@@ -53,5 +53,5 @@ basic functionality › int64_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.3c2ba165.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.3c2ba165.0.snapshot
@@ -288,5 +288,5 @@ basic functionality › comp20
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.3e5f990b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.3e5f990b.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › lor3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.3edefd23.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.3edefd23.0.snapshot
@@ -42,5 +42,5 @@ basic functionality › decr_3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.3ffd0bf3.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.3ffd0bf3.0.snapshot
@@ -31,5 +31,5 @@ basic functionality › orshort1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.427c6671.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.427c6671.0.snapshot
@@ -49,5 +49,5 @@ basic functionality › uint64_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.448497ab.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.448497ab.0.snapshot
@@ -31,5 +31,5 @@ basic functionality › binop5
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.46348f36.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.46348f36.0.snapshot
@@ -72,5 +72,5 @@ basic functionality › precedence5
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.48db380c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.48db380c.0.snapshot
@@ -31,5 +31,5 @@ basic functionality › if4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.4d1501b9.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.4d1501b9.0.snapshot
@@ -53,5 +53,5 @@ basic functionality › nan
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.4d6f9417.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.4d6f9417.0.snapshot
@@ -31,5 +31,5 @@ basic functionality › not1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.4f5bd247.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.4f5bd247.0.snapshot
@@ -53,5 +53,5 @@ basic functionality › heap_number_i64_wrapper
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.52ca8e0e.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.52ca8e0e.0.snapshot
@@ -257,5 +257,5 @@ basic functionality › func_shadow
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 329
+ ;; custom section \"cmi\", size 374
 )

--- a/compiler/test/__snapshots__/basic_functionality.565dbeda.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.565dbeda.0.snapshot
@@ -31,5 +31,5 @@ basic functionality › hex_neg
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.5705b20c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.5705b20c.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › modulo5
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.593b8d63.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.593b8d63.0.snapshot
@@ -109,5 +109,5 @@ basic functionality › if_one_sided6
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.5b56d472.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.5b56d472.0.snapshot
@@ -31,5 +31,5 @@ basic functionality › and3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.5cd54e52.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.5cd54e52.0.snapshot
@@ -31,5 +31,5 @@ basic functionality › or4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.5d973a3e.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.5d973a3e.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › binop6
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.61c58118.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.61c58118.0.snapshot
@@ -74,5 +74,5 @@ basic functionality › block_no_expression
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.626b2e44.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.626b2e44.0.snapshot
@@ -106,5 +106,5 @@ basic functionality › if_one_sided5
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.65d36891.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.65d36891.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › lor2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.67d2cc45.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.67d2cc45.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › binop3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.684b6ecb.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.684b6ecb.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › binop2.2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.68d08483.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.68d08483.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › land2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.6f9706c2.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.6f9706c2.0.snapshot
@@ -31,5 +31,5 @@ basic functionality › or1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.704872bc.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.704872bc.0.snapshot
@@ -31,5 +31,5 @@ basic functionality › assert1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.711a4824.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.711a4824.0.snapshot
@@ -780,5 +780,5 @@ basic functionality › pattern_match_unsafe_wasm
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 341
+ ;; custom section \"cmi\", size 386
 )

--- a/compiler/test/__snapshots__/basic_functionality.7222ab37.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.7222ab37.0.snapshot
@@ -31,5 +31,5 @@ basic functionality › tru
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.7287219f.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.7287219f.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › asr1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.7599b5a6.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.7599b5a6.0.snapshot
@@ -81,5 +81,5 @@ basic functionality › assignment1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.7848308f.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.7848308f.0.snapshot
@@ -31,5 +31,5 @@ basic functionality › or3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.79ea1ccc.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.79ea1ccc.0.snapshot
@@ -81,5 +81,5 @@ basic functionality › assignment1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.7b13e79a.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.7b13e79a.0.snapshot
@@ -31,5 +31,5 @@ basic functionality › and4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.7bb7b0d4.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.7bb7b0d4.0.snapshot
@@ -49,5 +49,5 @@ basic functionality › uint32_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.7beffe4d.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.7beffe4d.0.snapshot
@@ -53,5 +53,5 @@ basic functionality › hex_dec_exp5
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.7ccc4940.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.7ccc4940.0.snapshot
@@ -111,5 +111,5 @@ basic functionality › division1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.7d0640b4.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.7d0640b4.0.snapshot
@@ -109,5 +109,5 @@ basic functionality › if_one_sided2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.83f51526.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.83f51526.0.snapshot
@@ -53,5 +53,5 @@ basic functionality › hex_dec_exp3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.86f332c6.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.86f332c6.0.snapshot
@@ -31,5 +31,5 @@ basic functionality › bin_neg
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.8c8313f3.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.8c8313f3.0.snapshot
@@ -53,5 +53,5 @@ basic functionality › hex_dec_exp2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.8e01d666.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.8e01d666.0.snapshot
@@ -53,5 +53,5 @@ basic functionality › infinity_neg
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.903ff701.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.903ff701.0.snapshot
@@ -53,5 +53,5 @@ basic functionality › hex_dec_exp4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.9110d0f5.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.9110d0f5.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › comp13
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.9157dba1.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.9157dba1.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › andshadow
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.9379df0d.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.9379df0d.0.snapshot
@@ -274,5 +274,5 @@ basic functionality › comp21
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.950b8fda.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.950b8fda.0.snapshot
@@ -31,5 +31,5 @@ basic functionality › binop2.3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.970a2a2b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.970a2a2b.0.snapshot
@@ -31,5 +31,5 @@ basic functionality › not2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.974b7936.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.974b7936.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › lxor3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.994117f8.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.994117f8.0.snapshot
@@ -42,5 +42,5 @@ basic functionality › incr_3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.9b9c7047.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.9b9c7047.0.snapshot
@@ -53,5 +53,5 @@ basic functionality › void
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.9c18b19d.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.9c18b19d.0.snapshot
@@ -89,5 +89,5 @@ basic functionality › if_one_sided3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.9df4a5e0.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.9df4a5e0.0.snapshot
@@ -31,5 +31,5 @@ basic functionality › and1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.9fb01eb5.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.9fb01eb5.0.snapshot
@@ -31,5 +31,5 @@ basic functionality › simple_max
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.a0045d1c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.a0045d1c.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › binop1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.a0747361.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.a0747361.0.snapshot
@@ -31,5 +31,5 @@ basic functionality › hex
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.a2e63440.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.a2e63440.0.snapshot
@@ -63,5 +63,5 @@ basic functionality › comp9
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.a3f7e180.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.a3f7e180.0.snapshot
@@ -73,5 +73,5 @@ basic functionality › bigint_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.a4ec9fca.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.a4ec9fca.0.snapshot
@@ -31,5 +31,5 @@ basic functionality › andshort2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.a58a9361.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.a58a9361.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › lxor2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.a5d5182f.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.a5d5182f.0.snapshot
@@ -63,5 +63,5 @@ basic functionality › comp2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.a72898d0.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.a72898d0.0.snapshot
@@ -63,5 +63,5 @@ basic functionality › comp8
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.abd9d13c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.abd9d13c.0.snapshot
@@ -63,5 +63,5 @@ basic functionality › comp7
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.b07cc734.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.b07cc734.0.snapshot
@@ -109,5 +109,5 @@ basic functionality › if_one_sided
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.b6a1b657.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.b6a1b657.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › lxor4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.b836b89a.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.b836b89a.0.snapshot
@@ -110,5 +110,5 @@ basic functionality › complex1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.bb137371.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.bb137371.0.snapshot
@@ -81,5 +81,5 @@ basic functionality › assignment1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.bd891a1f.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.bd891a1f.0.snapshot
@@ -31,5 +31,5 @@ basic functionality › oct
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.bef9449e.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.bef9449e.0.snapshot
@@ -63,5 +63,5 @@ basic functionality › comp1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.c1554a92.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c1554a92.0.snapshot
@@ -31,5 +31,5 @@ basic functionality › or2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.c2c74be4.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c2c74be4.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › lsr2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.c4090bb1.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c4090bb1.0.snapshot
@@ -303,5 +303,5 @@ basic functionality › toplevel_statements
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 337
+ ;; custom section \"cmi\", size 382
 )

--- a/compiler/test/__snapshots__/basic_functionality.c49928a5.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c49928a5.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › lsr1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.c55feb83.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c55feb83.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › comp14
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.c8095f7c.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c8095f7c.0.snapshot
@@ -42,5 +42,5 @@ basic functionality › incr_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.c8144b17.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.c8144b17.0.snapshot
@@ -31,5 +31,5 @@ basic functionality › bin
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.cb9c6c66.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.cb9c6c66.0.snapshot
@@ -42,5 +42,5 @@ basic functionality › incr_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.cdeddcd2.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.cdeddcd2.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › modulo3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.cefeb364.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.cefeb364.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › lor4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.d0c0c62b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d0c0c62b.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › int64_pun_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.d0cb4f44.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d0cb4f44.0.snapshot
@@ -42,5 +42,5 @@ basic functionality › decr_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.d124f931.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d124f931.0.snapshot
@@ -31,5 +31,5 @@ basic functionality › nil
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.d6ca4146.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d6ca4146.0.snapshot
@@ -84,5 +84,5 @@ basic functionality › andshort1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.d8a7dcf9.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d8a7dcf9.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › modulo1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.d8f6f027.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d8f6f027.0.snapshot
@@ -53,5 +53,5 @@ basic functionality › hex_dec_exp1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.d9fc01df.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.d9fc01df.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › land3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.dbf5d3ff.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.dbf5d3ff.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › comp18
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.df4cd2bf.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.df4cd2bf.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › comp15
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.e2902464.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.e2902464.0.snapshot
@@ -61,5 +61,5 @@ basic functionality › comp10
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.e3995c7d.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.e3995c7d.0.snapshot
@@ -92,5 +92,5 @@ basic functionality › if_one_sided4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.e56cd2a2.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.e56cd2a2.0.snapshot
@@ -63,5 +63,5 @@ basic functionality › comp6
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.e58c3266.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.e58c3266.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › asr2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.e6ea6b06.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.e6ea6b06.0.snapshot
@@ -49,5 +49,5 @@ basic functionality › int32_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.e811c1e1.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.e811c1e1.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › binop2.1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.ee7c0ebc.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.ee7c0ebc.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › modulo2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.f132ca8b.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.f132ca8b.0.snapshot
@@ -42,5 +42,5 @@ basic functionality › decr_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.f47797ca.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.f47797ca.0.snapshot
@@ -53,5 +53,5 @@ basic functionality › hex_dec_exp5
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.f58be537.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.f58be537.0.snapshot
@@ -306,5 +306,5 @@ basic functionality › comp19
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.f90a3baa.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.f90a3baa.0.snapshot
@@ -53,5 +53,5 @@ basic functionality › heap_number_i32_wrapper_max
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.f9743171.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.f9743171.0.snapshot
@@ -53,5 +53,5 @@ basic functionality › heap_number_i32_wrapper
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.fd64a58f.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.fd64a58f.0.snapshot
@@ -44,5 +44,5 @@ basic functionality › int64_pun_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.fe19cffe.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.fe19cffe.0.snapshot
@@ -65,5 +65,5 @@ basic functionality › bigint_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/basic_functionality.fe88cb04.0.snapshot
+++ b/compiler/test/__snapshots__/basic_functionality.fe88cb04.0.snapshot
@@ -439,5 +439,5 @@ basic functionality › func_shadow_and_indirect_call
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 340
+ ;; custom section \"cmi\", size 385
 )

--- a/compiler/test/__snapshots__/boxes.08fca3f7.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.08fca3f7.0.snapshot
@@ -112,5 +112,5 @@ boxes › box_subtraction1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/boxes.0c59fc4e.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.0c59fc4e.0.snapshot
@@ -125,5 +125,5 @@ boxes › box_multiplication2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/boxes.17668725.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.17668725.0.snapshot
@@ -125,5 +125,5 @@ boxes › box_division2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/boxes.2b56febf.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.2b56febf.0.snapshot
@@ -125,5 +125,5 @@ boxes › box_addition2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/boxes.7d564476.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.7d564476.0.snapshot
@@ -112,5 +112,5 @@ boxes › box_division1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/boxes.9035923e.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.9035923e.0.snapshot
@@ -125,5 +125,5 @@ boxes › box_subtraction2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/boxes.adbe1660.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.adbe1660.0.snapshot
@@ -112,5 +112,5 @@ boxes › box_addition1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/boxes.bc258c1b.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.bc258c1b.0.snapshot
@@ -112,5 +112,5 @@ boxes › box_multiplication1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/boxes.eb81e542.0.snapshot
+++ b/compiler/test/__snapshots__/boxes.eb81e542.0.snapshot
@@ -92,5 +92,5 @@ boxes › test_set_extra1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/chars.200d9e1a.0.snapshot
+++ b/compiler/test/__snapshots__/chars.200d9e1a.0.snapshot
@@ -31,5 +31,5 @@ chars › char4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/chars.259e330c.0.snapshot
+++ b/compiler/test/__snapshots__/chars.259e330c.0.snapshot
@@ -31,5 +31,5 @@ chars › char2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/chars.27fb7f30.0.snapshot
+++ b/compiler/test/__snapshots__/chars.27fb7f30.0.snapshot
@@ -31,5 +31,5 @@ chars › char8
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/chars.51010573.0.snapshot
+++ b/compiler/test/__snapshots__/chars.51010573.0.snapshot
@@ -31,5 +31,5 @@ chars › char7
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/chars.7e0f68db.0.snapshot
+++ b/compiler/test/__snapshots__/chars.7e0f68db.0.snapshot
@@ -31,5 +31,5 @@ chars › char6
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/chars.af4b3613.0.snapshot
+++ b/compiler/test/__snapshots__/chars.af4b3613.0.snapshot
@@ -31,5 +31,5 @@ chars › char5
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/chars.e1cac8cd.0.snapshot
+++ b/compiler/test/__snapshots__/chars.e1cac8cd.0.snapshot
@@ -31,5 +31,5 @@ chars › char3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/comments.573e549e.0.snapshot
+++ b/compiler/test/__snapshots__/comments.573e549e.0.snapshot
@@ -31,5 +31,5 @@ comments › comment_alone
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/comments.8f52e899.0.snapshot
+++ b/compiler/test/__snapshots__/comments.8f52e899.0.snapshot
@@ -31,5 +31,5 @@ comments › comment_block
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/comments.ccf5fcf4.0.snapshot
+++ b/compiler/test/__snapshots__/comments.ccf5fcf4.0.snapshot
@@ -31,5 +31,5 @@ comments › comment_shebang
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/comments.fd91c233.0.snapshot
+++ b/compiler/test/__snapshots__/comments.fd91c233.0.snapshot
@@ -31,5 +31,5 @@ comments › comment_doc
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/early_return.1183a893.0.snapshot
+++ b/compiler/test/__snapshots__/early_return.1183a893.0.snapshot
@@ -13,10 +13,10 @@ early return › early_return3
  (import \"_genv\" \"metadataPtr\" (global $metadataPtr_0 i32))
  (import \"GRAIN$MODULE$runtime/gc.gr\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc.gr\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives.gr\" \"GRAIN$EXPORT$==\" (global $==_1118 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives.gr\" \"GRAIN$EXPORT$==\" (global $==_1116 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc.gr\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc.gr\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives.gr\" \"==\" (func $==_1118 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives.gr\" \"==\" (func $==_1116 (param i32 i32 i32) (result i32)))
  (global $foo_1113 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (memory $0 0)
@@ -38,10 +38,10 @@ early return › early_return3
   (block $compile_block.7
    (block $compile_store.2
     (local.set $7
-     (call $==_1118
+     (call $==_1116
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $==_1118)
+       (global.get $==_1116)
       )
       (i32.const 3)
       (i32.const 1)
@@ -110,5 +110,5 @@ early return › early_return3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 955
+ ;; custom section \"cmi\", size 1000
 )

--- a/compiler/test/__snapshots__/enums.aa34084a.0.snapshot
+++ b/compiler/test/__snapshots__/enums.aa34084a.0.snapshot
@@ -61,5 +61,5 @@ enums › adt_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 607
+ ;; custom section \"cmi\", size 652
 )

--- a/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
+++ b/compiler/test/__snapshots__/enums.ae26523b.0.snapshot
@@ -412,5 +412,5 @@ enums › enum_recursive_data_definition
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 885
+ ;; custom section \"cmi\", size 930
 )

--- a/compiler/test/__snapshots__/exceptions.a68ae348.0.snapshot
+++ b/compiler/test/__snapshots__/exceptions.a68ae348.0.snapshot
@@ -61,5 +61,5 @@ exceptions › exception_4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1619
+ ;; custom section \"cmi\", size 1760
 )

--- a/compiler/test/__snapshots__/exceptions.ccac3e71.0.snapshot
+++ b/compiler/test/__snapshots__/exceptions.ccac3e71.0.snapshot
@@ -61,5 +61,5 @@ exceptions › exception_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 847
+ ;; custom section \"cmi\", size 892
 )

--- a/compiler/test/__snapshots__/functions.06134c8a.0.snapshot
+++ b/compiler/test/__snapshots__/functions.06134c8a.0.snapshot
@@ -74,5 +74,5 @@ functions › dup_func
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/functions.0b8146ea.0.snapshot
+++ b/compiler/test/__snapshots__/functions.0b8146ea.0.snapshot
@@ -81,5 +81,5 @@ functions › regression_1725
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/functions.14922a92.0.snapshot
+++ b/compiler/test/__snapshots__/functions.14922a92.0.snapshot
@@ -79,5 +79,5 @@ functions › shorthand_4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/functions.1be5ecd5.0.snapshot
+++ b/compiler/test/__snapshots__/functions.1be5ecd5.0.snapshot
@@ -74,5 +74,5 @@ functions › shorthand_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/functions.23afd9c9.0.snapshot
+++ b/compiler/test/__snapshots__/functions.23afd9c9.0.snapshot
@@ -406,5 +406,5 @@ functions › lam_destructure_5
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/functions.28e0f2b3.0.snapshot
+++ b/compiler/test/__snapshots__/functions.28e0f2b3.0.snapshot
@@ -109,5 +109,5 @@ functions › lambda_pat_any
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/functions.49ccab54.0.snapshot
+++ b/compiler/test/__snapshots__/functions.49ccab54.0.snapshot
@@ -165,5 +165,5 @@ functions › curried_func
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/functions.6eacded0.0.snapshot
+++ b/compiler/test/__snapshots__/functions.6eacded0.0.snapshot
@@ -14,20 +14,20 @@ functions › func_recursive_closure
  (import \"GRAIN$MODULE$runtime/gc.gr\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc.gr\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc.gr\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives.gr\" \"GRAIN$EXPORT$-\" (global $-_1139 (mut i32)))
- (import \"GRAIN$MODULE$pervasives.gr\" \"GRAIN$EXPORT$==\" (global $==_1134 (mut i32)))
- (import \"GRAIN$MODULE$pervasives.gr\" \"GRAIN$EXPORT$+\" (global $+_1124 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives.gr\" \"GRAIN$EXPORT$-\" (global $-_1137 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives.gr\" \"GRAIN$EXPORT$==\" (global $==_1132 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives.gr\" \"GRAIN$EXPORT$+\" (global $+_1122 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc.gr\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc.gr\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc.gr\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives.gr\" \"-\" (func $-_1139 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives.gr\" \"==\" (func $==_1134 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives.gr\" \"+\" (func $+_1124 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives.gr\" \"-\" (func $-_1137 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives.gr\" \"==\" (func $==_1132 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives.gr\" \"+\" (func $+_1122 (param i32 i32 i32) (result i32)))
  (global $truc_1116 (mut i32) (i32.const 0))
  (global $makeAdder_1113 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 1))
  (memory $0 0)
- (elem $elem (global.get $relocBase_0) $func_1147)
+ (elem $elem (global.get $relocBase_0) $func_1145)
  (export \"memory\" (memory $0))
  (export \"truc\" (func $truc_1116))
  (export \"GRAIN$EXPORT$truc\" (global $truc_1116))
@@ -118,7 +118,7 @@ functions › func_recursive_closure
    )
   )
  )
- (func $func_1147 (param $0 i32) (param $1 i32) (result i32)
+ (func $func_1145 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -144,10 +144,10 @@ functions › func_recursive_closure
       )
      )
     )
-    (return_call $+_1124
+    (return_call $+_1122
      (call $incRef_0
       (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $+_1124)
+      (global.get $+_1122)
      )
      (local.get $1)
      (local.get $2)
@@ -227,10 +227,10 @@ functions › func_recursive_closure
    )
    (block $compile_store.19
     (local.set $11
-     (call $==_1134
+     (call $==_1132
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
-       (global.get $==_1134)
+       (global.get $==_1132)
       )
       (call $incRef_0
        (global.get $GRAIN$EXPORT$incRef_0)
@@ -255,10 +255,10 @@ functions › func_recursive_closure
       (block $compile_block.30
        (block $compile_store.23
         (local.set $12
-         (call $==_1134
+         (call $==_1132
           (call $incRef_0
            (global.get $GRAIN$EXPORT$incRef_0)
-           (global.get $==_1134)
+           (global.get $==_1132)
           )
           (call $incRef_0
            (global.get $GRAIN$EXPORT$incRef_0)
@@ -298,10 +298,10 @@ functions › func_recursive_closure
         (block $compile_block.29
          (block $compile_store.27
           (local.set $10
-           (call $-_1139
+           (call $-_1137
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)
-             (global.get $-_1139)
+             (global.get $-_1137)
             )
             (call $incRef_0
              (global.get $GRAIN$EXPORT$incRef_0)
@@ -431,10 +431,10 @@ functions › func_recursive_closure
       )
      )
     )
-    (return_call $+_1124
+    (return_call $+_1122
      (call $incRef_0
       (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $+_1124)
+      (global.get $+_1122)
      )
      (local.get $10)
      (local.get $11)
@@ -477,5 +477,5 @@ functions › func_recursive_closure
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 980
+ ;; custom section \"cmi\", size 1025
 )

--- a/compiler/test/__snapshots__/functions.7a8986a5.0.snapshot
+++ b/compiler/test/__snapshots__/functions.7a8986a5.0.snapshot
@@ -69,5 +69,5 @@ functions › app_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/functions.84b6e84b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.84b6e84b.0.snapshot
@@ -74,5 +74,5 @@ functions › shorthand_3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/functions.8baf471f.0.snapshot
+++ b/compiler/test/__snapshots__/functions.8baf471f.0.snapshot
@@ -256,5 +256,5 @@ functions › lam_destructure_3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/functions.9223245d.0.snapshot
+++ b/compiler/test/__snapshots__/functions.9223245d.0.snapshot
@@ -363,5 +363,5 @@ functions › lam_destructure_7
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/functions.9fd69835.0.snapshot
+++ b/compiler/test/__snapshots__/functions.9fd69835.0.snapshot
@@ -79,5 +79,5 @@ functions › shorthand_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/functions.b37949b2.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b37949b2.0.snapshot
@@ -259,5 +259,5 @@ functions › lam_destructure_4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/functions.b3a8d88b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b3a8d88b.0.snapshot
@@ -366,5 +366,5 @@ functions › lam_destructure_8
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/functions.b632a2ab.0.snapshot
+++ b/compiler/test/__snapshots__/functions.b632a2ab.0.snapshot
@@ -104,5 +104,5 @@ functions › lam_destructure_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/functions.c6e8a9aa.0.snapshot
+++ b/compiler/test/__snapshots__/functions.c6e8a9aa.0.snapshot
@@ -109,5 +109,5 @@ functions › lam_destructure_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/functions.ce978f54.0.snapshot
+++ b/compiler/test/__snapshots__/functions.ce978f54.0.snapshot
@@ -31,5 +31,5 @@ functions › multi_bind2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/functions.d9466880.0.snapshot
+++ b/compiler/test/__snapshots__/functions.d9466880.0.snapshot
@@ -235,5 +235,5 @@ functions › func_record_associativity2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 581
+ ;; custom section \"cmi\", size 626
 )

--- a/compiler/test/__snapshots__/functions.e6c6212b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.e6c6212b.0.snapshot
@@ -80,5 +80,5 @@ functions › fn_trailing_comma
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/functions.f400bb7b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.f400bb7b.0.snapshot
@@ -409,5 +409,5 @@ functions › lam_destructure_6
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/functions.f647681b.0.snapshot
+++ b/compiler/test/__snapshots__/functions.f647681b.0.snapshot
@@ -179,5 +179,5 @@ functions › func_record_associativity1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 451
+ ;; custom section \"cmi\", size 496
 )

--- a/compiler/test/__snapshots__/includes.1d829099.0.snapshot
+++ b/compiler/test/__snapshots__/includes.1d829099.0.snapshot
@@ -32,5 +32,5 @@ includes › include_relative_path2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 408
+ ;; custom section \"cmi\", size 453
 )

--- a/compiler/test/__snapshots__/includes.46f78654.0.snapshot
+++ b/compiler/test/__snapshots__/includes.46f78654.0.snapshot
@@ -46,5 +46,5 @@ includes › include_some_multiple
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 376
+ ;; custom section \"cmi\", size 421
 )

--- a/compiler/test/__snapshots__/includes.5dfba7dd.0.snapshot
+++ b/compiler/test/__snapshots__/includes.5dfba7dd.0.snapshot
@@ -32,5 +32,5 @@ includes › include_alias
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 376
+ ;; custom section \"cmi\", size 421
 )

--- a/compiler/test/__snapshots__/includes.6c8d23dc.0.snapshot
+++ b/compiler/test/__snapshots__/includes.6c8d23dc.0.snapshot
@@ -46,5 +46,5 @@ includes › include_some_multiple_trailing2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 376
+ ;; custom section \"cmi\", size 421
 )

--- a/compiler/test/__snapshots__/includes.6e78c003.0.snapshot
+++ b/compiler/test/__snapshots__/includes.6e78c003.0.snapshot
@@ -46,5 +46,5 @@ includes › include_some_multiple_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 376
+ ;; custom section \"cmi\", size 421
 )

--- a/compiler/test/__snapshots__/includes.7afbe731.0.snapshot
+++ b/compiler/test/__snapshots__/includes.7afbe731.0.snapshot
@@ -32,5 +32,5 @@ includes › include_some
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 376
+ ;; custom section \"cmi\", size 421
 )

--- a/compiler/test/__snapshots__/includes.8222ee98.0.snapshot
+++ b/compiler/test/__snapshots__/includes.8222ee98.0.snapshot
@@ -32,5 +32,5 @@ includes › include_module
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 376
+ ;; custom section \"cmi\", size 421
 )

--- a/compiler/test/__snapshots__/includes.86ff4075.0.snapshot
+++ b/compiler/test/__snapshots__/includes.86ff4075.0.snapshot
@@ -46,5 +46,5 @@ includes › include_alias_multiple
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 376
+ ;; custom section \"cmi\", size 421
 )

--- a/compiler/test/__snapshots__/includes.a3212bd0.0.snapshot
+++ b/compiler/test/__snapshots__/includes.a3212bd0.0.snapshot
@@ -32,5 +32,5 @@ includes › include_relative_path3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 390
+ ;; custom section \"cmi\", size 435
 )

--- a/compiler/test/__snapshots__/includes.b3434679.0.snapshot
+++ b/compiler/test/__snapshots__/includes.b3434679.0.snapshot
@@ -45,7 +45,7 @@ includes › include_some_constructor
       )
       (i32.store offset=8
        (local.get $0)
-       (i32.const 2227)
+       (i32.const 2243)
       )
       (i32.store offset=12
        (local.get $0)
@@ -77,7 +77,7 @@ includes › include_some_constructor
     )
     (i32.store offset=8
      (local.get $0)
-     (i32.const 2227)
+     (i32.const 2243)
     )
     (i32.store offset=12
      (local.get $0)
@@ -104,5 +104,5 @@ includes › include_some_constructor
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 372
+ ;; custom section \"cmi\", size 417
 )

--- a/compiler/test/__snapshots__/includes.bd3eb3af.0.snapshot
+++ b/compiler/test/__snapshots__/includes.bd3eb3af.0.snapshot
@@ -11,10 +11,10 @@ includes › include_some_mixed
  (import \"_genv\" \"metadataPtr\" (global $metadataPtr_0 i32))
  (import \"GRAIN$MODULE$runtime/gc.gr\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc.gr\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$tlists.gr\" \"GRAIN$EXPORT$sum\" (global $sum_1120 (mut i32)))
+ (import \"GRAIN$MODULE$tlists.gr\" \"GRAIN$EXPORT$sum\" (global $sum_1126 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc.gr\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc.gr\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$tlists.gr\" \"sum\" (func $sum_1120 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$tlists.gr\" \"sum\" (func $sum_1126 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (memory $0 0)
  (elem $elem (global.get $relocBase_0))
@@ -50,7 +50,7 @@ includes › include_some_mixed
       )
       (i32.store offset=8
        (local.get $0)
-       (i32.const 2227)
+       (i32.const 2243)
       )
       (i32.store offset=12
        (local.get $0)
@@ -84,7 +84,7 @@ includes › include_some_mixed
       )
       (i32.store offset=8
        (local.get $0)
-       (i32.const 2227)
+       (i32.const 2243)
       )
       (i32.store offset=12
        (local.get $0)
@@ -108,10 +108,10 @@ includes › include_some_mixed
     (block $do_backpatches.5
     )
    )
-   (return_call $sum_1120
+   (return_call $sum_1126
     (call $incRef_0
      (global.get $GRAIN$EXPORT$incRef_0)
-     (global.get $sum_1120)
+     (global.get $sum_1126)
     )
     (local.get $7)
    )
@@ -122,5 +122,5 @@ includes › include_some_mixed
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 372
+ ;; custom section \"cmi\", size 417
 )

--- a/compiler/test/__snapshots__/includes.beda767e.0.snapshot
+++ b/compiler/test/__snapshots__/includes.beda767e.0.snapshot
@@ -32,5 +32,5 @@ includes › include_relative_path1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 401
+ ;; custom section \"cmi\", size 446
 )

--- a/compiler/test/__snapshots__/includes.c0c0d5ca.0.snapshot
+++ b/compiler/test/__snapshots__/includes.c0c0d5ca.0.snapshot
@@ -97,5 +97,5 @@ includes › include_relative_path4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 374
+ ;; custom section \"cmi\", size 419
 )

--- a/compiler/test/__snapshots__/includes.c62f45f8.0.snapshot
+++ b/compiler/test/__snapshots__/includes.c62f45f8.0.snapshot
@@ -11,7 +11,7 @@ includes › include_muliple_modules
  (import \"_genv\" \"metadataPtr\" (global $metadataPtr_0 i32))
  (import \"GRAIN$MODULE$runtime/gc.gr\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc.gr\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
- (import \"GRAIN$MODULE$provideAll.gr\" \"GRAIN$EXPORT$x\" (global $x_1130 (mut i32)))
+ (import \"GRAIN$MODULE$provideAll.gr\" \"GRAIN$EXPORT$x\" (global $x_1136 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc.gr\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc.gr\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
@@ -48,7 +48,7 @@ includes › include_muliple_modules
       )
       (i32.store offset=8
        (local.get $0)
-       (i32.const 2227)
+       (i32.const 2243)
       )
       (i32.store offset=12
        (local.get $0)
@@ -80,7 +80,7 @@ includes › include_muliple_modules
     )
     (i32.store offset=8
      (local.get $0)
-     (i32.const 2227)
+     (i32.const 2243)
     )
     (i32.store offset=12
      (local.get $0)
@@ -94,7 +94,7 @@ includes › include_muliple_modules
      (local.get $0)
      (call $incRef_0
       (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $x_1130)
+      (global.get $x_1136)
      )
     )
     (i32.store offset=24
@@ -110,5 +110,5 @@ includes › include_muliple_modules
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 425
+ ;; custom section \"cmi\", size 470
 )

--- a/compiler/test/__snapshots__/includes.cedde8e9.0.snapshot
+++ b/compiler/test/__snapshots__/includes.cedde8e9.0.snapshot
@@ -45,7 +45,7 @@ includes › include_same_module_unify
       )
       (i32.store offset=8
        (local.get $0)
-       (i32.const 2227)
+       (i32.const 2243)
       )
       (i32.store offset=12
        (local.get $0)
@@ -77,7 +77,7 @@ includes › include_same_module_unify
     )
     (i32.store offset=8
      (local.get $0)
-     (i32.const 2227)
+     (i32.const 2243)
     )
     (i32.store offset=12
      (local.get $0)
@@ -104,5 +104,5 @@ includes › include_same_module_unify
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 372
+ ;; custom section \"cmi\", size 417
 )

--- a/compiler/test/__snapshots__/includes.de6b420f.0.snapshot
+++ b/compiler/test/__snapshots__/includes.de6b420f.0.snapshot
@@ -42,7 +42,7 @@ includes › annotation_across_import
     )
     (i32.store offset=8
      (local.get $0)
-     (i32.const 2227)
+     (i32.const 2243)
     )
     (i32.store offset=12
      (local.get $0)
@@ -61,5 +61,5 @@ includes › annotation_across_import
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 372
+ ;; custom section \"cmi\", size 417
 )

--- a/compiler/test/__snapshots__/includes.f2bf866b.0.snapshot
+++ b/compiler/test/__snapshots__/includes.f2bf866b.0.snapshot
@@ -45,7 +45,7 @@ includes › include_all_constructor
       )
       (i32.store offset=8
        (local.get $0)
-       (i32.const 2227)
+       (i32.const 2243)
       )
       (i32.store offset=12
        (local.get $0)
@@ -77,7 +77,7 @@ includes › include_all_constructor
     )
     (i32.store offset=8
      (local.get $0)
-     (i32.const 2227)
+     (i32.const 2243)
     )
     (i32.store offset=12
      (local.get $0)
@@ -104,5 +104,5 @@ includes › include_all_constructor
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 372
+ ;; custom section \"cmi\", size 417
 )

--- a/compiler/test/__snapshots__/includes.f4ba5583.0.snapshot
+++ b/compiler/test/__snapshots__/includes.f4ba5583.0.snapshot
@@ -46,5 +46,5 @@ includes › include_module2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 376
+ ;; custom section \"cmi\", size 421
 )

--- a/compiler/test/__snapshots__/let_mut.00e05fe2.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.00e05fe2.0.snapshot
@@ -81,5 +81,5 @@ let mut › let-mut_division1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/let_mut.1176df90.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.1176df90.0.snapshot
@@ -89,5 +89,5 @@ let mut › let-mut_multiplication2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/let_mut.3307d5a7.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.3307d5a7.0.snapshot
@@ -68,5 +68,5 @@ let mut › let-mut3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/let_mut.43f6980c.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.43f6980c.0.snapshot
@@ -89,5 +89,5 @@ let mut › let-mut_division3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/let_mut.48249b50.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.48249b50.0.snapshot
@@ -89,5 +89,5 @@ let mut › let-mut5
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/let_mut.4c3f3b2b.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.4c3f3b2b.0.snapshot
@@ -96,5 +96,5 @@ let mut › let-mut2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/let_mut.4c75261e.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.4c75261e.0.snapshot
@@ -81,5 +81,5 @@ let mut › let-mut_multiplication1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/let_mut.634331f0.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.634331f0.0.snapshot
@@ -89,5 +89,5 @@ let mut › let-mut_multiplication3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/let_mut.63c16374.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.63c16374.0.snapshot
@@ -68,5 +68,5 @@ let mut › let-mut4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/let_mut.6796c72d.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.6796c72d.0.snapshot
@@ -81,5 +81,5 @@ let mut › let-mut_subtraction1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/let_mut.baaea1d3.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.baaea1d3.0.snapshot
@@ -89,5 +89,5 @@ let mut › let-mut_subtraction2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/let_mut.cbbbaeb4.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.cbbbaeb4.0.snapshot
@@ -89,5 +89,5 @@ let mut › let-mut_addition2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/let_mut.d2de286b.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.d2de286b.0.snapshot
@@ -81,5 +81,5 @@ let mut › let-mut_addition1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/let_mut.e90db621.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.e90db621.0.snapshot
@@ -89,5 +89,5 @@ let mut › let-mut_subtraction3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/let_mut.f8f208a2.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.f8f208a2.0.snapshot
@@ -89,5 +89,5 @@ let mut › let-mut_addition3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/let_mut.f9e32f30.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.f9e32f30.0.snapshot
@@ -89,5 +89,5 @@ let mut › let-mut_division2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/let_mut.fcc9c65d.0.snapshot
+++ b/compiler/test/__snapshots__/let_mut.fcc9c65d.0.snapshot
@@ -39,5 +39,5 @@ let mut › let-mut1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/lists.884ce894.0.snapshot
+++ b/compiler/test/__snapshots__/lists.884ce894.0.snapshot
@@ -233,5 +233,5 @@ lists › list_spread
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/lists.d9fd46fb.0.snapshot
+++ b/compiler/test/__snapshots__/lists.d9fd46fb.0.snapshot
@@ -190,5 +190,5 @@ lists › list1_trailing_space
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/lists.e5378351.0.snapshot
+++ b/compiler/test/__snapshots__/lists.e5378351.0.snapshot
@@ -190,5 +190,5 @@ lists › list1_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/loops.0a25def1.0.snapshot
+++ b/compiler/test/__snapshots__/loops.0a25def1.0.snapshot
@@ -257,5 +257,5 @@ loops › loop2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/loops.0fafc5f0.0.snapshot
+++ b/compiler/test/__snapshots__/loops.0fafc5f0.0.snapshot
@@ -182,5 +182,5 @@ loops › loop5
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/loops.c2b7bfc6.0.snapshot
+++ b/compiler/test/__snapshots__/loops.c2b7bfc6.0.snapshot
@@ -130,5 +130,5 @@ loops › loop3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/loops.f1c03b79.0.snapshot
+++ b/compiler/test/__snapshots__/loops.f1c03b79.0.snapshot
@@ -182,5 +182,5 @@ loops › loop4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/modules.52d25a2f.0.snapshot
+++ b/compiler/test/__snapshots__/modules.52d25a2f.0.snapshot
@@ -31,5 +31,5 @@ modules › smallest_submodule
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/optimizations.d72b00c6.0.snapshot
+++ b/compiler/test/__snapshots__/optimizations.d72b00c6.0.snapshot
@@ -82,5 +82,5 @@ optimizations › trs1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/optimizations.ff6d5bfb.0.snapshot
+++ b/compiler/test/__snapshots__/optimizations.ff6d5bfb.0.snapshot
@@ -176,5 +176,5 @@ optimizations › test_dead_branch_elimination_5
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/pattern_matching.0539d13e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0539d13e.0.snapshot
@@ -226,5 +226,5 @@ pattern matching › record_match_3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 598
+ ;; custom section \"cmi\", size 643
 )

--- a/compiler/test/__snapshots__/pattern_matching.05b60a1e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.05b60a1e.0.snapshot
@@ -347,5 +347,5 @@ pattern matching › adt_match_deep
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 441
+ ;; custom section \"cmi\", size 486
 )

--- a/compiler/test/__snapshots__/pattern_matching.0ad4ac05.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0ad4ac05.0.snapshot
@@ -1256,5 +1256,5 @@ pattern matching › tuple_match_deep4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/pattern_matching.0bb6923e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0bb6923e.0.snapshot
@@ -977,5 +977,5 @@ pattern matching › adt_match_4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/pattern_matching.0fa61137.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.0fa61137.0.snapshot
@@ -238,5 +238,5 @@ pattern matching › low_level_constant_match_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/pattern_matching.14dc7554.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.14dc7554.0.snapshot
@@ -200,5 +200,5 @@ pattern matching › record_match_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 598
+ ;; custom section \"cmi\", size 643
 )

--- a/compiler/test/__snapshots__/pattern_matching.16cd197e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.16cd197e.0.snapshot
@@ -173,5 +173,5 @@ pattern matching › constant_match_3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/pattern_matching.16eb3dbf.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.16eb3dbf.0.snapshot
@@ -398,5 +398,5 @@ pattern matching › guarded_match_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/pattern_matching.25930935.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.25930935.0.snapshot
@@ -238,5 +238,5 @@ pattern matching › low_level_constant_match_3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/pattern_matching.3722b060.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.3722b060.0.snapshot
@@ -421,5 +421,5 @@ pattern matching › tuple_match_deep
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/pattern_matching.46f91987.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.46f91987.0.snapshot
@@ -200,5 +200,5 @@ pattern matching › record_match_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 598
+ ;; custom section \"cmi\", size 643
 )

--- a/compiler/test/__snapshots__/pattern_matching.5b158103.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.5b158103.0.snapshot
@@ -458,5 +458,5 @@ pattern matching › constant_match_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/pattern_matching.5b6ff2d3.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.5b6ff2d3.0.snapshot
@@ -477,5 +477,5 @@ pattern matching › alias_match_5
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/pattern_matching.5ff49e44.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.5ff49e44.0.snapshot
@@ -307,5 +307,5 @@ pattern matching › record_match_4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 598
+ ;; custom section \"cmi\", size 643
 )

--- a/compiler/test/__snapshots__/pattern_matching.64686134.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.64686134.0.snapshot
@@ -331,5 +331,5 @@ pattern matching › constant_match_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/pattern_matching.702ed9b0.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.702ed9b0.0.snapshot
@@ -1342,5 +1342,5 @@ pattern matching › tuple_match_deep6
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/pattern_matching.7082d3ca.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.7082d3ca.0.snapshot
@@ -297,5 +297,5 @@ pattern matching › tuple_match_3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/pattern_matching.79346fef.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.79346fef.0.snapshot
@@ -1213,5 +1213,5 @@ pattern matching › tuple_match_deep3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/pattern_matching.7f7fe4ef.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.7f7fe4ef.0.snapshot
@@ -75,5 +75,5 @@ pattern matching › alias_match_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/pattern_matching.8614dff3.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.8614dff3.0.snapshot
@@ -102,5 +102,5 @@ pattern matching › alias_match_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/pattern_matching.8c0dc67a.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.8c0dc67a.0.snapshot
@@ -848,5 +848,5 @@ pattern matching › adt_match_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/pattern_matching.9561763b.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.9561763b.0.snapshot
@@ -787,5 +787,5 @@ pattern matching › tuple_match_deep2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/pattern_matching.98756c45.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.98756c45.0.snapshot
@@ -221,5 +221,5 @@ pattern matching › record_match_deep
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 561
+ ;; custom section \"cmi\", size 606
 )

--- a/compiler/test/__snapshots__/pattern_matching.9ffaa7a7.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.9ffaa7a7.0.snapshot
@@ -238,5 +238,5 @@ pattern matching › low_level_constant_match_4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/pattern_matching.aa8d2963.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.aa8d2963.0.snapshot
@@ -427,5 +427,5 @@ pattern matching › guarded_match_4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/pattern_matching.ac58ffc3.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.ac58ffc3.0.snapshot
@@ -398,5 +398,5 @@ pattern matching › guarded_match_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/pattern_matching.b1b060ad.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.b1b060ad.0.snapshot
@@ -891,5 +891,5 @@ pattern matching › adt_match_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/pattern_matching.b9db0dd9.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.b9db0dd9.0.snapshot
@@ -427,5 +427,5 @@ pattern matching › guarded_match_3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/pattern_matching.be46eb0e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.be46eb0e.0.snapshot
@@ -244,5 +244,5 @@ pattern matching › low_level_constant_match_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/pattern_matching.c91eac29.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.c91eac29.0.snapshot
@@ -934,5 +934,5 @@ pattern matching › adt_match_3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/pattern_matching.c9582b6d.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.c9582b6d.0.snapshot
@@ -360,5 +360,5 @@ pattern matching › alias_match_4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/pattern_matching.d048ece0.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.d048ece0.0.snapshot
@@ -1020,5 +1020,5 @@ pattern matching › adt_match_5
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/pattern_matching.e17bcd61.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.e17bcd61.0.snapshot
@@ -123,5 +123,5 @@ pattern matching › or_match_4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/pattern_matching.e41ad64e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.e41ad64e.0.snapshot
@@ -1299,5 +1299,5 @@ pattern matching › tuple_match_deep5
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/pattern_matching.eb4334e1.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.eb4334e1.0.snapshot
@@ -469,5 +469,5 @@ pattern matching › constant_match_4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/pattern_matching.f0c08ea4.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.f0c08ea4.0.snapshot
@@ -1385,5 +1385,5 @@ pattern matching › tuple_match_deep7
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/pattern_matching.f25e0163.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.f25e0163.0.snapshot
@@ -575,5 +575,5 @@ pattern matching › or_match_3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/pattern_matching.f3d48b0e.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.f3d48b0e.0.snapshot
@@ -123,5 +123,5 @@ pattern matching › or_match_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/pattern_matching.f6c9c89c.0.snapshot
+++ b/compiler/test/__snapshots__/pattern_matching.f6c9c89c.0.snapshot
@@ -321,5 +321,5 @@ pattern matching › or_match_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/provides.0ef7e7b3.0.snapshot
+++ b/compiler/test/__snapshots__/provides.0ef7e7b3.0.snapshot
@@ -32,5 +32,5 @@ provides › provide7
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 376
+ ;; custom section \"cmi\", size 421
 )

--- a/compiler/test/__snapshots__/provides.10f4f118.0.snapshot
+++ b/compiler/test/__snapshots__/provides.10f4f118.0.snapshot
@@ -46,5 +46,5 @@ provides › provide9
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 376
+ ;; custom section \"cmi\", size 421
 )

--- a/compiler/test/__snapshots__/provides.2a5f527b.0.snapshot
+++ b/compiler/test/__snapshots__/provides.2a5f527b.0.snapshot
@@ -41,5 +41,5 @@ provides › multiple_provides_8
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1390
+ ;; custom section \"cmi\", size 1435
 )

--- a/compiler/test/__snapshots__/provides.30cbc409.0.snapshot
+++ b/compiler/test/__snapshots__/provides.30cbc409.0.snapshot
@@ -13,11 +13,11 @@ provides › provide_start_function
  (import \"GRAIN$MODULE$runtime/gc.gr\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc.gr\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc.gr\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives.gr\" \"GRAIN$EXPORT$print\" (global $print_1117 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives.gr\" \"GRAIN$EXPORT$print\" (global $print_1115 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc.gr\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc.gr\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc.gr\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives.gr\" \"print\" (func $print_1117 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives.gr\" \"print\" (func $print_1115 (param i32 i32 i32) (result i32)))
  (global $_start_1113 (mut i32) (i32.const 0))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 0))
  (memory $0 0)
@@ -109,10 +109,10 @@ provides › provide_start_function
      )
     )
    )
-   (return_call $print_1117
+   (return_call $print_1115
     (call $incRef_0
      (global.get $GRAIN$EXPORT$incRef_0)
-     (global.get $print_1117)
+     (global.get $print_1115)
     )
     (local.get $8)
     (local.get $7)
@@ -190,10 +190,10 @@ provides › provide_start_function
     )
    )
    (drop
-    (call $print_1117
+    (call $print_1115
      (call $incRef_0
       (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $print_1117)
+      (global.get $print_1115)
      )
      (local.get $7)
      (local.get $6)
@@ -209,5 +209,5 @@ provides › provide_start_function
    (i32.const 1879048190)
   )
  )
- ;; custom section \"cmi\", size 976
+ ;; custom section \"cmi\", size 1021
 )

--- a/compiler/test/__snapshots__/provides.82c10ab4.0.snapshot
+++ b/compiler/test/__snapshots__/provides.82c10ab4.0.snapshot
@@ -13,21 +13,21 @@ provides › provide12
  (import \"GRAIN$MODULE$runtime/gc.gr\" \"GRAIN$EXPORT$malloc\" (global $GRAIN$EXPORT$malloc_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc.gr\" \"GRAIN$EXPORT$incRef\" (global $GRAIN$EXPORT$incRef_0 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc.gr\" \"GRAIN$EXPORT$decRef\" (global $GRAIN$EXPORT$decRef_0 (mut i32)))
- (import \"GRAIN$MODULE$pervasives.gr\" \"GRAIN$EXPORT$print\" (global $print_1198 (mut i32)))
- (import \"GRAIN$MODULE$providedType.gr\" \"GRAIN$EXPORT$apply\" (global $apply_1196 (mut i32)))
+ (import \"GRAIN$MODULE$pervasives.gr\" \"GRAIN$EXPORT$print\" (global $print_1203 (mut i32)))
+ (import \"GRAIN$MODULE$providedType.gr\" \"GRAIN$EXPORT$apply\" (global $apply_1201 (mut i32)))
  (import \"GRAIN$MODULE$runtime/gc.gr\" \"malloc\" (func $malloc_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc.gr\" \"incRef\" (func $incRef_0 (param i32 i32) (result i32)))
  (import \"GRAIN$MODULE$runtime/gc.gr\" \"decRef\" (func $decRef_0 (param i32 i32) (result i32)))
- (import \"GRAIN$MODULE$pervasives.gr\" \"print\" (func $print_1198 (param i32 i32 i32) (result i32)))
- (import \"GRAIN$MODULE$providedType.gr\" \"apply\" (func $apply_1196 (param i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$pervasives.gr\" \"print\" (func $print_1203 (param i32 i32 i32) (result i32)))
+ (import \"GRAIN$MODULE$providedType.gr\" \"apply\" (func $apply_1201 (param i32 i32) (result i32)))
  (global $GRAIN$TABLE_SIZE i32 (i32.const 1))
  (memory $0 0)
- (elem $elem (global.get $relocBase_0) $lam_lambda_1197)
+ (elem $elem (global.get $relocBase_0) $lam_lambda_1202)
  (export \"memory\" (memory $0))
  (export \"_gmain\" (func $_gmain))
  (export \"_start\" (func $_start))
  (export \"GRAIN$TABLE_SIZE\" (global $GRAIN$TABLE_SIZE))
- (func $lam_lambda_1197 (param $0 i32) (param $1 i32) (result i32)
+ (func $lam_lambda_1202 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -112,10 +112,10 @@ provides › provide12
       )
      )
     )
-    (return_call $print_1198
+    (return_call $print_1203
      (call $incRef_0
       (global.get $GRAIN$EXPORT$incRef_0)
-      (global.get $print_1198)
+      (global.get $print_1203)
      )
      (local.get $9)
      (local.get $8)
@@ -168,10 +168,10 @@ provides › provide12
      )
     )
    )
-   (return_call $apply_1196
+   (return_call $apply_1201
     (call $incRef_0
      (global.get $GRAIN$EXPORT$incRef_0)
-     (global.get $apply_1196)
+     (global.get $apply_1201)
     )
     (local.get $6)
    )
@@ -182,5 +182,5 @@ provides › provide12
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 378
+ ;; custom section \"cmi\", size 423
 )

--- a/compiler/test/__snapshots__/provides.c3bb4eff.0.snapshot
+++ b/compiler/test/__snapshots__/provides.c3bb4eff.0.snapshot
@@ -64,5 +64,5 @@ provides › provide8
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 376
+ ;; custom section \"cmi\", size 421
 )

--- a/compiler/test/__snapshots__/provides.c6bf4567.0.snapshot
+++ b/compiler/test/__snapshots__/provides.c6bf4567.0.snapshot
@@ -69,5 +69,5 @@ provides › let_rec_provide
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 960
+ ;; custom section \"cmi\", size 1005
 )

--- a/compiler/test/__snapshots__/provides.f378d570.0.snapshot
+++ b/compiler/test/__snapshots__/provides.f378d570.0.snapshot
@@ -32,5 +32,5 @@ provides › provide4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 379
+ ;; custom section \"cmi\", size 424
 )

--- a/compiler/test/__snapshots__/records.012b017b.0.snapshot
+++ b/compiler/test/__snapshots__/records.012b017b.0.snapshot
@@ -31,5 +31,5 @@ records › record_spread_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 517
+ ;; custom section \"cmi\", size 562
 )

--- a/compiler/test/__snapshots__/records.02742729.0.snapshot
+++ b/compiler/test/__snapshots__/records.02742729.0.snapshot
@@ -121,5 +121,5 @@ records › record_get_multiple
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 517
+ ;; custom section \"cmi\", size 562
 )

--- a/compiler/test/__snapshots__/records.02af5946.0.snapshot
+++ b/compiler/test/__snapshots__/records.02af5946.0.snapshot
@@ -61,5 +61,5 @@ records › record_definition_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1224
+ ;; custom section \"cmi\", size 1272
 )

--- a/compiler/test/__snapshots__/records.2dc39420.0.snapshot
+++ b/compiler/test/__snapshots__/records.2dc39420.0.snapshot
@@ -61,5 +61,5 @@ records › record_pun
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1160
+ ;; custom section \"cmi\", size 1208
 )

--- a/compiler/test/__snapshots__/records.49dfc6ff.0.snapshot
+++ b/compiler/test/__snapshots__/records.49dfc6ff.0.snapshot
@@ -156,5 +156,5 @@ records › record_destruct_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 598
+ ;; custom section \"cmi\", size 643
 )

--- a/compiler/test/__snapshots__/records.54f5977c.0.snapshot
+++ b/compiler/test/__snapshots__/records.54f5977c.0.snapshot
@@ -243,5 +243,5 @@ records › record_destruct_4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 598
+ ;; custom section \"cmi\", size 643
 )

--- a/compiler/test/__snapshots__/records.5f340064.0.snapshot
+++ b/compiler/test/__snapshots__/records.5f340064.0.snapshot
@@ -61,5 +61,5 @@ records › record_value_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1204
+ ;; custom section \"cmi\", size 1252
 )

--- a/compiler/test/__snapshots__/records.60c0a141.0.snapshot
+++ b/compiler/test/__snapshots__/records.60c0a141.0.snapshot
@@ -312,5 +312,5 @@ records › record_recursive_data_definition
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 561
+ ;; custom section \"cmi\", size 606
 )

--- a/compiler/test/__snapshots__/records.60c7acc4.0.snapshot
+++ b/compiler/test/__snapshots__/records.60c7acc4.0.snapshot
@@ -65,5 +65,5 @@ records › record_pun_mixed_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1651
+ ;; custom section \"cmi\", size 1702
 )

--- a/compiler/test/__snapshots__/records.63a951b8.0.snapshot
+++ b/compiler/test/__snapshots__/records.63a951b8.0.snapshot
@@ -156,5 +156,5 @@ records › record_destruct_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 598
+ ;; custom section \"cmi\", size 643
 )

--- a/compiler/test/__snapshots__/records.89d08e01.0.snapshot
+++ b/compiler/test/__snapshots__/records.89d08e01.0.snapshot
@@ -61,5 +61,5 @@ records › record_pun_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1196
+ ;; custom section \"cmi\", size 1244
 )

--- a/compiler/test/__snapshots__/records.98824516.0.snapshot
+++ b/compiler/test/__snapshots__/records.98824516.0.snapshot
@@ -177,5 +177,5 @@ records › record_destruct_deep
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 561
+ ;; custom section \"cmi\", size 606
 )

--- a/compiler/test/__snapshots__/records.a3299dd2.0.snapshot
+++ b/compiler/test/__snapshots__/records.a3299dd2.0.snapshot
@@ -185,5 +185,5 @@ records › record_destruct_3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 598
+ ;; custom section \"cmi\", size 643
 )

--- a/compiler/test/__snapshots__/records.a702778a.0.snapshot
+++ b/compiler/test/__snapshots__/records.a702778a.0.snapshot
@@ -151,5 +151,5 @@ records › record_get_multilevel
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 637
+ ;; custom section \"cmi\", size 682
 )

--- a/compiler/test/__snapshots__/records.a9c472b1.0.snapshot
+++ b/compiler/test/__snapshots__/records.a9c472b1.0.snapshot
@@ -96,5 +96,5 @@ records › record_multiple_fields_definition_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 2225
+ ;; custom section \"cmi\", size 2279
 )

--- a/compiler/test/__snapshots__/records.b50d234d.0.snapshot
+++ b/compiler/test/__snapshots__/records.b50d234d.0.snapshot
@@ -91,5 +91,5 @@ records › record_get_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 441
+ ;; custom section \"cmi\", size 486
 )

--- a/compiler/test/__snapshots__/records.d34c4740.0.snapshot
+++ b/compiler/test/__snapshots__/records.d34c4740.0.snapshot
@@ -65,5 +65,5 @@ records › record_pun_mixed
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1597
+ ;; custom section \"cmi\", size 1648
 )

--- a/compiler/test/__snapshots__/records.d393173c.0.snapshot
+++ b/compiler/test/__snapshots__/records.d393173c.0.snapshot
@@ -243,5 +243,5 @@ records › record_destruct_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 598
+ ;; custom section \"cmi\", size 643
 )

--- a/compiler/test/__snapshots__/records.d44e8007.0.snapshot
+++ b/compiler/test/__snapshots__/records.d44e8007.0.snapshot
@@ -65,5 +65,5 @@ records › record_pun_mixed_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1609
+ ;; custom section \"cmi\", size 1660
 )

--- a/compiler/test/__snapshots__/records.e4326567.0.snapshot
+++ b/compiler/test/__snapshots__/records.e4326567.0.snapshot
@@ -96,5 +96,5 @@ records › record_multiple_fields_both_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 2177
+ ;; custom section \"cmi\", size 2231
 )

--- a/compiler/test/__snapshots__/records.e5b56da8.0.snapshot
+++ b/compiler/test/__snapshots__/records.e5b56da8.0.snapshot
@@ -61,5 +61,5 @@ records › record_both_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1200
+ ;; custom section \"cmi\", size 1248
 )

--- a/compiler/test/__snapshots__/records.e705a980.0.snapshot
+++ b/compiler/test/__snapshots__/records.e705a980.0.snapshot
@@ -65,5 +65,5 @@ records › record_pun_multiple
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1615
+ ;; custom section \"cmi\", size 1666
 )

--- a/compiler/test/__snapshots__/records.f6e43cdb.0.snapshot
+++ b/compiler/test/__snapshots__/records.f6e43cdb.0.snapshot
@@ -65,5 +65,5 @@ records › record_pun_multiple_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1669
+ ;; custom section \"cmi\", size 1720
 )

--- a/compiler/test/__snapshots__/records.f6feee77.0.snapshot
+++ b/compiler/test/__snapshots__/records.f6feee77.0.snapshot
@@ -96,5 +96,5 @@ records › record_multiple_fields_value_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 2185
+ ;; custom section \"cmi\", size 2239
 )

--- a/compiler/test/__snapshots__/records.fae50a8e.0.snapshot
+++ b/compiler/test/__snapshots__/records.fae50a8e.0.snapshot
@@ -65,5 +65,5 @@ records › record_pun_mixed_2_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 1663
+ ;; custom section \"cmi\", size 1714
 )

--- a/compiler/test/__snapshots__/stdlib.179d20b9.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.179d20b9.0.snapshot
@@ -44,5 +44,5 @@ stdlib › stdlib_equal_4
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/stdlib.1c0b04b7.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.1c0b04b7.0.snapshot
@@ -186,5 +186,5 @@ stdlib › stdlib_equal_20
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 598
+ ;; custom section \"cmi\", size 643
 )

--- a/compiler/test/__snapshots__/stdlib.24cb9bbf.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.24cb9bbf.0.snapshot
@@ -100,5 +100,5 @@ stdlib › stdlib_equal_18
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/stdlib.323e410a.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.323e410a.0.snapshot
@@ -126,5 +126,5 @@ stdlib › stdlib_equal_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/stdlib.37483d2d.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.37483d2d.0.snapshot
@@ -190,5 +190,5 @@ stdlib › stdlib_cons
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/stdlib.4a5061c2.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.4a5061c2.0.snapshot
@@ -186,5 +186,5 @@ stdlib › stdlib_equal_19
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 598
+ ;; custom section \"cmi\", size 643
 )

--- a/compiler/test/__snapshots__/stdlib.5fe88631.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.5fe88631.0.snapshot
@@ -100,5 +100,5 @@ stdlib › stdlib_equal_16
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/stdlib.648f406e.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.648f406e.0.snapshot
@@ -124,5 +124,5 @@ stdlib › stdlib_equal_12
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/stdlib.69635cff.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.69635cff.0.snapshot
@@ -186,5 +186,5 @@ stdlib › stdlib_equal_21
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 598
+ ;; custom section \"cmi\", size 643
 )

--- a/compiler/test/__snapshots__/stdlib.6bf88430.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.6bf88430.0.snapshot
@@ -96,5 +96,5 @@ stdlib › stdlib_equal_15
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/stdlib.6de47be2.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.6de47be2.0.snapshot
@@ -96,5 +96,5 @@ stdlib › stdlib_equal_14
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/stdlib.8300ad7c.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.8300ad7c.0.snapshot
@@ -374,5 +374,5 @@ stdlib › stdlib_equal_3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/stdlib.91a94037.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.91a94037.0.snapshot
@@ -104,5 +104,5 @@ stdlib › stdlib_equal_11
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/stdlib.a70e79ca.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.a70e79ca.0.snapshot
@@ -96,5 +96,5 @@ stdlib › stdlib_equal_9
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/stdlib.b30d7785.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.b30d7785.0.snapshot
@@ -108,5 +108,5 @@ stdlib › stdlib_equal_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/stdlib.c09a513a.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.c09a513a.0.snapshot
@@ -44,5 +44,5 @@ stdlib › stdlib_equal_6
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/stdlib.cbf0318e.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.cbf0318e.0.snapshot
@@ -186,5 +186,5 @@ stdlib › stdlib_equal_22
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 598
+ ;; custom section \"cmi\", size 643
 )

--- a/compiler/test/__snapshots__/stdlib.d28dee65.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.d28dee65.0.snapshot
@@ -100,5 +100,5 @@ stdlib › stdlib_equal_10
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/stdlib.d4faa5bf.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.d4faa5bf.0.snapshot
@@ -92,5 +92,5 @@ stdlib › stdlib_equal_13
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/stdlib.d887bb04.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.d887bb04.0.snapshot
@@ -44,5 +44,5 @@ stdlib › stdlib_equal_7
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/stdlib.dae8b12a.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.dae8b12a.0.snapshot
@@ -44,5 +44,5 @@ stdlib › stdlib_equal_5
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/stdlib.e306600a.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.e306600a.0.snapshot
@@ -92,5 +92,5 @@ stdlib › stdlib_equal_8
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/stdlib.e6349872.0.snapshot
+++ b/compiler/test/__snapshots__/stdlib.e6349872.0.snapshot
@@ -100,5 +100,5 @@ stdlib › stdlib_equal_17
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/strings.434adad0.0.snapshot
+++ b/compiler/test/__snapshots__/strings.434adad0.0.snapshot
@@ -53,5 +53,5 @@ strings › string2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/strings.a67428df.0.snapshot
+++ b/compiler/test/__snapshots__/strings.a67428df.0.snapshot
@@ -53,5 +53,5 @@ strings › string1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/strings.b2ad5a89.0.snapshot
+++ b/compiler/test/__snapshots__/strings.b2ad5a89.0.snapshot
@@ -69,5 +69,5 @@ strings › string3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/strings.fb85549f.0.snapshot
+++ b/compiler/test/__snapshots__/strings.fb85549f.0.snapshot
@@ -100,5 +100,5 @@ strings › concat
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/tuples.1451773e.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.1451773e.0.snapshot
@@ -318,5 +318,5 @@ tuples › nested_tup_3
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/tuples.1d60b40c.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.1d60b40c.0.snapshot
@@ -219,5 +219,5 @@ tuples › nested_tup_1
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/tuples.2c91b91d.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.2c91b91d.0.snapshot
@@ -201,5 +201,5 @@ tuples › tup1_destruct_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/tuples.8d1f0463.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.8d1f0463.0.snapshot
@@ -61,5 +61,5 @@ tuples › tup1_trailing
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/tuples.a34621a0.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.a34621a0.0.snapshot
@@ -245,5 +245,5 @@ tuples › big_tup_access
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/tuples.b4f702d8.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.b4f702d8.0.snapshot
@@ -31,5 +31,5 @@ tuples › no_non_trailing_comma_singleton_tup
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/tuples.c1eb0a50.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.c1eb0a50.0.snapshot
@@ -318,5 +318,5 @@ tuples › nested_tup_2
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/__snapshots__/tuples.f206002b.0.snapshot
+++ b/compiler/test/__snapshots__/tuples.f206002b.0.snapshot
@@ -61,5 +61,5 @@ tuples › tup1_trailing_space
    (call $_gmain)
   )
  )
- ;; custom section \"cmi\", size 323
+ ;; custom section \"cmi\", size 368
 )

--- a/compiler/test/suites/crcs.re
+++ b/compiler/test/suites/crcs.re
@@ -1,0 +1,107 @@
+open Grain_tests.TestFramework;
+open Grain_tests.Runner;
+open Grain_utils;
+
+describe("cyclic redundancy checks", ({test}) => {
+  let assertMatchingCRCs = (~config_fn=?, name, program_str1, program_str2) => {
+    test(
+      name,
+      ({expect}) => {
+        let prog1 =
+          compile(
+            ~config_fn?,
+            ~hook=Grain.Compile.stop_after_typed,
+            name,
+            program_str1,
+          );
+        let prog2 =
+          compile(
+            ~config_fn?,
+            ~hook=Grain.Compile.stop_after_typed,
+            name,
+            program_str2,
+          );
+
+        let crc1 =
+          switch (prog1.cstate_desc) {
+          | TypeChecked(typed) => Digest.to_hex(typed.signature.cmi_crc)
+          | _ => failwith("impossible")
+          };
+        let crc2 =
+          switch (prog2.cstate_desc) {
+          | TypeChecked(typed) => Digest.to_hex(typed.signature.cmi_crc)
+          | _ => failwith("impossible")
+          };
+        expect.string(crc1).toEqual(crc2);
+      },
+    );
+  };
+
+  assertMatchingCRCs("test_empty_modules", "module Main", "module Main");
+  assertMatchingCRCs(
+    "test_same_module",
+    {|
+      module Main
+
+      provide let foo = 5
+      provide let bar = "string"
+
+      provide enum Foo {
+        Bar(String),
+        Qux{num: Number}
+      }
+
+      provide module Bar {
+        provide let baz = Bar("bar")
+      }
+    |},
+    {|
+      module Main
+
+      provide let foo = 5
+      provide let bar = "string"
+
+      provide enum Foo {
+        Bar(String),
+        Qux{num: Number}
+      }
+
+      provide module Bar {
+        provide let baz = Bar("bar")
+      }
+    |},
+  );
+  assertMatchingCRCs(
+    "test_different_module_same_interface",
+    {|
+      module Main
+
+      provide let foo = 5
+      provide let bar = "string"
+
+      provide enum Foo {
+        Bar(String),
+        Qux{num: Number}
+      }
+
+      provide module Bar {
+        provide let baz = Bar("bar")
+      }
+    |},
+    {|
+      module Main
+
+      provide let foo = 17
+      provide let bar = "different string"
+
+      provide enum Foo {
+        Bar(String),
+        Qux{num: Number}
+      }
+
+      provide module Bar {
+        provide let baz = Qux{num: 6}
+      }
+    |},
+  );
+});


### PR DESCRIPTION
Closes #1843

Ensures we always are keying off of object name & removes cache for out-of-date objects. Also ensures consistent CMIs on the first & subsequent builds.