### PR TITLE
feat(stdlib): Reimplement `Number.sin`, `Number.cos`, `Number.tan`

### DIFF
--- a/compiler/test/stdlib/number.test.gr
+++ b/compiler/test/stdlib/number.test.gr
@@ -1017,3 +1017,21 @@ assert Number.isNaN(Number.cos(-18_446_744_073_709_551_616)) // -2^64
 assert Number.isNaN(Number.cos(Infinity))
 assert Number.isNaN(Number.cos(-Infinity))
 assert Number.isNaN(Number.cos(NaN))
+
+// Number.tan - base cases
+assert Number.tan(0) == 0
+assert Number.isClose(Number.tan(Number.pi / 6), 1 / Number.sqrt(3))
+assert Number.isClose(Number.tan(Number.pi / 4), 1)
+assert Number.isClose(Number.tan(Number.pi / 3), Number.sqrt(3))
+// Note: one might expect this to produce infinity but instead we produce 16331239353195370 because pi can not be represented accurately in iee754, This logic follows c
+assert Number.isClose(Number.tan(Number.pi / 2), 16331239353195370)
+// Number.tan - special cases
+assert Number.tan(1/2) == Number.tan(0.5)
+assert Number.tan(1/4) == Number.tan(0.25)
+assert Number.isClose(Number.tan(18_446_744_073_709_551_615), -0.02360508353) // 2^64-1
+assert Number.isClose(Number.tan(-18_446_744_073_709_551_615), 0.02360508353) // -2^64+1
+assert Number.isNaN(Number.tan(18_446_744_073_709_551_616)) // 2^64
+assert Number.isNaN(Number.tan(-18_446_744_073_709_551_616)) // -2^64
+assert Number.isNaN(Number.tan(Infinity))
+assert Number.isNaN(Number.tan(-Infinity))
+assert Number.isNaN(Number.tan(NaN))

--- a/compiler/test/stdlib/number.test.gr
+++ b/compiler/test/stdlib/number.test.gr
@@ -950,8 +950,6 @@ assert Number.linearMap(
 ) ==
   150
 
-// TODO: For each positive test implement a negative test
-// TODO: Set accuracy so we verify the function is closer then normal
 // Number.Sin - 0 to pi/2
 assert Number.isClose(Number.sin(Number.pi / 6), 1/2)
 assert Number.isClose(Number.sin(Number.pi / 4), Number.sqrt(2) / 2)
@@ -961,8 +959,8 @@ assert Number.isClose(Number.sin(Number.pi / 2), 1)
 assert Number.isClose(Number.sin(2 * Number.pi / 3), Number.sqrt(3) / 2)
 assert Number.isClose(Number.sin(3 * Number.pi / 4), Number.sqrt(2) / 2)
 assert Number.isClose(Number.sin(5 * Number.pi / 6), 1/2)
-// TODO: Test below fails because of how issues with representing pi in f64
-// assert Number.isClose(Number.sin(Number.pi), 0)
+// Note: This has an absolute error of 1e-15 because Number.pi is not exact
+assert Number.isClose(Number.sin(Number.pi), 0, absoluteTolerance=1e-15)
 // Number.Sin - 2pi to 3pi/2
 assert Number.isClose(Number.sin(7 * Number.pi / 6), -1/2)
 assert Number.isClose(Number.sin(5 * Number.pi / 4), Number.sqrt(2) / -2)
@@ -972,14 +970,17 @@ assert Number.isClose(Number.sin(3 * Number.pi / 2), -1)
 assert Number.isClose(Number.sin(5 * Number.pi / 3), Number.sqrt(3) / -2)
 assert Number.isClose(Number.sin(7 * Number.pi / 4), Number.sqrt(2) / -2)
 assert Number.isClose(Number.sin(11 * Number.pi / 6), -1/2)
-// TODO: Test below fails because of how issues with representing pi in f64
-// assert Number.isClose(Number.sin(2 * Number.pi), 0)
-// TODO: Test larger numbers
-// TODO: Test Some Rationals
-// TODO: Explicit Int Vs Float Tests
+// Note: This has an absolute error of 1e-15 because Number.pi is not exact
+assert Number.isClose(Number.sin(2 * Number.pi), 0, absoluteTolerance=1e-15)
 // Number.Sin - Special Cases
+assert Number.sin(1/2) == Number.sin(0.5)
+assert Number.sin(1/4) == Number.sin(0.25)
+assert Number.isClose(Number.sin(18_446_744_073_709_551_615), 0.0235985099) // 2^64-1
+assert Number.isClose(Number.sin(-18_446_744_073_709_551_615), -0.0235985099) // -2^64+1
 assert Number.sin(0) == 0
 assert Number.sin(-0.0) == 0
+assert Number.isNaN(Number.sin(18_446_744_073_709_551_616)) // 2^64
+assert Number.isNaN(Number.sin(-18_446_744_073_709_551_616)) // -2^64
 assert Number.isNaN(Number.sin(Infinity))
 assert Number.isNaN(Number.sin(-Infinity))
 assert Number.isNaN(Number.sin(NaN))

--- a/compiler/test/stdlib/number.test.gr
+++ b/compiler/test/stdlib/number.test.gr
@@ -950,37 +950,70 @@ assert Number.linearMap(
 ) ==
   150
 
-// Number.Sin - 0 to pi/2
+// Number.sin - 0 to pi/2
+assert Number.sin(0) == 0
 assert Number.isClose(Number.sin(Number.pi / 6), 1/2)
 assert Number.isClose(Number.sin(Number.pi / 4), Number.sqrt(2) / 2)
 assert Number.isClose(Number.sin(Number.pi / 3), Number.sqrt(3) / 2)
 assert Number.isClose(Number.sin(Number.pi / 2), 1)
-// Number.Sin - pi/2 to 2pi
+// Number.sin - pi/2 to 2pi
 assert Number.isClose(Number.sin(2 * Number.pi / 3), Number.sqrt(3) / 2)
 assert Number.isClose(Number.sin(3 * Number.pi / 4), Number.sqrt(2) / 2)
 assert Number.isClose(Number.sin(5 * Number.pi / 6), 1/2)
-// Note: This has an absolute error of 1e-15 because Number.pi is not exact
+// Note: This has an absolute error of 1e-15 because `Number.pi` is not exact
 assert Number.isClose(Number.sin(Number.pi), 0, absoluteTolerance=1e-15)
-// Number.Sin - 2pi to 3pi/2
+// Number.sin - 2pi to 3pi/2
 assert Number.isClose(Number.sin(7 * Number.pi / 6), -1/2)
 assert Number.isClose(Number.sin(5 * Number.pi / 4), Number.sqrt(2) / -2)
 assert Number.isClose(Number.sin(4 * Number.pi / 3), Number.sqrt(3) / -2)
 assert Number.isClose(Number.sin(3 * Number.pi / 2), -1)
-// Number.Sin - 3pi/2 to 0
+// Number.sin - 3pi/2 to 0
 assert Number.isClose(Number.sin(5 * Number.pi / 3), Number.sqrt(3) / -2)
 assert Number.isClose(Number.sin(7 * Number.pi / 4), Number.sqrt(2) / -2)
 assert Number.isClose(Number.sin(11 * Number.pi / 6), -1/2)
-// Note: This has an absolute error of 1e-15 because Number.pi is not exact
+// Note: This has an absolute error of 1e-15 because `Number.pi` is not exact
 assert Number.isClose(Number.sin(2 * Number.pi), 0, absoluteTolerance=1e-15)
-// Number.Sin - Special Cases
+// Number.sin - special cases
 assert Number.sin(1/2) == Number.sin(0.5)
 assert Number.sin(1/4) == Number.sin(0.25)
 assert Number.isClose(Number.sin(18_446_744_073_709_551_615), 0.0235985099) // 2^64-1
 assert Number.isClose(Number.sin(-18_446_744_073_709_551_615), -0.0235985099) // -2^64+1
-assert Number.sin(0) == 0
-assert Number.sin(-0.0) == 0
 assert Number.isNaN(Number.sin(18_446_744_073_709_551_616)) // 2^64
 assert Number.isNaN(Number.sin(-18_446_744_073_709_551_616)) // -2^64
 assert Number.isNaN(Number.sin(Infinity))
 assert Number.isNaN(Number.sin(-Infinity))
 assert Number.isNaN(Number.sin(NaN))
+
+// Number.cos - 0 to pi/2
+assert Number.cos(0) == 1
+assert Number.isClose(Number.cos(Number.pi / 6), Number.sqrt(3) / 2)
+assert Number.isClose(Number.cos(Number.pi / 4), Number.sqrt(2) / 2)
+assert Number.isClose(Number.cos(Number.pi / 3), 1/2)
+// Note: This has an absolute error of 1e-15 because `Number.pi` is not exact
+assert Number.isClose(Number.cos(Number.pi / 2), 0, absoluteTolerance=1e-15)
+// Number.cos - pi/2 to 2pi
+assert Number.isClose(Number.cos(2 * Number.pi / 3), -1/2)
+assert Number.isClose(Number.cos(3 * Number.pi / 4), Number.sqrt(2) / -2)
+assert Number.isClose(Number.cos(5 * Number.pi / 6), Number.sqrt(3) / -2)
+assert Number.isClose(Number.cos(Number.pi), -1)
+// Number.cos - 2pi to 3pi/2
+assert Number.isClose(Number.cos(7 * Number.pi / 6), Number.sqrt(3) / -2)
+assert Number.isClose(Number.cos(5 * Number.pi / 4), Number.sqrt(2) / -2)
+assert Number.isClose(Number.cos(4 * Number.pi / 3), -1/2)
+// Note: This has an absolute error of 1e-15 because `Number.pi` is not exact
+assert Number.isClose(Number.cos(3 * Number.pi / 2), 0, absoluteTolerance=1e-15)
+// Number.cos - 3pi/2 to 0
+assert Number.isClose(Number.cos(5 * Number.pi / 3), 1/2)
+assert Number.isClose(Number.cos(7 * Number.pi / 4), Number.sqrt(2) / 2)
+assert Number.isClose(Number.cos(11 * Number.pi / 6), Number.sqrt(3) / 2)
+assert Number.isClose(Number.cos(2 * Number.pi), 1)
+// Number.cos - special cases
+assert Number.cos(1/2) == Number.cos(0.5)
+assert Number.cos(1/4) == Number.cos(0.25)
+assert Number.isClose(Number.cos(18_446_744_073_709_551_615), -0.99972151638) // 2^64-1
+assert Number.isClose(Number.cos(-18_446_744_073_709_551_615), -0.99972151638) // -2^64+1
+assert Number.isNaN(Number.cos(18_446_744_073_709_551_616)) // 2^64
+assert Number.isNaN(Number.cos(-18_446_744_073_709_551_616)) // -2^64
+assert Number.isNaN(Number.cos(Infinity))
+assert Number.isNaN(Number.cos(-Infinity))
+assert Number.isNaN(Number.cos(NaN))

--- a/compiler/test/stdlib/number.test.gr
+++ b/compiler/test/stdlib/number.test.gr
@@ -949,3 +949,37 @@ assert Number.linearMap(
   0.5
 ) ==
   150
+
+// TODO: For each positive test implement a negative test
+// TODO: Set accuracy so we verify the function is closer then normal
+// Number.Sin - 0 to pi/2
+assert Number.isClose(Number.sin(Number.pi / 6), 1/2)
+assert Number.isClose(Number.sin(Number.pi / 4), Number.sqrt(2) / 2)
+assert Number.isClose(Number.sin(Number.pi / 3), Number.sqrt(3) / 2)
+assert Number.isClose(Number.sin(Number.pi / 2), 1)
+// Number.Sin - pi/2 to 2pi
+assert Number.isClose(Number.sin(2 * Number.pi / 3), Number.sqrt(3) / 2)
+assert Number.isClose(Number.sin(3 * Number.pi / 4), Number.sqrt(2) / 2)
+assert Number.isClose(Number.sin(5 * Number.pi / 6), 1/2)
+// TODO: Test below fails because of how issues with representing pi in f64
+// assert Number.isClose(Number.sin(Number.pi), 0)
+// Number.Sin - 2pi to 3pi/2
+assert Number.isClose(Number.sin(7 * Number.pi / 6), -1/2)
+assert Number.isClose(Number.sin(5 * Number.pi / 4), Number.sqrt(2) / -2)
+assert Number.isClose(Number.sin(4 * Number.pi / 3), Number.sqrt(3) / -2)
+assert Number.isClose(Number.sin(3 * Number.pi / 2), -1)
+// Number.Sin - 3pi/2 to 0
+assert Number.isClose(Number.sin(5 * Number.pi / 3), Number.sqrt(3) / -2)
+assert Number.isClose(Number.sin(7 * Number.pi / 4), Number.sqrt(2) / -2)
+assert Number.isClose(Number.sin(11 * Number.pi / 6), -1/2)
+// TODO: Test below fails because of how issues with representing pi in f64
+// assert Number.isClose(Number.sin(2 * Number.pi), 0)
+// TODO: Test larger numbers
+// TODO: Test Some Rationals
+// TODO: Explicit Int Vs Float Tests
+// Number.Sin - Special Cases
+assert Number.sin(0) == 0
+assert Number.sin(-0.0) == 0
+assert Number.isNaN(Number.sin(Infinity))
+assert Number.isNaN(Number.sin(-Infinity))
+assert Number.isNaN(Number.sin(NaN))

--- a/compiler/test/stdlib/number.test.gr
+++ b/compiler/test/stdlib/number.test.gr
@@ -978,8 +978,18 @@ assert Number.sin(1/2) == Number.sin(0.5)
 assert Number.sin(1/4) == Number.sin(0.25)
 assert Number.isClose(Number.sin(18_446_744_073_709_551_615), 0.0235985099) // 2^64-1
 assert Number.isClose(Number.sin(-18_446_744_073_709_551_615), -0.0235985099) // -2^64+1
-assert Number.isNaN(Number.sin(18_446_744_073_709_551_616)) // 2^64
-assert Number.isNaN(Number.sin(-18_446_744_073_709_551_616)) // -2^64
+assert Number.isClose(Number.sin(18_446_744_073_709_551_616), 0.0235985099) // 2^64
+assert Number.isClose(Number.sin(-18_446_744_073_709_551_616), -0.0235985099) // -2^64
+assert Number.isClose( // Note: We lose a lot of precision here do to ieee754 representation
+  Number.sin(1.7976931348623157e+308),
+  0.0049619,
+  absoluteTolerance=1e7
+) // Max F64
+assert Number.isClose(
+  Number.sin(-1.7976931348623157e+308),
+  0.00496,
+  absoluteTolerance=1e7
+) // Max F64
 assert Number.isNaN(Number.sin(Infinity))
 assert Number.isNaN(Number.sin(-Infinity))
 assert Number.isNaN(Number.sin(NaN))
@@ -1012,8 +1022,10 @@ assert Number.cos(1/2) == Number.cos(0.5)
 assert Number.cos(1/4) == Number.cos(0.25)
 assert Number.isClose(Number.cos(18_446_744_073_709_551_615), -0.99972151638) // 2^64-1
 assert Number.isClose(Number.cos(-18_446_744_073_709_551_615), -0.99972151638) // -2^64+1
-assert Number.isNaN(Number.cos(18_446_744_073_709_551_616)) // 2^64
-assert Number.isNaN(Number.cos(-18_446_744_073_709_551_616)) // -2^64
+assert Number.isClose(Number.cos(18_446_744_073_709_551_616), -0.99972151638) // 2^64
+assert Number.isClose(Number.cos(-18_446_744_073_709_551_616), -0.99972151638) // -2^64
+assert Number.isClose(Number.cos(1.7976931348623157e+308), -0.99998768942) // Max F64
+assert Number.isClose(Number.cos(-1.7976931348623157e+308), -0.99998768942) // Max F64
 assert Number.isNaN(Number.cos(Infinity))
 assert Number.isNaN(Number.cos(-Infinity))
 assert Number.isNaN(Number.cos(NaN))
@@ -1030,8 +1042,18 @@ assert Number.tan(1/2) == Number.tan(0.5)
 assert Number.tan(1/4) == Number.tan(0.25)
 assert Number.isClose(Number.tan(18_446_744_073_709_551_615), -0.02360508353) // 2^64-1
 assert Number.isClose(Number.tan(-18_446_744_073_709_551_615), 0.02360508353) // -2^64+1
-assert Number.isNaN(Number.tan(18_446_744_073_709_551_616)) // 2^64
-assert Number.isNaN(Number.tan(-18_446_744_073_709_551_616)) // -2^64
+assert Number.isClose(Number.tan(18_446_744_073_709_551_616), -0.02360508353) // 2^64
+assert Number.isClose(Number.tan(-18_446_744_073_709_551_616), 0.02360508353) // -2^64
+assert Number.isClose( // Note: We lose a lot of precision here do to ieee754 representation
+  Number.tan(1.7976931348623157e+308),
+  -0.00496201587,
+  absoluteTolerance=1e7
+) // Max F64
+assert Number.isClose(
+  Number.tan(-1.7976931348623157e+308),
+  -0.00496201587,
+  absoluteTolerance=1e7
+) // Max F64
 assert Number.isNaN(Number.tan(Infinity))
 assert Number.isNaN(Number.tan(-Infinity))
 assert Number.isNaN(Number.tan(NaN))

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -1085,10 +1085,13 @@ provide let linearMap = (inputRange, outputRange, current) => {
  */
 @unsafe
 provide let sin = (radians: Number) => {
+  // TODO(#2159): let coerceNumberToWasmF64 handle this
+  if (radians > 18_446_744_073_709_551_615) return NaN
+  if (radians < -18_446_744_073_709_551_615) return NaN
   use WasmF64.{ (==) }
   let xval = coerceNumberToWasmF64(radians)
   let value = sin(xval)
-  if (!isFloat(radians) && value == WasmF64.trunc(value)) {
+  return if (!isFloat(radians) && value == WasmF64.trunc(value)) {
     WasmI32.toGrain(reducedInteger(WasmI64.truncF64S(value))): Number
   } else {
     WasmI32.toGrain(newFloat64(value)): Number

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -48,6 +48,8 @@ from "runtime/atoi/parse" include Parse as Atoi
 from "runtime/atof/parse" include Parse as Atof
 from "runtime/unsafe/tags" include Tags
 from "runtime/exception" include Exception
+from "runtime/math/trig" include Trig
+use Trig.{ sin }
 
 use Atoi.{ type ParseIntError }
 
@@ -1070,5 +1072,25 @@ provide let linearMap = (inputRange, outputRange, current) => {
       (inputRange.rangeEnd - inputRange.rangeStart) +
       outputRange.rangeStart
     clamp(outputRange, mapped)
+  }
+}
+
+/**
+ * Computes the sine of a number (in radians).
+ *
+ * @param radians: The input in radians
+ * @returns The computed sine
+ *
+ * @since v0.7.0
+ */
+@unsafe
+provide let sin = (radians: Number) => {
+  use WasmF64.{ (==) }
+  let xval = coerceNumberToWasmF64(radians)
+  let value = sin(xval)
+  if (!isFloat(radians) && value == WasmF64.trunc(value)) {
+    WasmI32.toGrain(reducedInteger(WasmI64.truncF64S(value))): Number
+  } else {
+    WasmI32.toGrain(newFloat64(value)): Number
   }
 }

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -49,7 +49,7 @@ from "runtime/atof/parse" include Parse as Atof
 from "runtime/unsafe/tags" include Tags
 from "runtime/exception" include Exception
 from "runtime/math/trig" include Trig
-use Trig.{ sin }
+use Trig.{ sin, cos }
 
 use Atoi.{ type ParseIntError }
 
@@ -1091,6 +1091,29 @@ provide let sin = (radians: Number) => {
   use WasmF64.{ (==) }
   let xval = coerceNumberToWasmF64(radians)
   let value = sin(xval)
+  return if (!isFloat(radians) && value == WasmF64.trunc(value)) {
+    WasmI32.toGrain(reducedInteger(WasmI64.truncF64S(value))): Number
+  } else {
+    WasmI32.toGrain(newFloat64(value)): Number
+  }
+}
+
+/**
+ * Computes the cosine of a number (in radians).
+ *
+ * @param radians: The input in radians
+ * @returns The computed cosine
+ *
+ * @since v0.7.0
+ */
+@unsafe
+provide let cos = (radians: Number) => {
+  // TODO(#2159): let coerceNumberToWasmF64 handle this
+  if (radians > 18_446_744_073_709_551_615) return NaN
+  if (radians < -18_446_744_073_709_551_615) return NaN
+  use WasmF64.{ (==) }
+  let xval = coerceNumberToWasmF64(radians)
+  let value = cos(xval)
   return if (!isFloat(radians) && value == WasmF64.trunc(value)) {
     WasmI32.toGrain(reducedInteger(WasmI64.truncF64S(value))): Number
   } else {

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -1081,6 +1081,8 @@ provide let linearMap = (inputRange, outputRange, current) => {
  * @param radians: The input in radians
  * @returns The computed sine
  *
+ * @example Number.sin(0) == 0
+ *
  * @since v0.7.0
  */
 @unsafe
@@ -1104,6 +1106,8 @@ provide let sin = (radians: Number) => {
  * @param radians: The input in radians
  * @returns The computed cosine
  *
+ * @example Number.cos(0) == 1
+ *
  * @since v0.7.0
  */
 @unsafe
@@ -1126,6 +1130,8 @@ provide let cos = (radians: Number) => {
  *
  * @param radians: The input in radians
  * @returns The computed tangent
+ *
+ * @example Number.tan(0) == 0
  *
  * @since v0.7.0
  */

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -1087,9 +1087,6 @@ provide let linearMap = (inputRange, outputRange, current) => {
  */
 @unsafe
 provide let sin = (radians: Number) => {
-  // TODO(#2159): let coerceNumberToWasmF64 handle this
-  if (radians > 18_446_744_073_709_551_615) return NaN
-  if (radians < -18_446_744_073_709_551_615) return NaN
   use WasmF64.{ (==) }
   let xval = coerceNumberToWasmF64(radians)
   let value = sin(xval)
@@ -1112,9 +1109,6 @@ provide let sin = (radians: Number) => {
  */
 @unsafe
 provide let cos = (radians: Number) => {
-  // TODO(#2159): let coerceNumberToWasmF64 handle this
-  if (radians > 18_446_744_073_709_551_615) return NaN
-  if (radians < -18_446_744_073_709_551_615) return NaN
   use WasmF64.{ (==) }
   let xval = coerceNumberToWasmF64(radians)
   let value = cos(xval)
@@ -1137,9 +1131,6 @@ provide let cos = (radians: Number) => {
  */
 @unsafe
 provide let tan = (radians: Number) => {
-  // TODO(#2159): let coerceNumberToWasmF64 handle this
-  if (radians > 18_446_744_073_709_551_615) return NaN
-  if (radians < -18_446_744_073_709_551_615) return NaN
   use WasmF64.{ (==) }
   let xval = coerceNumberToWasmF64(radians)
   let value = tan(xval)

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -49,7 +49,7 @@ from "runtime/atof/parse" include Parse as Atof
 from "runtime/unsafe/tags" include Tags
 from "runtime/exception" include Exception
 from "runtime/math/trig" include Trig
-use Trig.{ sin, cos }
+use Trig.{ sin, cos, tan }
 
 use Atoi.{ type ParseIntError }
 
@@ -1114,6 +1114,29 @@ provide let cos = (radians: Number) => {
   use WasmF64.{ (==) }
   let xval = coerceNumberToWasmF64(radians)
   let value = cos(xval)
+  return if (!isFloat(radians) && value == WasmF64.trunc(value)) {
+    WasmI32.toGrain(reducedInteger(WasmI64.truncF64S(value))): Number
+  } else {
+    WasmI32.toGrain(newFloat64(value)): Number
+  }
+}
+
+/**
+ * Computes the tangent of a number (in radians).
+ *
+ * @param radians: The input in radians
+ * @returns The computed tangent
+ *
+ * @since v0.7.0
+ */
+@unsafe
+provide let tan = (radians: Number) => {
+  // TODO(#2159): let coerceNumberToWasmF64 handle this
+  if (radians > 18_446_744_073_709_551_615) return NaN
+  if (radians < -18_446_744_073_709_551_615) return NaN
+  use WasmF64.{ (==) }
+  let xval = coerceNumberToWasmF64(radians)
+  let value = tan(xval)
   return if (!isFloat(radians) && value == WasmF64.trunc(value)) {
     WasmI32.toGrain(reducedInteger(WasmI64.truncF64S(value))): Number
   } else {

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -1566,3 +1566,53 @@ Throws:
 * When `outputRange` is not finite
 * When `outputRange` includes NaN
 
+### Number.**sin**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+sin : (radians: Number) => Number
+```
+
+Computes the sine of a number (in radians).
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`radians`|`Number`|The input in radians|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The computed sine|
+
+### Number.**cos**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+cos : (radians: Number) => Number
+```
+
+Computes the cosine of a number (in radians).
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`radians`|`Number`|The input in radians|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The computed cosine|
+

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -1616,3 +1616,28 @@ Returns:
 |----|-----------|
 |`Number`|The computed cosine|
 
+### Number.**tan**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+tan : (radians: Number) => Number
+```
+
+Computes the tangent of a number (in radians).
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`radians`|`Number`|The input in radians|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The computed tangent|
+

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -1591,6 +1591,12 @@ Returns:
 |----|-----------|
 |`Number`|The computed sine|
 
+Examples:
+
+```grain
+Number.sin(0) == 0
+```
+
 ### Number.**cos**
 
 <details disabled>
@@ -1616,6 +1622,12 @@ Returns:
 |----|-----------|
 |`Number`|The computed cosine|
 
+Examples:
+
+```grain
+Number.cos(0) == 1
+```
+
 ### Number.**tan**
 
 <details disabled>
@@ -1640,4 +1652,10 @@ Returns:
 |type|description|
 |----|-----------|
 |`Number`|The computed tangent|
+
+Examples:
+
+```grain
+Number.tan(0) == 0
+```
 

--- a/stdlib/runtime/math/kernel/cos.gr
+++ b/stdlib/runtime/math/kernel/cos.gr
@@ -8,7 +8,7 @@
  * is preserved.
  * ====================================================
  */
-module KernelCos
+module Cosine
 
 from "runtime/unsafe/wasmf64" include WasmF64
 

--- a/stdlib/runtime/math/kernel/cos.gr
+++ b/stdlib/runtime/math/kernel/cos.gr
@@ -1,0 +1,70 @@
+/*
+ * ====================================================
+ * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+ *
+ * Developed at SunSoft, a Sun Microsystems, Inc. business.
+ * Permission to use, copy, modify, and distribute this
+ * software is freely granted, provided that this notice
+ * is preserved.
+ * ====================================================
+ */
+module KernelCos
+
+from "runtime/unsafe/wasmf64" include WasmF64
+
+/*
+ * Source: https://git.musl-libc.org/cgit/musl/tree/src/math/__cos.c
+ *
+ * kernel cos function on [-pi/4, pi/4], pi/4 ~ 0.785398164
+ * Input x is assumed to be bounded by ~pi/4 in magnitude.
+ * Input y is the tail of x.
+ *
+ * Algorithm
+ *      1. Since cos(-x) = cos(x), we need only to consider positive x.
+ *      2. if x < 2^-27 (hx<0x3e400000 0), return 1 with inexact if x!=0.
+ *      3. cos(x) is approximated by a polynomial of degree 14 on
+ *         [0,pi/4]
+ *                                       4            14
+ *              cos(x) ~ 1 - x*x/2 + C1*x + ... + C6*x
+ *         where the remez error is
+ *
+ *      |              2     4     6     8     10    12     14 |     -58
+ *      |cos(x)-(1-.5*x +C1*x +C2*x +C3*x +C4*x +C5*x  +C6*x  )| <= 2
+ *      |                                                      |
+ *
+ *                     4     6     8     10    12     14
+ *      4. let r = C1*x +C2*x +C3*x +C4*x +C5*x  +C6*x  , then
+ *             cos(x) ~ 1 - x*x/2 + r
+ *         since cos(x+y) ~ cos(x) - sin(x)*y
+ *                        ~ cos(x) - x*y,
+ *         a correction term is necessary in cos(x) and hence
+ *              cos(x+y) = 1 - (x*x/2 - (r - x*y))
+ *         For better accuracy, rearrange to
+ *              cos(x+y) ~ w + (tmp + (r-x*y))
+ *         where w = 1 - x*x/2 and tmp is a tiny correction term
+ *         (1 - x*x/2 == w + tmp exactly in infinite precision).
+ *         The exactness of w + tmp in infinite precision depends on w
+ *         and tmp having the same precision as x.  If they have extra
+ *         precision due to compiler bugs, then the extra precision is
+ *         only good provided it is retained in all terms of the final
+ *         expression for cos().  Retention happens in all cases tested
+ *         under FreeBSD, so don't pessimize things by forcibly clipping
+ *         any extra precision in w.
+ */
+@unsafe
+provide let cos = (x: WasmF64, y: WasmF64) => {
+  use WasmF64.{ (+), (-), (*) }
+  let c1 = 4.16666666666666019037e-02W /* 0x3FA55555, 0x5555554C */
+  let c2 = -1.38888888888741095749e-03W /* 0xBF56C16C, 0x16C15177 */
+  let c3 = 2.48015872894767294178e-05W /* 0x3EFA01A0, 0x19CB1590 */
+  let c4 = -2.75573143513906633035e-07W /* 0xBE927E4F, 0x809C52AD */
+  let c5 = 2.08757232129817482790e-09W /* 0x3E21EE9E, 0xBDB4B1C4 */
+  let c6 = -1.13596475577881948265e-11W /* 0xBDA8FAE9, 0xBE8838D4 */
+
+  let z = x * x
+  let w = z * z
+  let r = z * (c1 + z * (c2 + z * c3)) + w * w * (c4 + z * (c5 + z * c6))
+  let hz = 0.5W * z
+  let w = 1.0W - hz
+  w + (1.0W - w - hz + (z * r - x * y))
+}

--- a/stdlib/runtime/math/kernel/cos.md
+++ b/stdlib/runtime/math/kernel/cos.md
@@ -1,12 +1,12 @@
 ---
-title: KernelCos
+title: Cosine
 ---
 
 ## Values
 
-Functions and constants included in the KernelCos module.
+Functions and constants included in the Cosine module.
 
-### KernelCos.**cos**
+### Cosine.**cos**
 
 ```grain
 cos : (x: WasmF64, y: WasmF64) => WasmF64

--- a/stdlib/runtime/math/kernel/cos.md
+++ b/stdlib/runtime/math/kernel/cos.md
@@ -1,14 +1,14 @@
 ---
-title: KernelSin
+title: KernelCos
 ---
 
 ## Values
 
-Functions and constants included in the KernelSin module.
+Functions and constants included in the KernelCos module.
 
-### KernelSin.**cos_kern**
+### KernelCos.**cos**
 
 ```grain
-cos_kern : (x: WasmF64, y: WasmF64) => WasmF64
+cos : (x: WasmF64, y: WasmF64) => WasmF64
 ```
 

--- a/stdlib/runtime/math/kernel/cos.md
+++ b/stdlib/runtime/math/kernel/cos.md
@@ -1,0 +1,14 @@
+---
+title: KernelSin
+---
+
+## Values
+
+Functions and constants included in the KernelSin module.
+
+### KernelSin.**cos_kern**
+
+```grain
+cos_kern : (x: WasmF64, y: WasmF64) => WasmF64
+```
+

--- a/stdlib/runtime/math/kernel/sin.gr
+++ b/stdlib/runtime/math/kernel/sin.gr
@@ -8,7 +8,7 @@
  * is preserved.
  * ====================================================
  */
-module KernelSin
+module Sine
 
 from "runtime/unsafe/wasmf64" include WasmF64
 

--- a/stdlib/runtime/math/kernel/sin.gr
+++ b/stdlib/runtime/math/kernel/sin.gr
@@ -1,0 +1,65 @@
+/*
+ * ====================================================
+ * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+ *
+ * Developed at SunSoft, a Sun Microsystems, Inc. business.
+ * Permission to use, copy, modify, and distribute this
+ * software is freely granted, provided that this notice
+ * is preserved.
+ * ====================================================
+ */
+module KernelSin
+
+from "runtime/unsafe/wasmf64" include WasmF64
+
+/*
+ * Source: https://git.musl-libc.org/cgit/musl/tree/src/math/__sin.c
+ *
+ * kernel sin function on ~[-pi/4, pi/4] (except on -0), pi/4 ~ 0.7854
+ * Input x is assumed to be bounded by ~pi/4 in magnitude.
+ * Input y is the tail of x.
+ * Input iy indicates whether y is 0. (if iy=0, y assume to be 0).
+ *
+ * Algorithm
+ *      1. Since sin(-x) = -sin(x), we need only to consider positive x.
+ *      2. Callers must return sin(-0) = -0 without calling here since our
+ *         odd polynomial is not evaluated in a way that preserves -0.
+ *         Callers may do the optimization sin(x) ~ x for tiny x.
+ *      3. sin(x) is approximated by a polynomial of degree 13 on
+ *         [0,pi/4]
+ *                               3            13
+ *              sin(x) ~ x + S1*x + ... + S6*x
+ *         where
+ *
+ *      |sin(x)         2     4     6     8     10     12  |     -58
+ *      |----- - (1+S1*x +S2*x +S3*x +S4*x +S5*x  +S6*x   )| <= 2
+ *      |  x                                               |
+ *
+ *      4. sin(x+y) = sin(x) + sin'(x')*y
+ *                  ~ sin(x) + (1-x*x/2)*y
+ *         For better accuracy, let
+ *                   3      2      2      2      2
+ *              r = x *(S2+x *(S3+x *(S4+x *(S5+x *S6))))
+ *         then                   3    2
+ *              sin(x) = x + (S1*x + (x *(r-y/2)+y))
+ */
+@unsafe
+provide let sin = (x: WasmF64, y: WasmF64, iy: Bool) => { // see: musl/tree/src/math/__sin.c
+  use WasmF64.{ (+), (-), (*) }
+  let s1 = -1.66666666666666324348e-01W /* 0xBFC55555, 0x55555549 */
+  let s2 = 8.33333333332248946124e-03W /* 0x3F811111, 0x1110F8A6 */
+  let s3 = -1.98412698298579493134e-04W /* 0xBF2A01A0, 0x19C161D5 */
+  let s4 = 2.75573137070700676789e-06W /* 0x3EC71DE3, 0x57B1FE7D */
+  let s5 = -2.50507602534068634195e-08W /* 0xBE5AE5E6, 0x8A2B9CEB */
+  let s6 = 1.58969099521155010221e-10W /* 0x3DE5D93A, 0x5ACFD57C */
+
+  let z = x * x
+  let w = z * z
+  let r = s2 + z * (s3 + z * s4) + z * w * (s5 + z * s6)
+  let v = z * x
+  if (!iy) {
+    x + v * (s1 + z * r)
+  } else {
+    x - (z * (0.5W * y - v * r) - y - v * s1)
+  }
+}

--- a/stdlib/runtime/math/kernel/sin.md
+++ b/stdlib/runtime/math/kernel/sin.md
@@ -1,12 +1,12 @@
 ---
-title: KernelSin
+title: Sine
 ---
 
 ## Values
 
-Functions and constants included in the KernelSin module.
+Functions and constants included in the Sine module.
 
-### KernelSin.**sin**
+### Sine.**sin**
 
 ```grain
 sin : (x: WasmF64, y: WasmF64, iy: Bool) => WasmF64

--- a/stdlib/runtime/math/kernel/sin.md
+++ b/stdlib/runtime/math/kernel/sin.md
@@ -6,9 +6,9 @@ title: KernelSin
 
 Functions and constants included in the KernelSin module.
 
-### KernelSin.**sin_kern**
+### KernelSin.**sin**
 
 ```grain
-sin_kern : (x: WasmF64, y: WasmF64, iy: Bool) => WasmF64
+sin : (x: WasmF64, y: WasmF64, iy: Bool) => WasmF64
 ```
 

--- a/stdlib/runtime/math/kernel/sin.md
+++ b/stdlib/runtime/math/kernel/sin.md
@@ -1,0 +1,14 @@
+---
+title: KernelSin
+---
+
+## Values
+
+Functions and constants included in the KernelSin module.
+
+### KernelSin.**sin_kern**
+
+```grain
+sin_kern : (x: WasmF64, y: WasmF64, iy: Bool) => WasmF64
+```
+

--- a/stdlib/runtime/math/kernel/tan.gr
+++ b/stdlib/runtime/math/kernel/tan.gr
@@ -8,7 +8,7 @@
  * is preserved.
  * ====================================================
  */
-module KernelTan
+module Tangent
 
 from "runtime/unsafe/wasmi32" include WasmI32
 from "runtime/unsafe/wasmi64" include WasmI64

--- a/stdlib/runtime/math/kernel/tan.gr
+++ b/stdlib/runtime/math/kernel/tan.gr
@@ -1,0 +1,136 @@
+/*
+ * ====================================================
+ * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+ *
+ * Developed at SunSoft, a Sun Microsystems, Inc. business.
+ * Permission to use, copy, modify, and distribute this
+ * software is freely granted, provided that this notice
+ * is preserved.
+ * ====================================================
+ */
+module KernelTan
+
+from "runtime/unsafe/wasmi32" include WasmI32
+from "runtime/unsafe/wasmi64" include WasmI64
+from "runtime/unsafe/wasmf64" include WasmF64
+
+/*
+ * Source: lib/msun/src/k_tan.c
+ *
+ * kernel tan function on ~[-pi/4, pi/4] (except on -0), pi/4 ~ 0.7854
+ * Input x is assumed to be bounded by ~pi/4 in magnitude.
+ * Input y is the tail of x.
+ * Input k indicates whether tan (if k = 1) or -1/tan (if k = -1) is returned.
+ *
+ * Algorithm
+ *	1. Since tan(-x) = -tan(x), we need only to consider positive x.
+ *	2. Callers must return tan(-0) = -0 without calling here since our
+ *	   odd polynomial is not evaluated in a way that preserves -0.
+ *	   Callers may do the optimization tan(x) ~ x for tiny x.
+ *	3. tan(x) is approximated by a odd polynomial of degree 27 on
+ *	   [0,0.67434]
+ *		  	         3             27
+ *	   	tan(x) ~ x + T1*x + ... + T13*x
+ *	   where
+ *
+ * 	        |tan(x)         2     4            26   |     -59.2
+ * 	        |----- - (1+T1*x +T2*x +.... +T13*x    )| <= 2
+ * 	        |  x 					|
+ *
+ *	   Note: tan(x+y) = tan(x) + tan'(x)*y
+ *		          ~ tan(x) + (1+x*x)*y
+ *	   Therefore, for better accuracy in computing tan(x+y), let
+ *		     3      2      2       2       2
+ *		r = x *(T2+x *(T3+x *(...+x *(T12+x *T13))))
+ *	   then
+ *		 		    3    2
+ *		tan(x+y) = x + (T1*x + (x *(r+y)+y))
+ *
+ *      4. For x in [0.67434,pi/4],  let y = pi/4 - x, then
+ *		tan(x) = tan(pi/4-y) = (1-tan(y))/(1+tan(y))
+ *		       = 1 - 2*(tan(y) - (tan(y)^2)/(1+tan(y)))
+ */
+@unsafe
+provide let tan = (x: WasmF64, y: WasmF64, iy: Bool) => {
+  use WasmI32.{ (&), (>>), (<), (>=) }
+  use WasmI64.{ (>>>) }
+  use WasmF64.{ (-), (+), (*), (/) }
+  let t0 = 3.33333333333334091986e-01W /* 3FD55555, 55555563 */
+  let t1 = 1.33333333333201242699e-01W /* 3FC11111, 1110FE7A */
+  let t2 = 5.39682539762260521377e-02W /* 3FABA1BA, 1BB341FE */
+  let t3 = 2.18694882948595424599e-02W /* 3F9664F4, 8406D637 */
+  let t4 = 8.86323982359930005737e-03W /* 3F8226E3, E96E8493 */
+  let t5 = 3.59207910759131235356e-03W /* 3F6D6D22, C9560328 */
+  let t6 = 1.45620945432529025516e-03W /* 3F57DBC8, FEE08315 */
+  let t7 = 5.88041240820264096874e-04W /* 3F4344D8, F2F26501 */
+  let t8 = 2.46463134818469906812e-04W /* 3F3026F7, 1A8D1068 */
+  let t9 = 7.81794442939557092300e-05W /* 3F147E88, A03792A6 */
+  let t10 = 7.14072491382608190305e-05W /* 3F12B80F, 32F0A7E9 */
+  let t11 = -1.85586374855275456654e-05W /* BEF375CB, DB605373 */
+  let t12 = 2.59073051863633712884e-05W /* 3EFB2A70, 74BF7AD4 */
+  let pio4 = 7.85398163397448278999e-01W /* 3FE921FB, 54442D18 */
+  let pio4lo = 3.06161699786838301793e-17W /* 3C81A626, 33145C07 */
+
+  let mut x = x
+  let mut y = y
+  let mut z = 0.0W
+  let mut r = 0.0W
+  let mut w = 0.0W
+
+  let h = WasmI64.reinterpretF64(x)
+  let hx = WasmI32.wrapI64(h >>> 32N) // High word of {x}
+  let ix = hx & 0x7FFFFFFFn // High word of |x|
+
+  let isBig = ix >= 0x3FE59428n
+  if (isBig) { /* |x| >= 0.6744 */
+    if (hx < 0n) {
+      x *= -1.0W
+      y *= -1.0W
+    }
+    z = pio4 - x
+    w = pio4lo - y
+    x = z + w
+    y = 0.0W
+  }
+  z = x * x
+  w = z * z
+
+  /*
+	 * Break x^5*(T[1]+x^2*T[2]+...) into
+	 * x^5(T[1]+x^4*T[3]+...+x^20*T[11]) +
+	 * x^5(x^2*(T[2]+x^4*T[4]+...+x^22*[T12]))
+	 */
+  r = t1 + w * (t3 + w * (t5 + w * (t7 + w * (t9 + w * t11))))
+  let v = z * (t2 + w * (t4 + w * (t6 + w * (t8 + w * (t10 + w * t12)))))
+  let s = z * x
+  r = y + z * (s * (r + v) + y)
+  r += t0 * s
+  w = x + r
+  if (isBig) {
+    let v = if (iy) 1.0W else 0.0W
+    return 1.0W -
+      WasmF64.convertI32S(hx >> 30n & 2n) *
+        (v - 2.0W * (x - (w * w / (w + v) - r)))
+  }
+  if (iy) return w
+  /*
+   * if allow error up to 2 ulp, simply return
+   * -1.0 / (x+r) here
+   */
+  // compute -1.0 / (x+r) accurately
+  use WasmI64.{ (&) }
+  // Set low bits
+  let z = w
+  let z = WasmF64.reinterpretI64(
+    WasmI64.reinterpretF64(z) & 0xFFFFFFFF00000000N
+  )
+  let v = r - (z - x) // z + v = r + x
+  let a = -1.0W / w
+  let t = a
+  // Set low bits
+  let t = WasmF64.reinterpretI64(
+    WasmI64.reinterpretF64(t) & 0xFFFFFFFF00000000N
+  )
+  let s = 1.0W + t * z
+  return t + a * (s + t * v)
+}

--- a/stdlib/runtime/math/kernel/tan.md
+++ b/stdlib/runtime/math/kernel/tan.md
@@ -1,12 +1,12 @@
 ---
-title: KernelTan
+title: Tangent
 ---
 
 ## Values
 
-Functions and constants included in the KernelTan module.
+Functions and constants included in the Tangent module.
 
-### KernelTan.**tan**
+### Tangent.**tan**
 
 ```grain
 tan : (x: WasmF64, y: WasmF64, iy: Bool) => WasmF64

--- a/stdlib/runtime/math/kernel/tan.md
+++ b/stdlib/runtime/math/kernel/tan.md
@@ -1,0 +1,14 @@
+---
+title: KernelTan
+---
+
+## Values
+
+Functions and constants included in the KernelTan module.
+
+### KernelTan.**tan**
+
+```grain
+tan : (x: WasmF64, y: WasmF64, iy: Bool) => WasmF64
+```
+

--- a/stdlib/runtime/math/rempio2.gr
+++ b/stdlib/runtime/math/rempio2.gr
@@ -1,0 +1,244 @@
+/*
+ * ====================================================
+ * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+ *
+ * Developed at SunSoft, a Sun Microsystems, Inc. business.
+ * Permission to use, copy, modify, and distribute this
+ * software is freely granted, provided that this notice
+ * is preserved.
+ * ====================================================
+ */
+module Rempio2
+
+from "runtime/unsafe/wasmi32" include WasmI32
+from "runtime/unsafe/wasmi64" include WasmI64
+from "runtime/unsafe/wasmf64" include WasmF64
+from "runtime/unsafe/memory" include Memory
+from "runtime/unsafe/conv" include Conv
+use Conv.{ toInt32, toUint64, toFloat64, fromInt32, fromUint64, fromFloat64 }
+from "runtime/math/umuldi" include Umuldi
+use Umuldi.{ umuldi }
+
+// Note: This file could be simplified if we add support for i128
+
+@unsafe
+let pio2_right = (q0: WasmI64, q1: WasmI64) => { // see: jdh8/metallic/blob/master/src/math/double/rem_pio2.c
+  use WasmI64.{ (-), (|), (<<), (>>>), (<) }
+  use WasmF64.{ (+), (*) }
+  // Bits of π/4
+  let p0 = 0xC4C6628B80DC1CD1N
+  let p1 = 0xC90FDAA22168C234N
+
+  let shift = WasmI64.clz(q1)
+  let q1 = q1 << shift | q0 >>> (64N - shift)
+  let q0 = WasmF64.convertI64U(q0 << shift)
+
+  let (lo, hi) = umuldi(p1, q1)
+  let lo = fromUint64(lo)
+  let hi = fromUint64(hi)
+
+  let ahi = hi >>> 11N
+  let alo = lo >>> 11N | hi << 53N
+  let blo = WasmI64.truncF64U(
+    0x1p-75W * WasmF64.convertI64U(q1) + 0x1p-75W * WasmF64.convertI64U(p1) * q0
+  )
+  use WasmI64.{ (+) }
+  let y0 = WasmF64.convertI64U(ahi + (if (lo < blo) 1N else 0N))
+  let y1 = 0x1p-64W * WasmF64.convertI64U(alo + blo)
+
+  return (toUint64(shift), toFloat64(y0), toFloat64(y1))
+}
+
+@unsafe
+let mut _PIO2_TABLE = -1n
+@unsafe
+let pio2_large_quot = (x: WasmF64, i: WasmI64) => { // see: jdh8/metallic/blob/master/src/math/double/rem_pio2.c
+  /*
+   * Note: The original c implementation makes use of i128,
+   *       as we do not have i128 the code here has to split
+   *       high and low bits.
+   */
+  use WasmI32.{ (+), (*), (==), (<<), (<=), (>=) }
+  use WasmI64.{ (-), (&), (>>>), (|), (!=) }
+  let magnitude = i & 0x7FFFFFFFFFFFFFFFN
+  // segmentation: note this would be better as a separate function but would require a heap allocation
+  let offset = (magnitude >>> 52N) - 1045N
+  let shift = offset & 63N
+  if (_PIO2_TABLE == -1n) {
+    // Note: This leaks memory but only in the sense that it allocates the array globally
+    _PIO2_TABLE = Memory.malloc(192n)
+    WasmI64.store(_PIO2_TABLE, 0x00000000A2F9836EN, 8n * 0n)
+    WasmI64.store(_PIO2_TABLE, 0x4E441529FC2757D1N, 8n * 1n)
+    WasmI64.store(_PIO2_TABLE, 0xF534DDC0DB629599N, 8n * 2n)
+    WasmI64.store(_PIO2_TABLE, 0x3C439041FE5163ABN, 8n * 3n)
+
+    WasmI64.store(_PIO2_TABLE, 0xDEBBC561B7246E3AN, 8n * 4n)
+    WasmI64.store(_PIO2_TABLE, 0x424DD2E006492EEAN, 8n * 5n)
+    WasmI64.store(_PIO2_TABLE, 0x09D1921CFE1DEB1CN, 8n * 6n)
+    WasmI64.store(_PIO2_TABLE, 0xB129A73EE88235F5N, 8n * 7n)
+
+    WasmI64.store(_PIO2_TABLE, 0x2EBB4484E99C7026N, 8n * 8n)
+    WasmI64.store(_PIO2_TABLE, 0xB45F7E413991D639N, 8n * 9n)
+    WasmI64.store(_PIO2_TABLE, 0x835339F49C845F8BN, 8n * 10n)
+    WasmI64.store(_PIO2_TABLE, 0xBDF9283B1FF897FFN, 8n * 11n)
+
+    WasmI64.store(_PIO2_TABLE, 0xDE05980FEF2F118BN, 8n * 12n)
+    WasmI64.store(_PIO2_TABLE, 0x5A0A6D1F6D367ECFN, 8n * 13n)
+    WasmI64.store(_PIO2_TABLE, 0x27CB09B74F463F66N, 8n * 14n)
+    WasmI64.store(_PIO2_TABLE, 0x9E5FEA2D7527BAC7N, 8n * 15n)
+
+    WasmI64.store(_PIO2_TABLE, 0xEBE5F17B3D0739F7N, 8n * 16n)
+    WasmI64.store(_PIO2_TABLE, 0x8A5292EA6BFB5FB1N, 8n * 17n)
+    WasmI64.store(_PIO2_TABLE, 0x1F8D5D0856033046N, 8n * 18n)
+    WasmI64.store(_PIO2_TABLE, 0xFC7B6BABF0CFBC20N, 8n * 19n)
+
+    WasmI64.store(_PIO2_TABLE, 0x9AF4361DA9E39161N, 8n * 20n)
+    WasmI64.store(_PIO2_TABLE, 0x5EE61B086599855FN, 8n * 21n)
+    WasmI64.store(_PIO2_TABLE, 0x14A068408DFFD880N, 8n * 22n)
+    WasmI64.store(_PIO2_TABLE, 0x4D73273106061557N, 8n * 23n)
+  }
+  let tblPtr = _PIO2_TABLE + (WasmI32.wrapI64(offset >>> 6N) << 3n)
+  let b0 = WasmI64.load(tblPtr, 8n * 0n)
+  let b1 = WasmI64.load(tblPtr, 8n * 1n)
+  let b2 = WasmI64.load(tblPtr, 8n * 2n)
+
+  // Get 192 bits of 0x1p-31 / π with `offset` bits skipped
+  let mut s0 = b0
+  let mut s1 = b1
+  let mut s2 = b2
+  if (shift != 0N) {
+    use WasmI64.{ (<<) }
+    let b3 = WasmI64.load(tblPtr, 8n * 3n)
+    let rshift = 64N - shift
+    s0 = b1 >>> rshift | b0 << shift
+    s1 = b2 >>> rshift | b1 << shift
+    s2 = b3 >>> rshift | b2 << shift
+  }
+
+  use WasmI64.{ (*), (+), (<), (<<) }
+
+  let significand = i & 0x000FFFFFFFFFFFFFN | 0x0010000000000000N
+
+  // First 128 bits of fractional part of x/(2π)
+  let (blo, bhi) = umuldi(s1, significand)
+  let blo = fromUint64(blo)
+  let bhi = fromUint64(bhi)
+
+  let ahi = s0 * significand
+  let clo = (s2 >>> 32N) * (significand >>> 32N)
+  let productLow = blo + clo
+  let productHigh = ahi + bhi + (if (productLow < clo) 1N else 0N)
+  // r = product << 2
+  let rLow = productLow << 2N
+  let rHigh = productHigh << 2N | productLow >>> 62N
+  // s = r >> 127
+  use WasmI64.{ (>>), (^) }
+  let sLow = rHigh >> 63N
+  let sHigh = sLow >> 1N
+  let q = WasmI32.wrapI64((productHigh >> 62N) - sLow)
+
+  let (right, y0, y1) = pio2_right(rLow ^ sLow, rHigh ^ sHigh)
+  let right = fromUint64(right)
+  let y0 = fromFloat64(y0)
+  let y1 = fromFloat64(y1)
+
+  let shifter = 0x3CB0000000000000N - (right << 52N)
+  let signbit = (i ^ rHigh) & 0x8000000000000000N
+  let coeff = WasmF64.reinterpretI64(shifter | signbit)
+
+  use WasmF64.{ (*) }
+  let y0 = y0 * coeff
+  let y1 = y1 * coeff
+
+  return (toInt32(q), toFloat64(y0), toFloat64(y1))
+}
+
+@unsafe
+provide let rempio2 = (x: WasmF64, i: WasmI64, sign: Bool) => {
+  use WasmI32.{ (&), (<), (!=) }
+  use WasmI64.{ (>>>) }
+  use WasmF64.{ (+), (-), (*) }
+  let pio2_1 = 1.57079632673412561417e+00W /* 0x3FF921FB, 0x54400000 */
+  let pio2_1t = 6.07710050650619224932e-11W /* 0x3DD0B461, 0x1A626331 */
+  let pio2_2 = 6.07710050630396597660e-11W /* 0x3DD0B461, 0x1A600000 */
+  let pio2_2t = 2.02226624879595063154e-21W /* 0x3BA3198A, 0x2E037073 */
+  let pio2_3 = 2.02226624871116645580e-21W /* 0x3BA3198A, 0x2E000000 */
+  let pio2_3t = 8.47842766036889956997e-32W /* 0x397B839A, 0x252049C1 */
+  let invpio2 = 6.36619772367581382433e-01W /* 0x3FE45F30, 0x6DC9C883 */
+
+  // High word of x
+  let ix = WasmI32.wrapI64(i >>> 32N) & 0x7FFFFFFFn
+
+  if (ix < 0x4002D97Cn) { // |x| < 3pi/4, special case with n=+-1
+    if (sign) {
+      let z = x - pio2_1
+      let mut y0 = 0.0W
+      let mut y1 = 0.0W
+      if (ix != 0x3FF921FBn) { // 33+53 bit pi is good enough
+        y0 = z - pio2_1t
+        y1 = z - y0 - pio2_1t
+      } else { // near pi/2, use 33+33+53 bit pi
+        let z = z - pio2_2
+        y0 = z - pio2_2t
+        y1 = z - y0 - pio2_2t
+      }
+      return (1l, toFloat64(y0), toFloat64(y1))
+    } else {
+      let z = x + pio2_1
+      let mut y0 = 0.0W
+      let mut y1 = 0.0W
+      if (ix != 0x3FF921FBn) { // 33+53 bit pi is good enough
+        y0 = z + pio2_1t
+        y1 = z - y0 + pio2_1t
+      } else { // near pi/2, use 33+33+53 bit pi
+        let z = z + pio2_2
+        y0 = z + pio2_2t
+        y1 = z - y0 + pio2_2t
+      }
+      return (-1l, toFloat64(y0), toFloat64(y1))
+    }
+  }
+
+  if (ix < 0x413921FBn) { // |x| ~< 2^20*pi/2, medium size
+    use WasmI32.{ (>>>) }
+    let q = WasmF64.nearest(x * invpio2)
+    let mut r = x - q * pio2_1
+    let mut w = q * pio2_1t // 1st round good to 85 bit
+    let j = ix >>> 20n
+    let mut y0 = r - w
+    use WasmI64.{ (>>>) }
+    let hi = WasmI32.wrapI64(WasmI64.reinterpretF64(y0) >>> 32N)
+    use WasmI32.{ (-), (>>>), (>) }
+    let i = j - (hi >>> 20n & 0x7FFn)
+    if (i > 16n) { // 2nd iteration needed, good to 118
+      use WasmF64.{ (-) }
+      let t = r
+      w = q * pio2_2
+      r = t - w
+      w = q * pio2_2t - (t - r - w)
+      y0 = r - w
+      use WasmI64.{ (>>>) }
+      let hi = WasmI32.wrapI64(WasmI64.reinterpretF64(y0) >>> 32N)
+      use WasmI32.{ (-), (>>>) }
+      let i = j - (hi >>> 20n & 0x7FFn)
+      if (i > 49n) { // 3rd iteration need, 151 bits acc
+        use WasmF64.{ (-) }
+        let t = r
+        w = q * pio2_3
+        r = t - w
+        w = q * pio2_3t - (t - r - w)
+        y0 = r - w
+      }
+    }
+    use WasmF64.{ (-) }
+    let y1 = r - y0 - w
+    let q = WasmI32.truncF64S(q)
+    return (toInt32(q), toFloat64(y0), toFloat64(y1))
+  }
+
+  let (q, y0, y1) = pio2_large_quot(x, i)
+  let q = fromInt32(q)
+  use WasmI32.{ (*) }
+  let q = if (sign) q * -1n else q
+  return (toInt32(q), y0, y1)
+}

--- a/stdlib/runtime/math/rempio2.md
+++ b/stdlib/runtime/math/rempio2.md
@@ -1,0 +1,14 @@
+---
+title: Rempio2
+---
+
+## Values
+
+Functions and constants included in the Rempio2 module.
+
+### Rempio2.**rempio2**
+
+```grain
+rempio2 : (x: WasmF64, i: WasmI64, sign: Bool) => (Int32, Float64, Float64)
+```
+

--- a/stdlib/runtime/math/trig.gr
+++ b/stdlib/runtime/math/trig.gr
@@ -12,6 +12,8 @@ from "runtime/math/kernel/sin" include KernelSin
 use KernelSin.{ sin as kern_sin }
 from "runtime/math/kernel/cos" include KernelCos
 use KernelCos.{ cos as kern_cos }
+from "runtime/math/kernel/tan" include KernelTan
+use KernelTan.{ tan as kern_tan }
 from "runtime/math/rempio2" include Rempio2
 use Rempio2.{ rempio2 }
 
@@ -87,4 +89,40 @@ provide let cos = (x: WasmF64) => { // see: musl/src/math/cos.c
     2n => kern_cos(y0, y1) * -1.0W,
     _ => kern_sin(y0, y1, true),
   }
+}
+
+@unsafe
+provide let tan = (x: WasmF64) => { // see: musl/src/math/tan.c
+  use WasmI32.{ (&), (<=), (<), (>=), (==) }
+  use WasmI64.{ (>>>) }
+  use WasmF64.{ (-) }
+  let i = WasmI64.reinterpretF64(x)
+  // Get high word of x
+  let ix = WasmI32.wrapI64(i >>> 32N)
+  let ix = ix & 0x7FFFFFFFn
+
+  // |x| ~< pi/4
+  if (ix <= 0x3FE921FBn) {
+    if (ix < 0x3E400000n) { // |x| < 2**-27
+      return x
+    }
+    return kern_tan(x, 0.0W, true)
+  }
+
+  // tan(Inf or NaN) is NaN
+  if (ix >= 0x7FF00000n) return x - x
+
+  use WasmI32.{ (>>>) }
+  let (n, y0, y1) = rempio2(x, i, ix >>> 31n == 0n)
+  let n = fromInt32(n)
+  let y0 = fromFloat64(y0)
+  let y1 = fromFloat64(y1)
+  use WasmI32.{ (-), (&), (<<), (!=) }
+  return match (n & 3n) {
+    0n => kern_tan(y0, y1, true),
+    1n => kern_tan(y0, y1, false),
+    2n => kern_tan(y0, y1, true),
+    _ => kern_sin(y0, y1, false),
+  }
+  // return kern_tan(y0, y1, (n & 1n) != 0n)
 }

--- a/stdlib/runtime/math/trig.gr
+++ b/stdlib/runtime/math/trig.gr
@@ -8,12 +8,12 @@ from "runtime/unsafe/wasmi64" include WasmI64
 from "runtime/unsafe/wasmf64" include WasmF64
 from "runtime/unsafe/conv" include Conv
 use Conv.{ fromInt32, fromFloat64 }
-from "runtime/math/kernel/sin" include KernelSin
-use KernelSin.{ sin as kern_sin }
-from "runtime/math/kernel/cos" include KernelCos
-use KernelCos.{ cos as kern_cos }
-from "runtime/math/kernel/tan" include KernelTan
-use KernelTan.{ tan as kern_tan }
+from "runtime/math/kernel/sin" include Sine
+use Sine.{ sin as kern_sin }
+from "runtime/math/kernel/cos" include Cosine
+use Cosine.{ cos as kern_cos }
+from "runtime/math/kernel/tan" include Tangent
+use Tangent.{ tan as kern_tan }
 from "runtime/math/rempio2" include Rempio2
 use Rempio2.{ rempio2 }
 

--- a/stdlib/runtime/math/trig.gr
+++ b/stdlib/runtime/math/trig.gr
@@ -9,11 +9,11 @@ from "runtime/unsafe/wasmf64" include WasmF64
 from "runtime/unsafe/conv" include Conv
 use Conv.{ fromInt32, fromFloat64 }
 from "runtime/math/kernel/sin" include Sine
-use Sine.{ sin as kern_sin }
+use Sine.{ sin as kernSin }
 from "runtime/math/kernel/cos" include Cosine
-use Cosine.{ cos as kern_cos }
+use Cosine.{ cos as kernCos }
 from "runtime/math/kernel/tan" include Tangent
-use Tangent.{ tan as kern_tan }
+use Tangent.{ tan as kernTan }
 from "runtime/math/rempio2" include Rempio2
 use Rempio2.{ rempio2 }
 
@@ -33,7 +33,7 @@ provide let sin = (x: WasmF64) => { // see: musl/src/math/sin.c
     if (ix < 0x3E500000n) { // |x| < 2**-26
       return x
     }
-    return kern_sin(x, 0.0W, false)
+    return kernSin(x, 0.0W, false)
   }
 
   // sin(Inf or NaN) is NaN
@@ -47,10 +47,10 @@ provide let sin = (x: WasmF64) => { // see: musl/src/math/sin.c
   let y1 = fromFloat64(y1)
 
   return match (n & 3n) {
-    0n => kern_sin(y0, y1, true),
-    1n => kern_cos(y0, y1),
-    2n => kern_sin(y0, y1, true) * -1.0W,
-    _ => kern_cos(y0, y1) * -1.0W,
+    0n => kernSin(y0, y1, true),
+    1n => kernCos(y0, y1),
+    2n => kernSin(y0, y1, true) * -1.0W,
+    _ => kernCos(y0, y1) * -1.0W,
   }
 }
 
@@ -70,7 +70,7 @@ provide let cos = (x: WasmF64) => { // see: musl/src/math/cos.c
     if (ix < 0x3E46A09En) { // |x| < 2**-27 * sqrt(2)
       return 1.0W
     }
-    return kern_cos(x, 0.0W)
+    return kernCos(x, 0.0W)
   }
 
   // cos(Inf or NaN) is NaN
@@ -84,10 +84,10 @@ provide let cos = (x: WasmF64) => { // see: musl/src/math/cos.c
   let y1 = fromFloat64(y1)
 
   return match (n & 3n) {
-    0n => kern_cos(y0, y1),
-    1n => kern_sin(y0, y1, true) * -1.0W,
-    2n => kern_cos(y0, y1) * -1.0W,
-    _ => kern_sin(y0, y1, true),
+    0n => kernCos(y0, y1),
+    1n => kernSin(y0, y1, true) * -1.0W,
+    2n => kernCos(y0, y1) * -1.0W,
+    _ => kernSin(y0, y1, true),
   }
 }
 
@@ -106,7 +106,7 @@ provide let tan = (x: WasmF64) => { // see: musl/src/math/tan.c
     if (ix < 0x3E400000n) { // |x| < 2**-27
       return x
     }
-    return kern_tan(x, 0.0W, true)
+    return kernTan(x, 0.0W, true)
   }
 
   // tan(Inf or NaN) is NaN
@@ -119,10 +119,9 @@ provide let tan = (x: WasmF64) => { // see: musl/src/math/tan.c
   let y1 = fromFloat64(y1)
   use WasmI32.{ (-), (&), (<<), (!=) }
   return match (n & 3n) {
-    0n => kern_tan(y0, y1, true),
-    1n => kern_tan(y0, y1, false),
-    2n => kern_tan(y0, y1, true),
-    _ => kern_sin(y0, y1, false),
+    0n => kernTan(y0, y1, true),
+    1n => kernTan(y0, y1, false),
+    2n => kernTan(y0, y1, true),
+    _ => kernTan(y0, y1, false),
   }
-  // return kern_tan(y0, y1, (n & 1n) != 0n)
 }

--- a/stdlib/runtime/math/trig.gr
+++ b/stdlib/runtime/math/trig.gr
@@ -9,9 +9,9 @@ from "runtime/unsafe/wasmf64" include WasmF64
 from "runtime/unsafe/conv" include Conv
 use Conv.{ fromInt32, fromFloat64 }
 from "runtime/math/kernel/sin" include KernelSin
-use KernelSin.{ sin }
+use KernelSin.{ sin as kern_sin }
 from "runtime/math/kernel/cos" include KernelCos
-use KernelCos.{ cos }
+use KernelCos.{ cos as kern_cos }
 from "runtime/math/rempio2" include Rempio2
 use Rempio2.{ rempio2 }
 
@@ -31,7 +31,7 @@ provide let sin = (x: WasmF64) => { // see: musl/src/math/sin.c
     if (ix < 0x3E500000n) { // |x| < 2**-26
       return x
     }
-    return sin(x, 0.0W, false)
+    return kern_sin(x, 0.0W, false)
   }
 
   // sin(Inf or NaN) is NaN
@@ -45,9 +45,46 @@ provide let sin = (x: WasmF64) => { // see: musl/src/math/sin.c
   let y1 = fromFloat64(y1)
 
   return match (n & 3n) {
-    0n => sin(y0, y1, true),
-    1n => cos(y0, y1),
-    2n => sin(y0, y1, true) * -1.0W,
-    _ => cos(y0, y1) * -1.0W,
+    0n => kern_sin(y0, y1, true),
+    1n => kern_cos(y0, y1),
+    2n => kern_sin(y0, y1, true) * -1.0W,
+    _ => kern_cos(y0, y1) * -1.0W,
+  }
+}
+
+@unsafe
+provide let cos = (x: WasmF64) => { // see: musl/src/math/cos.c
+  use WasmI32.{ (&), (<), (<=), (>=), (==) }
+  use WasmI64.{ (>>>) }
+  use WasmF64.{ (-), (*) }
+  let i = WasmI64.reinterpretF64(x)
+
+  // Get high word of x
+  let ix = WasmI32.wrapI64(i >>> 32N)
+  let ix = ix & 0x7FFFFFFFn
+
+  // |x| ~< pi/4
+  if (ix <= 0x3FE921FBn) {
+    if (ix < 0x3E46A09En) { // |x| < 2**-27 * sqrt(2)
+      return 1.0W
+    }
+    return kern_cos(x, 0.0W)
+  }
+
+  // cos(Inf or NaN) is NaN
+  if (ix >= 0x7FF00000n) return x - x
+
+  // argument reduction needed
+  use WasmI32.{ (>>>) }
+  let (n, y0, y1) = rempio2(x, i, ix >>> 31n == 0n)
+  let n = fromInt32(n)
+  let y0 = fromFloat64(y0)
+  let y1 = fromFloat64(y1)
+
+  return match (n & 3n) {
+    0n => kern_cos(y0, y1),
+    1n => kern_sin(y0, y1, true) * -1.0W,
+    2n => kern_cos(y0, y1) * -1.0W,
+    _ => kern_sin(y0, y1, true),
   }
 }

--- a/stdlib/runtime/math/trig.gr
+++ b/stdlib/runtime/math/trig.gr
@@ -1,0 +1,53 @@
+/**
+ * Raw trigonometric functions.
+ */
+module Trig
+
+from "runtime/unsafe/wasmi32" include WasmI32
+from "runtime/unsafe/wasmi64" include WasmI64
+from "runtime/unsafe/wasmf64" include WasmF64
+from "runtime/unsafe/conv" include Conv
+use Conv.{ fromInt32, fromFloat64 }
+from "runtime/math/kernel/sin" include KernelSin
+use KernelSin.{ sin }
+from "runtime/math/kernel/cos" include KernelCos
+use KernelCos.{ cos }
+from "runtime/math/rempio2" include Rempio2
+use Rempio2.{ rempio2 }
+
+@unsafe
+provide let sin = (x: WasmF64) => { // see: musl/src/math/sin.c
+  use WasmI32.{ (&), (<), (<=), (>=), (==) }
+  use WasmI64.{ (>>>) }
+  use WasmF64.{ (-), (*) }
+
+  let i = WasmI64.reinterpretF64(x)
+  // Get high word of x
+  let ix = WasmI32.wrapI64(i >>> 32N)
+  let ix = ix & 0x7FFFFFFFn
+
+  // |x| ~< pi/4
+  if (ix <= 0x3FE921FBn) {
+    if (ix < 0x3E500000n) { // |x| < 2**-26
+      return x
+    }
+    return sin(x, 0.0W, false)
+  }
+
+  // sin(Inf or NaN) is NaN
+  if (ix >= 0x7FF00000n) return x - x
+
+  // argument reduction needed
+  use WasmI32.{ (>>>) }
+  let (n, y0, y1) = rempio2(x, i, ix >>> 31n == 0n)
+  let n = fromInt32(n)
+  let y0 = fromFloat64(y0)
+  let y1 = fromFloat64(y1)
+
+  return match (n & 3n) {
+    0n => sin(y0, y1, true),
+    1n => cos(y0, y1),
+    2n => sin(y0, y1, true) * -1.0W,
+    _ => cos(y0, y1) * -1.0W,
+  }
+}

--- a/stdlib/runtime/math/trig.md
+++ b/stdlib/runtime/math/trig.md
@@ -1,0 +1,22 @@
+---
+title: Trig
+---
+
+Raw trigonometric functions.
+
+## Values
+
+Functions and constants included in the Trig module.
+
+### Trig.**sin**
+
+```grain
+sin : (x: WasmF64) => WasmF64
+```
+
+### Trig.**cos**
+
+```grain
+cos : (x: WasmF64) => WasmF64
+```
+

--- a/stdlib/runtime/math/trig.md
+++ b/stdlib/runtime/math/trig.md
@@ -20,3 +20,9 @@ sin : (x: WasmF64) => WasmF64
 cos : (x: WasmF64) => WasmF64
 ```
 
+### Trig.**tan**
+
+```grain
+tan : (x: WasmF64) => WasmF64
+```
+

--- a/stdlib/runtime/math/umuldi.gr
+++ b/stdlib/runtime/math/umuldi.gr
@@ -1,0 +1,26 @@
+module Umuldi
+
+from "runtime/unsafe/wasmi32" include WasmI32
+from "runtime/unsafe/wasmi64" include WasmI64
+from "runtime/unsafe/conv" include Conv
+use Conv.{ toUint64 }
+
+@unsafe
+provide let umuldi = (u: WasmI64, v: WasmI64) => { // see: jdh8/metallic/blob/master/src/soft/integer/umulditi3.h
+  use WasmI64.{ (+), (*), (&), (>>>), (<<) }
+  let u1 = u & 0xFFFFFFFFN
+  let v1 = v & 0xFFFFFFFFN
+
+  let a1 = u >>> 32N
+  let b1 = v >>> 32N
+
+  let t = u1 * v1
+  let w0 = t & 0xFFFFFFFFN
+  let t = a1 * v1 + (t >>> 32N)
+  let w1 = t >>> 32N
+  let t = u1 * b1 + (t & 0xFFFFFFFFN)
+
+  let result = (t << 32N) + w0
+  let res128_hi = a1 * b1 + w1 + (t >>> 32N)
+  return (toUint64(result), toUint64(res128_hi))
+}

--- a/stdlib/runtime/math/umuldi.md
+++ b/stdlib/runtime/math/umuldi.md
@@ -1,0 +1,14 @@
+---
+title: Umuldi
+---
+
+## Values
+
+Functions and constants included in the Umuldi module.
+
+### Umuldi.**umuldi**
+
+```grain
+umuldi : (u: WasmI64, v: WasmI64) => (Uint64, Uint64)
+```
+


### PR DESCRIPTION
This pr reintroduces `Number.sin` after it was removed in #2046, this uses the implementation found in [libc](https://git.musl-libc.org/cgit/musl/tree/src/math), with some adaptations made for wasm and grain. It uses a small kernal function that accuratly can compute `sin` for values between `-pi/4` to `pi/4` and a range reduction algorithm to map any values outside the range into the range efficently.

Notes:
* I made a new math folder in the stdlib, as these functions can be used for multiple number types it makes sense to seperate them out so they are easier to understand.
* I am going to make a follow up pr for `gamma` and `factorial`
* I am going to make another follow up pr for `Float32` and `Float64`, `sin`, `cos` and `tan`
Some Notes:
* When it comes to bigints we lose a lot of accuracy do to how `f64`s store numbers.


work for #1478 