### PR TITLE
fix(compiler): Correct type approximation on recursive functions

### DIFF
--- a/compiler/src/typed/typecore.re
+++ b/compiler/src/typed/typecore.re
@@ -635,7 +635,14 @@ let rec type_approx = (env, sexp: Parsetree.expression) =>
   | PExpLambda(args, e) =>
     newty(
       TTyArrow(
-        List.map(x => (x.pla_label, newvar()), args),
+        List.map(
+          x =>
+            switch (x.pla_label) {
+            | Default(_) => (x.pla_label, type_option(newvar()))
+            | _ => (x.pla_label, newvar())
+            },
+          args,
+        ),
         type_approx(env, e),
         TComOk,
       ),

--- a/compiler/src/typed/typecore.re
+++ b/compiler/src/typed/typecore.re
@@ -605,7 +605,15 @@ let rec approx_type = (env, sty) =>
   | PTyArrow(args, ret) =>
     newty(
       TTyArrow(
-        List.map(x => (x.ptyp_arg_label, newvar()), args),
+        List.map(
+          x => {
+            switch (x.ptyp_arg_label) {
+            | Default(_) => (x.ptyp_arg_label, type_option(newvar()))
+            | _ => (x.ptyp_arg_label, newvar())
+            }
+          },
+          args,
+        ),
         approx_type(env, ret),
         TComOk,
       ),
@@ -1869,7 +1877,15 @@ and type_application = (~in_function=?, ~loc, env, funct, sargs) => {
   let (ty_args, ty_ret) =
     switch (ty_fun.desc) {
     | TTyVar(_) =>
-      let t_args = List.map(arg => (arg.paa_label, newvar()), sargs)
+      let t_args =
+        List.map(
+          arg =>
+            switch (arg.paa_label) {
+            | Default(_) => (arg.paa_label, type_option(newvar()))
+            | _ => (arg.paa_label, newvar())
+            },
+          sargs,
+        )
       and t_ret = newvar();
       unify(
         env,

--- a/compiler/test/suites/functions.re
+++ b/compiler/test/suites/functions.re
@@ -335,6 +335,20 @@ truc()|},
     |},
     "999\n",
   );
+  assertRun(
+    "default_args7",
+    {|
+    let rec pExp = () => exp(p=0)
+    and exp = (p=0) => 0
+
+    let parse = (s: String) => {
+      exp(p=0)
+    }
+
+    print(parse("abc"))
+  |},
+    "0\n",
+  );
 
   assertRun(
     "labeled_args_typecheck1",

--- a/compiler/test/suites/functions.re
+++ b/compiler/test/suites/functions.re
@@ -349,6 +349,20 @@ truc()|},
   |},
     "0\n",
   );
+  assertCompileError(
+    "default_args8",
+    {|
+    let rec pExp = () => exp(0)
+    and exp = (p=0) => 0
+
+    let parse = (s: String) => {
+      exp(0)
+    }
+
+    parse("abc")
+  |},
+    "It is called with too many arguments.",
+  );
 
   assertRun(
     "labeled_args_typecheck1",


### PR DESCRIPTION
This pr fixes #2151, we seem to have made an invalid assumption when creating the type here which was causing the crashes. 


For anyone interested the root cause of the issue was in `type_approx` which is used when we are guessing types for recursive functions, we were producing the a `TTyvar` instead of an `option(TTyvar)` on default arguments. 