### PR TITLE
chore(compiler): Stabilize snapshots

### DIFF
--- a/compiler/test/suites/optimizations.re
+++ b/compiler/test/suites/optimizations.re
@@ -5,6 +5,9 @@ open Grain_middle_end.Anf_helper;
 open Grain_utils;
 open Grain_parsing;
 
+// Prevent updating stamps for consistent snapshots
+let gensym = Grain_typed.Ident.(name => {name, stamp: 0, flags: 0});
+
 describe("optimizations", ({test, testSkip}) => {
   let test_or_skip =
     Sys.backend_type == Other("js_of_ocaml") ? testSkip : test;
@@ -150,7 +153,7 @@ describe("optimizations", ({test, testSkip}) => {
     "((x) => {\n    let x = 4;\n    let y = x;\n    x})",
     {
       open Grain_typed;
-      let x = Ident.create("lambda_arg");
+      let x = gensym("lambda_arg");
       AExp.comp(
         ~loc=Location.dummy_loc,
         Comp.lambda(
@@ -208,7 +211,7 @@ describe("optimizations", ({test, testSkip}) => {
     "((x) => {let a = (x, 1); let b = (x, 1); (x, 1)})",
     {
       open Grain_typed;
-      let arg = Ident.create("lambda_arg");
+      let arg = gensym("lambda_arg");
       AExp.comp(
         ~loc=Location.dummy_loc,
         Comp.lambda(~loc=Location.dummy_loc, [(arg, Managed)]) @@
@@ -236,7 +239,7 @@ describe("optimizations", ({test, testSkip}) => {
     "((x) => {1})",
     {
       open Grain_typed;
-      let x = Ident.create("lambda_arg");
+      let x = gensym("lambda_arg");
       AExp.comp(
         ~loc=Location.dummy_loc,
         Comp.lambda(
@@ -265,8 +268,8 @@ describe("optimizations", ({test, testSkip}) => {
     "provide let foo = () => {let mut x = 5; x = 6}",
     {
       open Grain_typed;
-      let foo = Ident.create("foo");
-      let x = Ident.create("x");
+      let foo = gensym("foo");
+      let x = gensym("x");
       AExp.let_(
         ~loc=Location.dummy_loc,
         Nonrecursive,
@@ -330,9 +333,9 @@ describe("optimizations", ({test, testSkip}) => {
     "provide let bar = () => { let mut x = 5; let foo = () => x; foo() }",
     {
       open Grain_typed;
-      let x = Ident.create("x");
-      let bar = Ident.create("bar");
-      let foo = Ident.create("foo");
+      let x = gensym("x");
+      let bar = gensym("bar");
+      let foo = gensym("foo");
       AExp.let_(
         ~loc=Location.dummy_loc,
         Nonrecursive,
@@ -420,10 +423,10 @@ describe("optimizations", ({test, testSkip}) => {
     "{\n    let x = 5;\n    let foo = ((y) => {y});\n    let y = (3, 5);\n    foo(3) + x}",
     {
       open Grain_typed;
-      let plus = Ident.create("+");
-      let foo = Ident.create("foo");
-      let arg = Ident.create("lambda_arg");
-      let app = Ident.create("app");
+      let plus = gensym("+");
+      let foo = gensym("foo");
+      let arg = gensym("lambda_arg");
+      let app = gensym("app");
       AExp.let_(
         ~loc=Location.dummy_loc,
         Nonrecursive,
@@ -529,10 +532,10 @@ describe("optimizations", ({test, testSkip}) => {
     |},
     {
       open Grain_typed;
-      let plus = Ident.create("+");
-      let foo = Ident.create("foo");
-      let arg = Ident.create("lambda_arg");
-      let app = Ident.create("app");
+      let plus = gensym("+");
+      let foo = gensym("foo");
+      let arg = gensym("lambda_arg");
+      let app = gensym("app");
       AExp.let_(
         ~loc=Location.dummy_loc,
         ~global=Global,
@@ -616,9 +619,9 @@ describe("optimizations", ({test, testSkip}) => {
     |},
     {
       open Grain_typed;
-      let foo = Ident.create("foo");
-      let fill = Ident.create("fill");
-      let copy = Ident.create("copy");
+      let foo = gensym("foo");
+      let fill = gensym("fill");
+      let copy = gensym("copy");
       AExp.let_(
         ~loc=Location.dummy_loc,
         ~global=Global,
@@ -716,7 +719,7 @@ describe("optimizations", ({test, testSkip}) => {
     |},
     {
       open Grain_typed;
-      let foo = Ident.create("foo");
+      let foo = gensym("foo");
       AExp.let_(
         ~loc=Location.dummy_loc,
         ~global=Global,


### PR DESCRIPTION
Depending on the order the test suites are run, calling `Ident.create` in the tests will change what stamps idents in further tests get, which can cause snapshot tests to fail. This prevents stamp changes.