### PR TITLE
feat(compiler): Add support for `Number[]` and `Number[>]` syntax

### DIFF
--- a/compiler/src/parsing/ast_helper.re
+++ b/compiler/src/parsing/ast_helper.re
@@ -89,6 +89,10 @@ module Type = {
   let var = (~loc, a) => mk(~loc, PTyVar(a));
   let arrow = (~loc, a, b) => mk(~loc, PTyArrow(a, b));
   let tuple = (~loc, a) => mk(~loc, PTyTuple(a));
+  let list = (~loc, a) =>
+    mk(~loc, PTyConstr({txt: Identifier.parse("List"), loc}, [a]));
+  let array = (~loc, a) =>
+    mk(~loc, PTyConstr({txt: Identifier.parse("Array"), loc}, [a]));
   let constr = (~loc, a, b) => mk(~loc, PTyConstr(a, b));
   let poly = (~loc, a, b) => mk(~loc, PTyPoly(a, b));
 

--- a/compiler/src/parsing/ast_helper.rei
+++ b/compiler/src/parsing/ast_helper.rei
@@ -62,6 +62,8 @@ module Type: {
   let arrow:
     (~loc: loc, list(parsed_type_argument), parsed_type) => parsed_type;
   let tuple: (~loc: loc, list(parsed_type)) => parsed_type;
+  let list: (~loc: loc, parsed_type) => parsed_type;
+  let array: (~loc: loc, parsed_type) => parsed_type;
   let constr: (~loc: loc, id, list(parsed_type)) => parsed_type;
   let poly: (~loc: loc, list(str), parsed_type) => parsed_type;
   let force_poly: parsed_type => parsed_type;

--- a/compiler/src/parsing/parser.mly
+++ b/compiler/src/parsing/parser.mly
@@ -330,6 +330,8 @@ typ:
   | lparen tuple_typs rparen { Type.tuple ~loc:(to_loc $loc) $2 }
   | lparen typ rparen { $2 }
   | LIDENT { Type.var ~loc:(to_loc $loc) $1 }
+  | data_typ lbrack rbrack { Type.list ~loc:(to_loc $loc) $1 }
+  | data_typ lbrackrcaret rbrack { Type.array ~loc:(to_loc $loc) $1 }
   | data_typ { $1 }
 
 arg_typ:


### PR DESCRIPTION
This pr adds shorthand syntax for `list` and `array` types which is discussed in #387, I think if we want the `?` and `!` shorthands we should have some more discussion, but the list and array syntax seem generalized enough that it is worth having. As far as I am aware this pr is non breaking because the old syntax still works. The syntax can be seen below:
* `List<Number>` becomes `Number[]`
* `Array<Number>` becomes `Array[>]`

This pr is not ready to be merged as I still need to add tests, make sure the formatter handles this correctly and make sure types get stringified using the shorthand in the lsp and graindoc. I am putting this pr before doing that as I want to make sure that we are okay with doing handling this in the parser instead of adding a parseTree element, given this is syntax sugar it seemed like the best option.

Currently this pr is not breaking as far as I am aware given we do not remove the `List<Number>` syntax and this would have been completely invalid syntax before.