### PR TITLE
chore(stdlib): Correct typo in `Int8` doc example

### DIFF
--- a/stdlib/int8.gr
+++ b/stdlib/int8.gr
@@ -433,7 +433,7 @@ provide let (>=) = (x: Int8, y: Int8) => {
  * @param value: The given value
  * @returns Containing the inverted bits of the given value
  *
- * @example Int.lnot(-5s) == 4s
+ * @example Int8.lnot(-5s) == 4s
  *
  * @since v0.6.0
  */

--- a/stdlib/int8.md
+++ b/stdlib/int8.md
@@ -682,7 +682,7 @@ Returns:
 Examples:
 
 ```grain
-Int.lnot(-5s) == 4s
+Int8.lnot(-5s) == 4s
 ```
 
 ### Int8.**(&)**


### PR DESCRIPTION
Small pr fixing a tiny typo in one of the examples in the `Int8` docs.