### PR TITLE
chore(stdlib): Add history item to `print` for `suffix` change

### DIFF
--- a/stdlib/pervasives.md
+++ b/stdlib/pervasives.md
@@ -855,9 +855,16 @@ Returns:
 
 ### Pervasives.**print**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.1.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>0.1.0</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.6.0</code></td><td>Added support for custom suffixes</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain

--- a/stdlib/runtime/string.gr
+++ b/stdlib/runtime/string.gr
@@ -855,6 +855,7 @@ provide let toString = value => {
  * @param suffix: The string to print after the argument
  *
  * @since v0.1.0
+ * @history v0.6.0: Added support for custom suffixes
  */
 @unsafe
 provide let print = (value, suffix="\n") => {

--- a/stdlib/runtime/string.md
+++ b/stdlib/runtime/string.md
@@ -66,9 +66,16 @@ Returns:
 
 ### String.**print**
 
-<details disabled>
-<summary tabindex="-1">Added in <code>0.1.0</code></summary>
-No other changes yet.
+<details>
+<summary>Added in <code>0.1.0</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.6.0</code></td><td>Added support for custom suffixes</td></tr>
+</tbody>
+</table>
 </details>
 
 ```grain


### PR DESCRIPTION
I noticed we never added a `history` attribute to `print` when we added the `suffix` argument in `v0.6.0`