### PR TITLE
feat(compiler): Ignore compiler warnings

### DIFF
--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -153,6 +153,12 @@ class GrainCommand extends commander.Command {
       "--verbose",
       "print critical information at various stages of compilation"
     );
+    cmd.forwardOption(
+      "--ignore-warnings <warnings>",
+      "compiler warnings to ignore",
+      list,
+      []
+    );
     return cmd;
   }
 }

--- a/compiler/src/utils/config.re
+++ b/compiler/src/utils/config.re
@@ -398,6 +398,61 @@ let import_memory =
     false,
   );
 
+type ignore_warning =
+  | IgnoreAll
+  | LetRecNonFunction
+  | AmbiguousName
+  | StatementType
+  | NonreturningStatement
+  | AllClausesGuarded
+  | PartialMatch
+  | UnusedMatch
+  | UnusedPat
+  | NonClosedRecordPattern
+  | UnreachableCase
+  | ShadowConstructor
+  | NoCmiFile
+  | FuncWasmUnsafe
+  | FromNumberLiteral
+  | UselessRecordSpread
+  | PrintUnsafe
+  | ToStringUnsafe
+  | ArrayIndexNonInteger;
+
+let ignore_warnings =
+  opt(
+    ~names=["ignore-warnings"],
+    ~conv=
+      Cmdliner.Arg.(
+        list(
+          enum([
+            ("all", IgnoreAll),
+            ("letRecNonFunction", LetRecNonFunction),
+            ("ambiguousName", AmbiguousName),
+            ("statementType", StatementType),
+            ("nonreturningStatement", NonreturningStatement),
+            ("allClausesGuarded", AllClausesGuarded),
+            ("partialMatch", PartialMatch),
+            ("unusedMatch", UnusedMatch),
+            ("unusedPat", UnusedPat),
+            ("nonClosedRecordPattern", NonClosedRecordPattern),
+            ("unreachableCase", UnreachableCase),
+            ("shadowConstructor", ShadowConstructor),
+            ("noCmiFile", NoCmiFile),
+            ("funcWasmUnsafe", FuncWasmUnsafe),
+            ("fromNumberLiteral", FromNumberLiteral),
+            ("uselessRecordSpread", UselessRecordSpread),
+            ("printUnsafe", PrintUnsafe),
+            ("toStringUnsafe", ToStringUnsafe),
+            ("arrayIndexNonInteger", ArrayIndexNonInteger),
+          ]),
+        )
+      ),
+    ~doc="Compiler warnings to ignore",
+    ~digestible=NotDigestible,
+    [],
+  );
+
 type compilation_mode =
   | Normal /* Standard compilation with regular bells and whistles */
   | Runtime /* GC doesn't exist yet, allocations happen in runtime heap */;

--- a/compiler/src/utils/config.rei
+++ b/compiler/src/utils/config.rei
@@ -5,6 +5,27 @@ type compilation_mode =
   | Normal /* Standard compilation with regular bells and whistles */
   | Runtime /* GC doesn't exist yet, allocations happen in runtime heap */;
 
+type ignore_warning =
+  | IgnoreAll
+  | LetRecNonFunction
+  | AmbiguousName
+  | StatementType
+  | NonreturningStatement
+  | AllClausesGuarded
+  | PartialMatch
+  | UnusedMatch
+  | UnusedPat
+  | NonClosedRecordPattern
+  | UnreachableCase
+  | ShadowConstructor
+  | NoCmiFile
+  | FuncWasmUnsafe
+  | FromNumberLiteral
+  | UselessRecordSpread
+  | PrintUnsafe
+  | ToStringUnsafe
+  | ArrayIndexNonInteger;
+
 /** The Grain stdlib directory, based on the current configuration */
 let stdlib_directory: unit => option(string);
 
@@ -81,6 +102,10 @@ let maximum_memory_pages: ref(option(int));
 /** Import the memory from `env.memory` */
 
 let import_memory: ref(bool);
+
+/** Compiler warnings to ignore */
+
+let ignore_warnings: ref(list(ignore_warning));
 
 /** Whether this module should be compiled in runtime mode */
 

--- a/compiler/test/runner.re
+++ b/compiler/test/runner.re
@@ -269,21 +269,22 @@ let makeCompileErrorRunner =
 };
 
 let makeWarningRunner =
-    (test, ~module_header=module_header, name, prog, warning) => {
+    (test, ~config_fn=?, ~module_header=module_header, name, prog, warning) => {
   test(name, ({expect}) => {
     Config.preserve_all_configs(() => {
       Config.print_warnings := false;
-      ignore @@ compile(name, module_header ++ prog);
+      ignore @@ compile(name, ~config_fn?, module_header ++ prog);
       expect.ext.warning.toHaveTriggered(warning);
     })
   });
 };
 
-let makeNoWarningRunner = (test, ~module_header=module_header, name, prog) => {
+let makeNoWarningRunner =
+    (test, ~config_fn=?, ~module_header=module_header, name, prog) => {
   test(name, ({expect}) => {
     Config.preserve_all_configs(() => {
       Config.print_warnings := false;
-      ignore @@ compile(name, module_header ++ prog);
+      ignore @@ compile(name, ~config_fn?, module_header ++ prog);
       expect.ext.warning.toHaveTriggeredNoWarnings();
     })
   });

--- a/compiler/test/suites/ignore_warnings.re
+++ b/compiler/test/suites/ignore_warnings.re
@@ -1,0 +1,72 @@
+open Grain_tests.TestFramework;
+open Grain_tests.Runner;
+open Grain_utils;
+
+let {describe} =
+  describeConfig |> withCustomMatchers(customMatchers) |> build;
+
+describe("ignore warnings", ({test, testSkip}) => {
+  let assertWarning = makeWarningRunner(test);
+  let assertNoWarning = makeNoWarningRunner(test);
+
+  let assertWarningFlag = (name, code, config_warning, expected_warning) => {
+    assertWarning(
+      ~config_fn=() => {Config.ignore_warnings := []},
+      name,
+      code,
+      expected_warning,
+    );
+
+    assertNoWarning(
+      ~config_fn=() => {Config.ignore_warnings := [config_warning]},
+      name,
+      code,
+    );
+  };
+
+  assertWarningFlag(
+    "warning_match",
+    {|
+    match (true) {
+      true => void
+    }
+    |},
+    Config.PartialMatch,
+    Warnings.PartialMatch("false"),
+  );
+
+  assertWarningFlag(
+    "warning_match_all_ignored",
+    {|
+    match (true) {
+      true => void
+    }
+    |},
+    Config.IgnoreAll,
+    Warnings.PartialMatch("false"),
+  );
+
+  assertWarningFlag(
+    "warning_useless_record_spread",
+    {|
+    record R { x: Number }
+    let r = { x: 1 }
+    let r2 = { ...r, x: 2 }
+    |},
+    Config.UselessRecordSpread,
+    Warnings.UselessRecordSpread,
+  );
+
+  assertWarningFlag(
+    "warning_print_unsafe",
+    {|
+    @unsafe
+    let f = () => {
+      let a = 1n
+      print(a)
+    }
+    |},
+    Config.PrintUnsafe,
+    Warnings.PrintUnsafe("I32"),
+  );
+});


### PR DESCRIPTION
```grain
match (true) {
  true => void
}
let a = [> 1, 2]
a[1.5]
```
```bash
# will warn
grain compile main.gr
# will not warn
grain compile main.gr --ignore-warnings=all
grain compile main.gr --ignore-warnings=partialMatch,arrayIndexNonInteger
```

Closes #163 