### PR TITLE
chore(stdlib): Removed redundant for-loop in `Set.intersect`

### DIFF
--- a/stdlib/set.gr
+++ b/stdlib/set.gr
@@ -445,11 +445,6 @@ provide let intersect = (set1, set2) => {
       add(key, set)
     }
   }, set1)
-  forEach(key => {
-    if (contains(key, set1)) {
-      add(key, set)
-    }
-  }, set2)
   set
 }
 


### PR DESCRIPTION
Fixes #2110. I didn't compile nor test this change.