### PR TITLE
feat(runtime): Simplify `copy` and `fill` polyfills in `Memory` module

### DIFF
--- a/stdlib/runtime/unsafe/memory.gr
+++ b/stdlib/runtime/unsafe/memory.gr
@@ -4,10 +4,17 @@ module Memory
 from "runtime/gc" include GC
 use GC.{ malloc, free, incRef, decRef }
 from "runtime/unsafe/wasmi32" include WasmI32
-use WasmI32.{ (+), (-), (<<), (==), (!=), ltU as (<), gtU as (>) }
+use WasmI32.{ (+), (-), (!=), ltU as (<), gtU as (>) }
 
 provide { malloc, free, incRef, decRef }
 
+/**
+ * Copies the given memory region into the given destination.
+ *
+ * @param dest: The destination memory region
+ * @param src: The source memory region
+ * @param length: The length of the memory region to copy
+ */
 provide let copy = (dest, src, length) => {
   if (dest != src) {
     if (dest < src) {
@@ -23,9 +30,16 @@ provide let copy = (dest, src, length) => {
   }
 }
 
-provide let fill = (dest, c, n) => {
-  for (let mut i = 0n; i < n; i += 1n) {
-    WasmI32.store8(dest, c, i)
+/**
+ * Fills the given memory region with the given value.
+ *
+ * @param dest: The destination memory region
+ * @param value: The value to fill the memory region with
+ * @param length: The length of the memory region to fill
+ */
+provide let fill = (dest, value, length) => {
+  for (let mut i = 0n; i < length; i += 1n) {
+    WasmI32.store8(dest, value, i)
   }
 }
 

--- a/stdlib/runtime/unsafe/memory.gr
+++ b/stdlib/runtime/unsafe/memory.gr
@@ -4,38 +4,28 @@ module Memory
 from "runtime/gc" include GC
 use GC.{ malloc, free, incRef, decRef }
 from "runtime/unsafe/wasmi32" include WasmI32
-use WasmI32.{ (+), (-), (<<), (==), (!=), ltU as (<) }
+use WasmI32.{ (+), (-), (<<), (==), (!=), ltU as (<), gtU as (>) }
 
 provide { malloc, free, incRef, decRef }
 
-provide let copy = (dest, src, n) => {
-  let mut dest = dest
-  let mut src = src
-  let mut n = n
+provide let copy = (dest, src, length) => {
   if (dest != src) {
     if (dest < src) {
-      while (n != 0n) {
-        WasmI32.store8(dest, WasmI32.load8U(src, 0n), 0n)
-        dest += 1n
-        src += 1n
-        n -= 1n
+      for (let mut i = 0n; i < length; i += 1n) {
+        WasmI32.store8(dest, WasmI32.load8U(src, i), i)
       }
     } else {
-      while (n != 0n) {
-        n -= 1n
-        WasmI32.store8(dest + n, WasmI32.load8U(src + n, 0n), 0n)
+      // Copy backwards to ensure we do not overwrite on overlapping regions
+      for (let mut n = length; n > 0n; n -= 1n) {
+        WasmI32.store8(dest + n - 1n, WasmI32.load8U(src + n - 1n, 0n), 0n)
       }
     }
   }
 }
 
 provide let fill = (dest, c, n) => {
-  let mut dest = dest
-  let mut n = n
-  while (n != 0n) {
-    WasmI32.store8(dest, c, 0n)
-    dest += 1n
-    n -= 1n
+  for (let mut i = 0n; i < n; i += 1n) {
+    WasmI32.store8(dest, c, i)
   }
 }
 

--- a/stdlib/runtime/unsafe/memory.gr
+++ b/stdlib/runtime/unsafe/memory.gr
@@ -9,7 +9,7 @@ use WasmI32.{ (+), (-), (!=), ltU as (<), gtU as (>) }
 provide { malloc, free, incRef, decRef }
 
 /**
- * Copies the given memory region into the given destination.
+ * Copies the source memory region to the destination memory region. Regions may overlap.
  *
  * @param dest: The destination memory region
  * @param src: The source memory region
@@ -31,7 +31,7 @@ provide let copy = (dest, src, length) => {
 }
 
 /**
- * Fills the given memory region with the given value.
+ * Fills the given memory region with the given 1-byte value. Values larger than 1 byte will be truncated.
  *
  * @param dest: The destination memory region
  * @param value: The value to fill the memory region with

--- a/stdlib/runtime/unsafe/memory.md
+++ b/stdlib/runtime/unsafe/memory.md
@@ -33,14 +33,34 @@ decRef : (userPtr: WasmI32) => WasmI32
 ### Memory.**copy**
 
 ```grain
-copy : (dest: WasmI32, src: WasmI32, n: WasmI32) => Void
+copy : (dest: WasmI32, src: WasmI32, length: WasmI32) => Void
 ```
+
+Copies the given memory region into the given destination.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`dest`|`WasmI32`|The destination memory region|
+|`src`|`WasmI32`|The source memory region|
+|`length`|`WasmI32`|The length of the memory region to copy|
 
 ### Memory.**fill**
 
 ```grain
-fill : (dest: WasmI32, c: WasmI32, n: WasmI32) => Void
+fill : (dest: WasmI32, value: WasmI32, length: WasmI32) => Void
 ```
+
+Fills the given memory region with the given value.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`dest`|`WasmI32`|The destination memory region|
+|`value`|`WasmI32`|The value to fill the memory region with|
+|`length`|`WasmI32`|The length of the memory region to fill|
 
 ### Memory.**compare**
 

--- a/stdlib/runtime/unsafe/memory.md
+++ b/stdlib/runtime/unsafe/memory.md
@@ -36,7 +36,7 @@ decRef : (userPtr: WasmI32) => WasmI32
 copy : (dest: WasmI32, src: WasmI32, length: WasmI32) => Void
 ```
 
-Copies the given memory region into the given destination.
+Copies the source memory region to the destination memory region. Regions may overlap.
 
 Parameters:
 
@@ -52,7 +52,7 @@ Parameters:
 fill : (dest: WasmI32, value: WasmI32, length: WasmI32) => Void
 ```
 
-Fills the given memory region with the given value.
+Fills the given memory region with the given 1-byte value. Values larger than 1 byte will be truncated.
 
 Parameters:
 


### PR DESCRIPTION
This pr simplifies the `Memory.copy` and `Memory.fill` polyfills in `Memory.gr`, I implemented them using a `for` loop as it means less mutable variables compared to the while loop approach and makes the code a lot easier to follow.

Additionally this removes a few operations per cycle on the functions as we are not modifying as many values every iteration.