### PR TITLE
fix(runtime): Correct `Bi.toFloat64` rounding

### DIFF
--- a/compiler/test/stdlib/float64.test.gr
+++ b/compiler/test/stdlib/float64.test.gr
@@ -27,8 +27,10 @@ assert fromNumber(-1/2) == -0.5d
 // Not exact because of ieee754 rounding error
 assert fromNumber(18_446_744_073_709_551_615) == 18_446_744_073_709_552_000.0d
 assert fromNumber(18_446_744_073_709_551_616) == 18_446_744_073_709_552_000.0d
+assert fromNumber(18_446_744_073_709_551_616) == 18_446_744_073_709_551_616.0d
 assert fromNumber(-18_446_744_073_709_551_615) == -18446744073709552000.0d
 assert fromNumber(-18_446_744_073_709_551_616) == -18446744073709552000.0d
+assert fromNumber(-18_446_744_073_709_551_616) == -18_446_744_073_709_551_616.0d
 // overflow
 assert fromNumber(1.7976931348623157e+309) == Infinityd
 assert fromNumber(-1.7976931348623157e+309) == -Infinityd

--- a/compiler/test/stdlib/float64.test.gr
+++ b/compiler/test/stdlib/float64.test.gr
@@ -21,6 +21,17 @@ assert e == 2.718281828459045d
 let fromNumber = fromNumber
 assert fromNumber(5) == 5.0d
 assert fromNumber(0) == 0.0d
+assert fromNumber(0.5) == 0.5d
+assert fromNumber(1/2) == 0.5d
+assert fromNumber(-1/2) == -0.5d
+// Not exact because of ieee754 rounding error
+assert fromNumber(18_446_744_073_709_551_615) == 18_446_744_073_709_552_000.0d
+assert fromNumber(18_446_744_073_709_551_616) == 18_446_744_073_709_552_000.0d
+assert fromNumber(-18_446_744_073_709_551_615) == -18446744073709552000.0d
+assert fromNumber(-18_446_744_073_709_551_616) == -18446744073709552000.0d
+// overflow
+assert fromNumber(1.7976931348623157e+309) == Infinityd
+assert fromNumber(-1.7976931348623157e+309) == -Infinityd
 
 assert toNumber(555.0d) == 555
 assert toNumber(0.0d) == 0

--- a/stdlib/runtime/bigint.gr
+++ b/stdlib/runtime/bigint.gr
@@ -521,11 +521,8 @@ provide let toFloat64 = (num: WasmI32) => {
     let mut result = 0.0W
     use WasmI32.{ (+) }
     for (let mut i = 0n; WasmI32.ltU(i, numLimbs); i += 1n) {
-      if (!WasmI32.eqz(i)) {
-        result *= factor
-      }
       use WasmF64.{ (+) }
-      result += WasmF64.convertI64U(getLimb(num, i))
+      result += WasmF64.convertI64U(getLimb(num, i)) * factor
     }
     result
   }


### PR DESCRIPTION
We were handling the conversion on `Bigints` to `Float64`s wrong in the runtime. This pr corrects that behaviour and fixes the issue.

I still need to add a regression test. 

Closes: #2159 