### PR TITLE
feat(compiler): Enable single-file compilation

### DIFF
--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -189,6 +189,10 @@ program
   .description("compile a grain program into wasm")
   .forwardOption("-o <filename>", "output filename")
   .forwardOption(
+    "--single-file",
+    "compile a single file without compiling dependencies"
+  )
+  .forwardOption(
     "--use-start-section",
     "replaces the _start export with a start section during linking"
   )

--- a/compiler/graindoc/docblock.re
+++ b/compiler/graindoc/docblock.re
@@ -330,7 +330,7 @@ let get_comments_from_loc = (loc: Grain_parsing.Location.t) => {
   | Some(comments) => comments
   | None =>
     let comments =
-      switch (compile_file(~is_root_file=true, ~hook=stop_after_parse, file)) {
+      switch (compile_file(~hook=stop_after_parse, file)) {
       | exception exn => []
       | {cstate_desc: Parsed(parsed_program)} => parsed_program.comments
       | _ => failwith("Invalid compilation state")

--- a/compiler/src/codegen/linkedtree.re
+++ b/compiler/src/codegen/linkedtree.re
@@ -35,9 +35,7 @@ let internal_name = (id, dep_id) => {
   Printf.sprintf("%s_%d", id, dep_id);
 };
 
-let link = main_mashtree => {
-  let main_module = Module_resolution.current_filename^();
-
+let link = (~main_object, dependencies) => {
   let new_base_dir = Filepath.String.dirname;
 
   let resolve = (~base_dir=?, mod_name) =>
@@ -49,7 +47,6 @@ let link = main_mashtree => {
       Config.wasi_polyfill_path(),
     );
 
-  let dependencies = Module_resolution.get_dependencies();
   let dependencies =
     switch (wasi_polyfill) {
     | Some(polyfill) => [polyfill, ...dependencies]
@@ -210,7 +207,8 @@ let link = main_mashtree => {
       dependencies,
     );
 
-  let main_program = process_mashtree(~main=true, main_module, main_mashtree);
+  let main_mashtree = Emitmod.load_object(main_object);
+  let main_program = process_mashtree(~main=true, main_object, main_mashtree);
   let programs = List.rev([main_program, ...programs]);
   let num_function_table_elements = num_function_table_elements^;
   let signature = main_mashtree.signature;

--- a/compiler/src/compile.rei
+++ b/compiler/src/compile.rei
@@ -11,16 +11,12 @@ type compilation_state_desc =
   | Initial(input_source)
   | Parsed(Parsetree.parsed_program)
   | WellFormed(Parsetree.parsed_program)
-  | DependenciesCompiled(Parsetree.parsed_program)
   | TypeChecked(Typedtree.typed_program)
   | TypedWellFormed(Typedtree.typed_program)
   | Linearized(Anftree.anf_program)
   | Optimized(Anftree.anf_program)
   | Mashed(Mashtree.mash_program)
-  | ObjectEmitted(Mashtree.mash_program)
-  | ObjectsLinked(Linkedtree.linked_program)
-  | Compiled(Compmod.compiled_program)
-  | Assembled;
+  | ObjectEmitted;
 
 type compilation_state = {
   cstate_desc: compilation_state_desc,
@@ -58,27 +54,23 @@ let stop_after_mashed: compilation_state => compilation_action;
 
 let stop_after_object_emitted: compilation_state => compilation_action;
 
-let stop_after_compiled: compilation_state => compilation_action;
+let reset_compiler_state: unit => unit;
 
-let stop_after_assembled: compilation_state => compilation_action;
+let compile_wasi_polyfill: unit => unit;
 
 let compile_string:
   (
-    ~is_root_file: bool=?,
     ~hook: compilation_state => compilation_action=?,
     ~name: string=?,
     ~outfile: string=?,
-    ~reset: bool=?,
     string
   ) =>
   compilation_state;
 
 let compile_file:
   (
-    ~is_root_file: bool=?,
     ~hook: compilation_state => compilation_action=?,
     ~outfile: string=?,
-    ~reset: bool=?,
     string
   ) =>
   compilation_state;

--- a/compiler/src/formatting/fmt.re
+++ b/compiler/src/formatting/fmt.re
@@ -23,7 +23,6 @@ let parse_source = program_str => {
       let eol = Fs_access.determine_eol(List.nth_opt(lines, 0));
       let compile_state =
         Compile.compile_string(
-          ~is_root_file=true,
           ~hook=stop_after_parse,
           ~name=?None,
           program_str,

--- a/compiler/src/link.re
+++ b/compiler/src/link.re
@@ -1,0 +1,11 @@
+open Grain_codegen;
+
+let link = (~main_object, ~outfile, dependencies) => {
+  let linked_program = Linkedtree.link(~main_object, dependencies);
+  let compiled_program = Compmod.compile_wasm_module(linked_program);
+  Emitmod.emit_binary(
+    compiled_program.asm,
+    compiled_program.signature,
+    outfile,
+  );
+};

--- a/compiler/src/parsing/driver.re
+++ b/compiler/src/parsing/driver.re
@@ -203,6 +203,22 @@ let scan_for_imports =
   };
 };
 
+let scan_string_for_imports =
+    (~defer_errors=true, name: string, src: string): list(loc(string)) => {
+  let lexbuf = Sedlexing.Utf8.from_string(src);
+  try({
+    let source = () => src;
+    let prog = parse(~name, lexbuf, source);
+    read_imports(prog);
+  }) {
+  | e =>
+    if (!defer_errors) {
+      raise(e);
+    };
+    []; // <- defer parse error until we try to compile this dependency
+  };
+};
+
 let print_syntax_error =
   Printf.(
     Location.(

--- a/compiler/src/parsing/driver.rei
+++ b/compiler/src/parsing/driver.rei
@@ -9,4 +9,7 @@ let read_imports: Parsetree.parsed_program => list(Location.loc(string));
 let scan_for_imports:
   (~defer_errors: bool=?, string) => list(Location.loc(string));
 
+let scan_string_for_imports:
+  (~defer_errors: bool=?, string, string) => list(Location.loc(string));
+
 let reset: unit => unit;

--- a/compiler/src/typed/cmi_format.rei
+++ b/compiler/src/typed/cmi_format.rei
@@ -52,7 +52,8 @@ let read_cmi: string => cmi_infos;
 type error =
   | Not_an_interface(string)
   | Wrong_version_interface(string, string)
-  | Corrupted_interface(string);
+  | Corrupted_interface(string)
+  | Interface_file_not_found(string);
 
 exception Error(error);
 

--- a/compiler/src/typed/dependency_graph.rei
+++ b/compiler/src/typed/dependency_graph.rei
@@ -1,11 +1,10 @@
 module type Dependency_value = {
   type t;
   let get_dependencies: (t, string => option(t)) => list(t);
+  let get_srcname: t => string;
   let get_filename: t => string;
   let is_up_to_date: t => bool;
   let check_up_to_date: t => unit;
-  // Guaranteed to only be called when dependencies are compiled.
-  let compile_module: (~loc: Grain_parsing.Location.t=?, t) => unit;
   let compare: (t, t) => int;
   let hash: t => int;
   let equal: (t, t) => bool;
@@ -26,14 +25,14 @@ module Make:
     let lookup_filename: string => option(DV.t);
 
     /**
-   Compiles the full dependency graph.
-   */
-    let compile_graph: unit => unit;
-
-    /**
    Returns a topologically sorted list of all dependencies.
    */
     let get_dependencies: unit => list(string);
+
+    /**
+   Returns a topologically sorted list of out of date dependencies.
+   */
+    let get_out_of_date_dependencies: unit => list(string);
 
     /**
    Dumps the edges in this graph to stderr.

--- a/compiler/src/typed/env.re
+++ b/compiler/src/typed/env.re
@@ -721,7 +721,7 @@ let clear_imports = () => {
 let clear_persistent_structures = () => {
   Consistbl.clear(crc_units);
   Hashtbl.clear(persistent_structures);
-  imported_units := StringSet.empty;
+  clear_imports();
 };
 
 let check_consistency = ps =>

--- a/compiler/src/typed/env.re
+++ b/compiler/src/typed/env.re
@@ -714,27 +714,14 @@ let add_import = s => {
   imported_units := StringSet.add(s, imported_units^);
 };
 
-let imported_opaque_units = ref(StringSet.empty);
-
-let add_imported_opaque = s =>
-  imported_opaque_units := StringSet.add(s, imported_opaque_units^);
-
-let with_cleared_imports = thunk => {
-  let old_imported_units = imported_units^;
-  let old_opaque_units = imported_opaque_units^;
+let clear_imports = () => {
   imported_units := StringSet.empty;
-  imported_opaque_units := StringSet.empty;
-  let ret = thunk();
-  imported_units := old_imported_units;
-  imported_opaque_units := old_opaque_units;
-  ret;
 };
 
-let clear_imports = () => {
+let clear_persistent_structures = () => {
   Consistbl.clear(crc_units);
   Hashtbl.clear(persistent_structures);
   imported_units := StringSet.empty;
-  imported_opaque_units := StringSet.empty;
 };
 
 let check_consistency = ps =>
@@ -759,12 +746,6 @@ let check_consistency = ps =>
 
 let save_pers_struct = ps => {
   Hashtbl.add(persistent_structures, ps.ps_filename, Some(ps));
-  List.iter(
-    fun
-    | Unsafe_string => ()
-    | Opaque => add_imported_opaque(ps.ps_filename),
-    ps.ps_flags,
-  );
 };
 
 let get_dependency_chain = (~loc, unit_name) => {
@@ -855,7 +836,7 @@ let acknowledge_pers_struct = (check, {Persistent_signature.filename, cmi}) => {
         let (unit_name, _) = get_unit();
         error(Depend_on_unsafe_string_unit(ps.ps_name, unit_name));
       }
-    | Opaque => add_imported_opaque(filename),
+    | Opaque => (),
     ps.ps_flags,
   );
   if (check) {
@@ -2276,9 +2257,6 @@ let imports = () => {
   );
 };
 
-/* Returns true if [s] is an imported opaque module */
-let is_imported_opaque = s => StringSet.mem(s, imported_opaque_units^);
-
 /* Build a module signature */
 let build_signature_with_imports =
     (~deprecated=?, sg, modname, filename, imports, type_metadata) => {
@@ -2598,35 +2576,6 @@ let () =
   );
 
 let () = {
-  Module_resolution.with_preserve_unit :=
-    (
-      (~loc, unit_name, srcpath, thunk) => {
-        mark_in_progress(~loc, unit_name, srcpath);
-        let saved_unit = get_unit();
-        let saved = Ident.save_state();
-        let cleanup = () => {
-          Ident.restore_state(saved);
-          set_unit(saved_unit);
-          mark_completed(unit_name, srcpath);
-        };
-        try({
-          let ret = with_cleared_imports(thunk);
-          cleanup();
-          ret;
-        }) {
-        | e =>
-          cleanup();
-          raise(e);
-        };
-      }
-    );
-  Module_resolution.current_unit_name :=
-    (
-      () => {
-        let (uname, _) = get_unit();
-        uname;
-      }
-    );
   Module_resolution.current_filename :=
     (
       () => {

--- a/compiler/src/typed/env.rei
+++ b/compiler/src/typed/env.rei
@@ -206,9 +206,6 @@ let crc_of_unit: string => Digest.t;
 
 let imports: unit => list((string, Digest.t));
 
-/* [is_imported_opaque md] returns true if [md] is an opaque imported module  */
-let is_imported_opaque: string => bool;
-
 /* Direct access to the table of imported compilation units with their CRC */
 
 module Consistbl: (module type of {
@@ -218,6 +215,7 @@ module Consistbl: (module type of {
 let crc_units: Consistbl.t;
 let add_import: string => unit;
 let clear_imports: unit => unit;
+let clear_persistent_structures: unit => unit;
 
 /* By-name insertions */
 /** Adds a value identifier with the given name and description.

--- a/compiler/src/typed/module_resolution.rei
+++ b/compiler/src/typed/module_resolution.rei
@@ -15,23 +15,17 @@ let resolve_unit:
   ) =>
   string;
 
-let compile_module_dependency: ref((string, string) => unit);
-
-let compile_dependency_graph:
-  (~base_file: string, list(Grain_parsing.Location.loc(string))) => unit;
+let load_dependency_graph: string => unit;
+let load_dependency_graph_from_string: (string, string) => unit;
 
 let read_file_cmi: string => Cmi_format.cmi_infos;
 
 let clear_dependency_graph: unit => unit;
 
-// Patched in by env.re:
-let with_preserve_unit:
-  ref((~loc: Grain_parsing.Location.t, string, string, unit => unit) => unit);
-
-let current_unit_name: ref(unit => string);
-
 let current_filename: ref(unit => string);
 
 let get_dependencies: unit => list(string);
+
+let get_out_of_date_dependencies: unit => list(string);
 
 let dump_dependency_graph: unit => unit;

--- a/compiler/src/typed/typemod.re
+++ b/compiler/src/typed/typemod.re
@@ -1051,6 +1051,7 @@ let initial_env = () => {
 let type_implementation = (prog: Parsetree.parsed_program) => {
   let sourcefile = prog.prog_loc.loc_start.pos_fname;
   let module_name = prog.module_name.txt;
+  Env.clear_imports();
   Env.set_unit((module_name, sourcefile));
   let initenv = initial_env();
   let (statements, sg, finalenv) = type_module(initenv, prog.statements);

--- a/compiler/test/suites/foreigns.re
+++ b/compiler/test/suites/foreigns.re
@@ -7,6 +7,7 @@ describe("foreigns", ({test}) => {
     let outfile = wasmfile(name);
     ignore @@
     compile(
+      ~link=true,
       name,
       {|
       module Test

--- a/compiler/test/suites/includes.re
+++ b/compiler/test/suites/includes.re
@@ -213,7 +213,7 @@ describe("includes", ({test, testSkip}) => {
     let outfile = wasmfile(name);
     ignore @@
     compile(
-      ~hook=Grain.Compile.stop_after_assembled,
+      ~link=true,
       name,
       {|
       module DeDupeIncludes

--- a/compiler/test/suites/linking.re
+++ b/compiler/test/suites/linking.re
@@ -54,7 +54,8 @@ describe("linking", ({test, testSkip}) => {
   test("no_start_section", ({expect}) => {
     let name = "no_start_section";
     let outfile = wasmfile(name);
-    ignore @@ compile(name, {|module Test; print("Hello, world!")|});
+    ignore @@
+    compile(~link=true, name, {|module Test; print("Hello, world!")|});
     let ic = open_in_bin(outfile);
     let sections = Grain_utils.Wasm_utils.get_wasm_sections(ic);
     close_in(ic);
@@ -90,6 +91,7 @@ describe("linking", ({test, testSkip}) => {
     ignore @@
     compile(
       ~config_fn=() => {Grain_utils.Config.use_start_section := true},
+      ~link=true,
       name,
       {|module Test; print("Hello, world!")|},
     );
@@ -128,6 +130,7 @@ describe("linking", ({test, testSkip}) => {
     ignore @@
     compile(
       ~config_fn=() => {Grain_utils.Config.import_memory := true},
+      ~link=true,
       name,
       {|module Test; print("Hello, world!")|},
     );

--- a/compiler/test/suites/modules.re
+++ b/compiler/test/suites/modules.re
@@ -1,5 +1,7 @@
 open Grain_tests.TestFramework;
 open Grain_tests.Runner;
+open Grain_codegen;
+open Grain_typed;
 
 describe("modules", ({test, testSkip}) => {
   let test_or_skip =
@@ -129,17 +131,14 @@ describe("modules", ({test, testSkip}) => {
   test("reprovided_module", ({expect}) => {
     let name = "reprovided_module";
     let outfile = wasmfile(name);
-    ignore @@
-    compile(
-      ~hook=Grain.Compile.stop_after_assembled,
-      name,
-      {|
+    let prog = {|
       module ReprovidedSimple
 
       from "simpleModule" include Simple
       provide { module Simple }
-      |},
-    );
+    |};
+    ignore @@ compile(~link=true, name, prog);
+
     let ic = open_in_bin(outfile);
     let sections = Grain_utils.Wasm_utils.get_wasm_sections(ic);
     close_in(ic);


### PR DESCRIPTION
Refactors the `DependenciesCompiled`, `ObjectsLinked`, `Compiled`, and `Assembled` states out of `compile.re` and introduces the `grainc` flag `--single-file` to compile a single dependency. The linker is now completely separate from the process of compilation—compiling a file now only means converting source code into an object file. Linking is the combining a number of object files into a wasm file (and `grainc` will still do both compiling and linking). This allows build tools to handle compilation and linking separately.

The future plan is to make single file mode the default once we have a build tool managing building projects (`silo`). I'm not sure that we should get rid of the dependency compilation _entirely_ since it would be useful for development, but that's a decision for later.