### PR TITLE
feat(stdlib): Add `**` to `Float64` and `Float32`

### DIFF
--- a/compiler/test/stdlib/float32.test.gr
+++ b/compiler/test/stdlib/float32.test.gr
@@ -26,6 +26,74 @@ assert fromNumber(0) == 0.0f
 assert toNumber(555.0f) == 555
 assert toNumber(0.0f) == 0
 
+// Float32.pow tests are based on test cases from libc-test: http://nsz.repo.hu/git/?p=libc-test
+/*
+  libc-test is licensed under the following standard MIT license:
+  Copyright © 2005-2013 libc-test AUTHORS
+  Permission is hereby granted, free of charge, to any person obtaining
+  a copy of this software and associated documentation files (the
+  "Software"), to deal in the Software without restriction, including
+  without limitation the rights to use, copy, modify, merge, publish,
+  distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so, subject to
+  the following conditions:
+  The above copyright notice and this permission notice shall be
+  included in all copies or substantial portions of the Software.
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+  CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  Portions of this software is derived from software authored by
+  third parties:
+  math tests use numbers under BSD and GPL licenses see src/math/ucb/*
+  and src/math/crlibm/* for details
+*/
+// pow
+assert Float32.isNaN(-8.06684839057968084f ** 4.53566256067686879f)
+assert 4.34523984933830487f ** -8.88799136300345083f == 0.000002134714122803416f
+assert Float32.isNaN(-8.38143342755524934f ** -2.76360733737958819f)
+assert Float32.isNaN(-6.53167358191348413f ** 4.56753527684274374f)
+assert 9.26705696697258574f ** 4.81139208435979615f == 44909.33203125f
+assert Float32.isNaN(-6.45004555606023633f ** 0.662071792337673881f)
+assert 7.85889025304169664f ** 0.0521545267500622481f == 1.11351774134586523f
+assert Float32.isNaN(-0.792054511984895959f ** 7.67640268511753998f)
+assert 0.615702673197924044f ** 2.01190257903248026f == 0.37690776586532595f
+assert Float32.isNaN(-0.558758682360915193f ** 0.0322398306026380407f)
+assert Float32.isNaN(0.0f ** NaNf)
+assert 0.0f ** Infinityf == 0.0f
+assert 0.0f ** 3.0f == 0.0f
+assert 0.0f ** 2.0f == 0.0f
+assert 0.0f ** 1.0f == 0.0f
+assert 0.0f ** 0.5f == 0.0f
+assert Float32.isNaN(0.0f ** 0.0f)
+assert Float32.isNaN(0.0f ** -0.0f)
+assert 0.0f ** -0.5f == Infinityf
+assert 0.0f ** -1.0f == Infinityf
+assert 0.0f ** -Infinityf == Infinityf
+assert Float32.isNaN(-0.0f ** NaNf)
+assert -0.0f ** Infinityf == 0.0f
+assert -0.0f ** 3.0f == -0.0f
+assert -0.0f ** 0.5f == 0.0f
+assert Float32.isNaN(-0.0f ** 0.0f)
+assert Float32.isNaN(-0.0f ** -0.0f)
+assert -0.0f ** -0.5f == Infinityf
+assert -0.0f ** -1.0f == -Infinityf
+assert -0.0f ** -2.0f == Infinityf
+assert -0.0f ** -3.0f == -Infinityf
+assert -0.0f ** -4.0f == Infinityf
+assert -0.0f ** -Infinityf == Infinityf
+assert Float32.isNaN(NaNf ** 0.0f)
+assert Float32.isNaN(Infinityf ** 0.0f)
+assert Float32.isNaN(-Infinityf ** 0.0f)
+assert Float32.isNaN(1.0f ** 0.0f)
+assert Float32.isNaN(-1.0f ** 0.0f)
+assert Float32.isNaN(-0.5f ** 0.0f)
+assert Float32.isNaN(NaNf ** -0.0f)
+assert 300.0f ** 1.0f == 300.0f
+
 assert 5.0f > 4.0f
 assert 5.0f >= 5.0f
 assert 5.0f < 17.0f

--- a/compiler/test/stdlib/float64.test.gr
+++ b/compiler/test/stdlib/float64.test.gr
@@ -25,6 +25,75 @@ assert fromNumber(0) == 0.0d
 assert toNumber(555.0d) == 555
 assert toNumber(0.0d) == 0
 
+// Float64.pow tests are based on test cases from libc-test: http://nsz.repo.hu/git/?p=libc-test
+/*
+  libc-test is licensed under the following standard MIT license:
+  Copyright © 2005-2013 libc-test AUTHORS
+  Permission is hereby granted, free of charge, to any person obtaining
+  a copy of this software and associated documentation files (the
+  "Software"), to deal in the Software without restriction, including
+  without limitation the rights to use, copy, modify, merge, publish,
+  distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so, subject to
+  the following conditions:
+  The above copyright notice and this permission notice shall be
+  included in all copies or substantial portions of the Software.
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+  CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  Portions of this software is derived from software authored by
+  third parties:
+  math tests use numbers under BSD and GPL licenses see src/math/ucb/*
+  and src/math/crlibm/* for details
+*/
+// pow
+assert Float64.isNaN(-8.06684839057968084d ** 4.53566256067686879d)
+assert 4.34523984933830487d ** -8.88799136300345083d ==
+  0.00000213471188255872853d
+assert Float64.isNaN(-8.38143342755524934d ** -2.76360733737958819d)
+assert Float64.isNaN(-6.53167358191348413d ** 4.56753527684274374d)
+assert 9.26705696697258574d ** 4.81139208435979615d == 44909.2994151296589d
+assert Float64.isNaN(-6.45004555606023633d ** 0.662071792337673881d)
+assert 7.85889025304169664d ** 0.0521545267500622481d == 1.11351774134586523d
+assert Float64.isNaN(-0.792054511984895959d ** 7.67640268511753998d)
+assert 0.615702673197924044d ** 2.01190257903248026d == 0.376907735213801831d
+assert Float64.isNaN(-0.558758682360915193d ** 0.0322398306026380407d)
+assert Float64.isNaN(0.0d ** NaNd)
+assert 0.0d ** Infinityd == 0.0d
+assert 0.0d ** 3.0d == 0.0d
+assert 0.0d ** 2.0d == 0.0d
+assert 0.0d ** 1.0d == 0.0d
+assert 0.0d ** 0.5d == 0.0d
+assert Float64.isNaN(0.0d ** 0.0d)
+assert Float64.isNaN(0.0d ** -0.0d)
+assert 0.0d ** -0.5d == Infinityd
+assert 0.0d ** -1.0d == Infinityd
+assert 0.0d ** -Infinityd == Infinityd
+assert Float64.isNaN(-0.0d ** NaNd)
+assert -0.0d ** Infinityd == 0.0d
+assert -0.0d ** 3.0d == -0.0d
+assert -0.0d ** 0.5d == 0.0d
+assert Float64.isNaN(-0.0d ** 0.0d)
+assert Float64.isNaN(-0.0d ** -0.0d)
+assert -0.0d ** -0.5d == Infinityd
+assert -0.0d ** -1.0d == -Infinityd
+assert -0.0d ** -2.0d == Infinityd
+assert -0.0d ** -3.0d == -Infinityd
+assert -0.0d ** -4.0d == Infinityd
+assert -0.0d ** -Infinityd == Infinityd
+assert Float64.isNaN(NaNd ** 0.0d)
+assert Float64.isNaN(Infinityd ** 0.0d)
+assert Float64.isNaN(-Infinityd ** 0.0d)
+assert Float64.isNaN(1.0d ** 0.0d)
+assert Float64.isNaN(-1.0d ** 0.0d)
+assert Float64.isNaN(-0.5d ** 0.0d)
+assert Float64.isNaN(NaNd ** -0.0d)
+assert 300.0d ** 1.0d == 300.0d
+
 assert 5.0d > 4.0d
 assert 5.0d >= 5.0d
 assert 5.0d < 17.0d

--- a/stdlib/float32.gr
+++ b/stdlib/float32.gr
@@ -14,6 +14,7 @@ module Float32
 
 from "runtime/unsafe/wasmi32" include WasmI32
 from "runtime/unsafe/wasmf32" include WasmF32
+from "runtime/unsafe/wasmf64" include WasmF64
 use WasmF32.{ (+), (-), (*), (/), (<), (<=), (>), (>=) }
 from "runtime/dataStructures" include DataStructures
 use DataStructures.{ newFloat32 }
@@ -153,6 +154,31 @@ provide let (/) = (x: Float32, y: Float32) => {
   let xv = WasmF32.load(WasmI32.fromGrain(x), _VALUE_OFFSET)
   let yv = WasmF32.load(WasmI32.fromGrain(y), _VALUE_OFFSET)
   let ptr = newFloat32(xv / yv)
+  WasmI32.toGrain(ptr): Float32
+}
+
+/**
+ * Computes the exponentiation of the given base and power.
+ *
+ * @param base: The base float
+ * @param power: The exponent float
+ * @returns The base raised to the given power
+ *
+ * @example
+ * use Float64.{ (**) }
+ * assert 2.0f ** 2.0f == 4.0f
+ *
+ * @since v0.7.0
+ */
+@unsafe
+provide let (**) = (base: Float32, power: Float32) => {
+  let basev = WasmF32.load(WasmI32.fromGrain(base), _VALUE_OFFSET)
+  let powerv = WasmF32.load(WasmI32.fromGrain(power), _VALUE_OFFSET)
+  let value = Numbers.powf(
+    WasmF64.promoteF32(basev),
+    WasmF64.promoteF32(powerv)
+  )
+  let ptr = newFloat32(WasmF32.demoteF64(value))
   WasmI32.toGrain(ptr): Float32
 }
 

--- a/stdlib/float32.md
+++ b/stdlib/float32.md
@@ -310,6 +310,39 @@ use Float32.{ (/) }
 assert 10.0f / 4.0f == 2.5f
 ```
 
+### Float32.**(\*\*)**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+(**) : (base: Float32, power: Float32) => Float32
+```
+
+Computes the exponentiation of the given base and power.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`base`|`Float32`|The base float|
+|`power`|`Float32`|The exponent float|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Float32`|The base raised to the given power|
+
+Examples:
+
+```grain
+use Float64.{ (**) }
+assert 2.0f ** 2.0f == 4.0f
+```
+
 ### Float32.**(<)**
 
 <details>

--- a/stdlib/float64.gr
+++ b/stdlib/float64.gr
@@ -157,6 +157,27 @@ provide let (/) = (x: Float64, y: Float64) => {
 }
 
 /**
+ * Computes the exponentiation of the given base and power.
+ *
+ * @param base: The base float
+ * @param power: The exponent float
+ * @returns The base raised to the given power
+ *
+ * @example
+ * use Float64.{ (**) }
+ * assert 2.0d ** 2.0d == 4.0d
+ *
+ * @since v0.7.0
+ */
+@unsafe
+provide let (**) = (base: Float64, power: Float64) => {
+  let basev = WasmF64.load(WasmI32.fromGrain(base), _VALUE_OFFSET)
+  let powerv = WasmF64.load(WasmI32.fromGrain(power), _VALUE_OFFSET)
+  let ptr = newFloat64(Numbers.powf(basev, powerv))
+  WasmI32.toGrain(ptr): Float64
+}
+
+/**
  * Checks if the first value is less than the second value.
  *
  * @param x: The first value

--- a/stdlib/float64.md
+++ b/stdlib/float64.md
@@ -310,6 +310,39 @@ use Float64.{ (/) }
 assert 25.0d / 4.0d == 6.25d
 ```
 
+### Float64.**(\*\*)**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+(**) : (base: Float64, power: Float64) => Float64
+```
+
+Computes the exponentiation of the given base and power.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`base`|`Float64`|The base float|
+|`power`|`Float64`|The exponent float|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Float64`|The base raised to the given power|
+
+Examples:
+
+```grain
+use Float64.{ (**) }
+assert 2.0d ** 2.0d == 4.0d
+```
+
 ### Float64.**(<)**
 
 <details>

--- a/stdlib/runtime/numbers.gr
+++ b/stdlib/runtime/numbers.gr
@@ -2923,6 +2923,343 @@ let rec expBySquaring = (y, x, n) => {
   }
 }
 
+// Math.pow for floats
+@unsafe
+provide let powf = (x: WasmF64, y: WasmF64) => {
+  // Based on https://git.musl-libc.org/cgit/musl/tree/src/math/pow.c
+  use WasmF64.{ (==), (!=), (<=), (/), (*), (+) }
+  // Fast paths
+  if (WasmF64.abs(y) <= 2.0W) {
+    if (y == 2.0W) {
+      return x * x
+    } else if (y == 0.5W) {
+      if (x != InfinityW) {
+        return WasmF64.abs(WasmF64.sqrt(x))
+      } else {
+        return InfinityW
+      }
+    } else if (y == -1.0W) {
+      return 1.0W / x
+    } else if (y == 1.0W) {
+      return x
+    } else if (y == 0.0W) {
+      return NaNW
+    }
+  }
+  // Full calculation
+  let dp_h1 = WasmF64.reinterpretI64(0x3FE2B80340000000N)
+  let dp_l1 = WasmF64.reinterpretI64(0x3E4CFDEB43CFD006N)
+  let two53 = WasmF64.reinterpretI64(0x4340000000000000N)
+  let huge = WasmF64.reinterpretI64(0x7E37E43C8800759CN)
+  let tiny = WasmF64.reinterpretI64(0x01A56E1FC2F8F359N)
+  let l1 = WasmF64.reinterpretI64(0x3FE3333333333303N)
+  let l2 = WasmF64.reinterpretI64(0x3FDB6DB6DB6FABFFN)
+  let l3 = WasmF64.reinterpretI64(0x3FD55555518F264DN)
+  let l4 = WasmF64.reinterpretI64(0x3FD17460A91D4101N)
+  let l5 = WasmF64.reinterpretI64(0x3FCD864A93C9DB65N)
+  let l6 = WasmF64.reinterpretI64(0x3FCA7E284A454EEFN)
+  let p1 = WasmF64.reinterpretI64(0x3FC555555555553EN)
+  let p2 = WasmF64.reinterpretI64(0xBF66C16C16BEBD93N)
+  let p3 = WasmF64.reinterpretI64(0x3F11566AAF25DE2CN)
+  let p4 = WasmF64.reinterpretI64(0xBEBBBD41C5D26BF1N)
+  let p5 = WasmF64.reinterpretI64(0x3E66376972BEA4D0N)
+  let lg2 = WasmF64.reinterpretI64(0x3FE62E42FEFA39EFN)
+  let lg2_h = WasmF64.reinterpretI64(0x3FE62E4300000000N)
+  let lg2_l = WasmF64.reinterpretI64(0xBE205C610CA86C39N)
+  let ovt = WasmF64.reinterpretI64(0x3C971547652B82FEN)
+  let cp = WasmF64.reinterpretI64(0x3FEEC709DC3A03FDN)
+  let cp_h = WasmF64.reinterpretI64(0x3FEEC709E0000000N)
+  let cp_l = WasmF64.reinterpretI64(0xBE3E2FE0145B01F5N)
+  let ivln2 = WasmF64.reinterpretI64(0x3FF71547652B82FEN)
+  let ivln2_h = WasmF64.reinterpretI64(0x3FF7154760000000N)
+  let ivln2_l = WasmF64.reinterpretI64(0x3E54AE0BF85DDF44N)
+  let inv3 = WasmF64.reinterpretI64(0x3FD5555555555555N)
+  use WasmI32.{
+    (==),
+    (!=),
+    (>=),
+    (<=),
+    (&),
+    (|),
+    (>),
+    (<),
+    (<<),
+    (>>),
+    (-),
+    (+),
+  }
+  use WasmI64.{ (>>) as shrSWasmI64 }
+  let u_ = WasmI64.reinterpretF64(x)
+  let hx = WasmI32.wrapI64(shrSWasmI64(u_, 32N))
+  let lx = WasmI32.wrapI64(u_)
+  let u_ = WasmI64.reinterpretF64(y)
+  let hy = WasmI32.wrapI64(shrSWasmI64(u_, 32N))
+  let ly = WasmI32.wrapI64(u_)
+  let mut ix = hx & 0x7FFFFFFFn
+  let iy = hy & 0x7FFFFFFFn
+  if ((iy | ly) == 0n) { // x**0 = 1, even if x is NaN
+    return 1.0W
+  } else if (
+    // Either Argument is Nan
+    ix > 0x7FF00000n ||
+    ix == 0x7FF00000n && lx != 0n ||
+    iy > 0x7FF00000n ||
+    iy == 0x7FF00000n && ly != 0n
+  ) {
+    use WasmF64.{ (+) }
+    return x + y
+  }
+  let mut yisint = 0n
+  let mut k = 0n
+  if (hx < 0n) {
+    if (iy >= 0x43400000n) {
+      yisint = 2n
+    } else if (iy >= 0x3FF00000n) {
+      k = (iy >> 20n) - 0x3FFn
+      let mut offset = 0n
+      let mut _ly = 0n
+      if (k > 20n) {
+        offset = 52n - k
+        _ly = ly
+      } else {
+        offset = 20n - k
+        _ly = iy
+      }
+      let jj = _ly >> offset
+      if (jj << offset == _ly) yisint = 2n - (jj & 1n)
+    }
+  }
+  if (ly == 0n) {
+    if (iy == 0x7FF00000n) { // y is +- inf
+      if ((ix - 0x3FF00000n | lx) == 0n) { // C: (-1)**+-inf is 1, JS: NaN
+        return NaNW
+      } else if (ix >= 0x3FF00000n) { // (|x|>1)**+-inf = inf,0
+        return if (hy >= 0n) y else 0.0W
+      } else { // (|x|<1)**+-inf = 0,inf
+        return if (hy >= 0n) 0.0W else y * -1.0W
+      }
+    } else if (iy == 0x3FF00000n) {
+      return if (hy >= 0n) x else 1.0W / x
+    } else if (hy == 0x3FE00000n) {
+      return x * x
+    } else if (hy == 0x3FE00000n) {
+      if (hx >= 0n) {
+        return WasmF64.sqrt(x)
+      }
+    }
+  }
+  let mut ax = WasmF64.abs(x)
+  let mut z = 0.0W
+  if (lx == 0n && (ix == 0n || ix == 0x7FF00000n || ix == 0x3FF00000n)) {
+    z = ax
+    if (hy < 0n) z = 1.0W / z
+    if (hx < 0n) {
+      if ((ix - 0x3FF00000n | yisint) == 0n) {
+        use WasmF64.{ (-) }
+        let d = z - z
+        z = d / d
+      } else if (yisint == 1n) {
+        z *= -1.0W
+      }
+    }
+    return z
+  }
+  let mut s = 1.0W
+  if (hx < 0n) {
+    if (yisint == 0n) {
+      return NaNW
+    } else if (yisint == 1n) {
+      s = -1.0W
+    }
+  }
+  let mut t1 = 0.0W
+  and t2 = 0.0W
+  and p_h = 0.0W
+  and p_l = 0.0W
+  and r = 0.0W
+  and t = 0.0W
+  and u = 0.0W
+  and v = 0.0W
+  and w = 0.0W
+  let mut j = 0n
+  and n = 0n
+  if (iy > 0x41E00000n) {
+    if (iy > 0x43F00000n) {
+      if (ix <= 0x3FEFFFFFn) {
+        let output = if (hy < 0n) huge * huge else tiny * tiny
+        return output
+      } else if (ix >= 0x3FF00000n) {
+        let output = if (hy > 0n) huge * huge else tiny * tiny
+        return output
+      }
+    }
+    if (ix < 0x3FEFFFFFn) {
+      if (hy < 0n) {
+        return s * huge * huge
+      } else {
+        return s * tiny * tiny
+      }
+    } else if (ix > 0x3FF00000n) {
+      if (hy > 0n) {
+        return s * huge * huge
+      } else {
+        return s * tiny * tiny
+      }
+    } else {
+      use WasmF64.{ (-), (+) }
+      use WasmI64.{ (&) }
+      t = ax - 1.0W
+      w = t * t * (0.5W - t * (inv3 - t * 0.25W))
+      u = ivln2_h * t
+      v = t * ivln2_l - w * ivln2
+      t1 = u + v
+      t1 = WasmF64.reinterpretI64(
+        WasmI64.reinterpretF64(t1) & 0xFFFFFFFF00000000N
+      )
+      t2 = v - (t1 - u)
+    }
+  } else {
+    let mut ss = 0.0W
+    and s2 = 0.0W
+    and s_h = 0.0W
+    and s_l = 0.0W
+    and t_h = 0.0W
+    and t_l = 0.0W
+    n = 0n
+    if (ix < 0x00100000n) {
+      use WasmI64.{ (>>>) }
+      ax *= two53
+      n -= 53n
+      ix = WasmI32.wrapI64(WasmI64.reinterpretF64(ax) >>> 32N)
+    }
+    n += (ix >> 20n) - 0x3FFn
+    j = ix & 0x000FFFFFn
+    ix = j | 0x3FF00000n
+    if (j <= 0x3988En) {
+      k = 0n
+    } else if (j < 0xBB67An) {
+      k = 1n
+    } else {
+      k = 0n
+      n += 1n
+      ix -= 0x00100000n
+    }
+    use WasmI64.{ (&), (|), (<<) }
+    ax = WasmF64.reinterpretI64(
+      WasmI64.reinterpretF64(ax) & 0xFFFFFFFFN | WasmI64.extendI32S(ix) << 32N
+    )
+    let bp = if (k != 0n) 1.5W else 1.0W
+    use WasmF64.{ (+), (-) }
+    u = ax - bp
+    v = 1.0W / (ax + bp)
+    ss = u * v
+    s_h = ss
+    s_h = WasmF64.reinterpretI64(
+      WasmI64.reinterpretF64(s_h) & 0xFFFFFFFF00000000N
+    )
+    use WasmI32.{ (+), (|), (<<) as shlWasmI64 }
+    t_h = WasmF64.reinterpretI64(
+      WasmI64.extendI32S(
+        (ix >> 1n | 0x20000000n) + 0x00080000n + shlWasmI64(k, 18n)
+      ) <<
+        32N
+    )
+    use WasmF64.{ (+) }
+    t_l = ax - (t_h - bp)
+    s_l = v * (u - s_h * t_h - s_h * t_l)
+    s2 = ss * ss
+    //formatter-ignore
+    r = s2 * s2 * (l1 + s2 * (l2 + s2 * (l3 + s2 * (l4 + s2 * (l5 + s2 * l6)))))
+    r += s_l * (s_h + ss)
+    s2 = s_h * s_h
+    t_h = 3.0W + s2 + r
+    t_h = WasmF64.reinterpretI64(
+      WasmI64.reinterpretF64(t_h) & 0xFFFFFFFF00000000N
+    )
+    t_l = r - (t_h - 3.0W - s2)
+    u = s_h * t_h
+    v = s_l * t_h + t_l * ss
+    p_h = u + v
+    p_h = WasmF64.reinterpretI64(
+      WasmI64.reinterpretF64(p_h) & 0xFFFFFFFF00000000N
+    )
+    p_l = v - (p_h - u)
+    let z_h = cp_h * p_h
+    let dp_l = if (k != 0n) dp_l1 else 0.0W
+    let z_l = cp_l * p_h + p_l * cp + dp_l
+    t = WasmF64.convertI32S(n)
+    let dp_h = if (k != 0n) dp_h1 else 0.0W
+    t1 = z_h + z_l + dp_h + t
+    t1 = WasmF64.reinterpretI64(
+      WasmI64.reinterpretF64(t1) & 0xFFFFFFFF00000000N
+    )
+    t2 = z_l - (t1 - t - dp_h - z_h)
+  }
+  use WasmF64.{ (>), (-), (+) }
+  use WasmI64.{ (&), (>>), (<<) }
+  let y1 = WasmF64.reinterpretI64(
+    WasmI64.reinterpretF64(y) & 0xFFFFFFFF00000000N
+  )
+  p_l = (y - y1) * t1 + y * t2
+  p_h = y1 * t1
+  z = p_l + p_h
+  let u_ = WasmI64.reinterpretF64(z)
+  let j = WasmI32.wrapI64(u_ >> 32N)
+  let i = WasmI32.wrapI64(u_)
+  use WasmI32.{ (-) as addWasmI32, (&) }
+  if (j >= 0x40900000n) {
+    if ((addWasmI32(j, 0x40900000n) | i) != 0n || p_l + ovt > z - p_h) {
+      return s * huge * huge
+    }
+  } else if ((j & 0x7FFFFFFFn) >= 0x4090CC00n) {
+    use WasmF64.{ (<=) }
+    if (addWasmI32(j, 0xC090CC00n | i) != 0n || p_l <= z - p_h) {
+      return s * tiny * tiny
+    }
+  }
+  use WasmI32.{ (&), (>>), (-), (+), (>), (*), (<<), (^) }
+  let i = j & 0x7FFFFFFFn
+  k = (i >> 20n) - 0x3FFn
+  n = 0n
+  if (i > 0x3FE00000n) {
+    use WasmI64.{ (<<) }
+    n = j + (0x00100000n >> (k + 1n))
+    k = ((n & 0x7FFFFFFFn) >> 20n) - 0x3FFn
+    t = 0.0W
+    t = WasmF64.reinterpretI64(
+      WasmI64.extendI32S(n & (0x000FFFFFn >> k ^ -1n)) << 32N
+    )
+    n = (n & 0x000FFFFFn | 0x00100000n) >> (20n - k)
+    if (j < 0n) n *= -1n
+    use WasmF64.{ (-) }
+    p_h -= t
+  }
+  use WasmI64.{ (&), (|) }
+  use WasmF64.{ (*), (+), (-) }
+  t = p_l + p_h
+  t = WasmF64.reinterpretI64(WasmI64.reinterpretF64(t) & 0xFFFFFFFF00000000N)
+  u = t * lg2_h
+  v = (p_l - (t - p_h)) * lg2 + t * lg2_l
+  z = u + v
+  w = v - (z - u)
+  t = z * z
+  t1 = z - t * (p1 + t * (p2 + t * (p3 + t * (p4 + t * p5))))
+  r = z * t1 / (t1 - 2.0W) - (w + z * w)
+  z = 1.0W - (r - z)
+  use WasmI32.{ (+) }
+  let j = WasmI32.wrapI64(shrSWasmI64(WasmI64.reinterpretF64(z), 32N)) +
+    (n << 20n)
+  if (j >> 20n <= 0n) {
+    z = scalbn(z, n)
+  } else {
+    use WasmI64.{ (<<) }
+    z = WasmF64.reinterpretI64(
+      WasmI64.reinterpretF64(z) & 0xFFFFFFFFN | WasmI64.extendI32S(j) << 32N
+    )
+  }
+  return s * z
+}
+
 // Math.pow is largely based on https://git.musl-libc.org/cgit/musl/tree/src/math/pow.c
 /*
  * ====================================================
@@ -2976,354 +3313,9 @@ provide let (**) = (base, power) => {
       expBySquaring(1, denominator, power)
     numerator / denominator
   } else {
-    // Based on https://git.musl-libc.org/cgit/musl/tree/src/math/pow.c
-    use WasmF64.{ (==), (!=), (<=), (/), (*), (+) }
     let x = coerceNumberToWasmF64(base)
     let y = coerceNumberToWasmF64(power)
-    // Fast paths
-    if (WasmF64.abs(y) <= 2.0W) {
-      if (y == 2.0W) {
-        return WasmI32.toGrain(newFloat64(x * x)): Number
-      } else if (y == 0.5W) {
-        if (x != InfinityW) {
-          return WasmI32.toGrain(newFloat64(WasmF64.abs(WasmF64.sqrt(x)))):
-            Number
-        } else {
-          return Infinity
-        }
-      } else if (y == -1.0W) {
-        return WasmI32.toGrain(newFloat64(1.0W / x)): Number
-      } else if (y == 1.0W) {
-        return WasmI32.toGrain(newFloat64(x)): Number
-      } else if (y == 0.0W) {
-        return NaN
-      }
-    }
-    // Full calculation
-    let dp_h1 = WasmF64.reinterpretI64(0x3FE2B80340000000N)
-    let dp_l1 = WasmF64.reinterpretI64(0x3E4CFDEB43CFD006N)
-    let two53 = WasmF64.reinterpretI64(0x4340000000000000N)
-    let huge = WasmF64.reinterpretI64(0x7E37E43C8800759CN)
-    let tiny = WasmF64.reinterpretI64(0x01A56E1FC2F8F359N)
-    let l1 = WasmF64.reinterpretI64(0x3FE3333333333303N)
-    let l2 = WasmF64.reinterpretI64(0x3FDB6DB6DB6FABFFN)
-    let l3 = WasmF64.reinterpretI64(0x3FD55555518F264DN)
-    let l4 = WasmF64.reinterpretI64(0x3FD17460A91D4101N)
-    let l5 = WasmF64.reinterpretI64(0x3FCD864A93C9DB65N)
-    let l6 = WasmF64.reinterpretI64(0x3FCA7E284A454EEFN)
-    let p1 = WasmF64.reinterpretI64(0x3FC555555555553EN)
-    let p2 = WasmF64.reinterpretI64(0xBF66C16C16BEBD93N)
-    let p3 = WasmF64.reinterpretI64(0x3F11566AAF25DE2CN)
-    let p4 = WasmF64.reinterpretI64(0xBEBBBD41C5D26BF1N)
-    let p5 = WasmF64.reinterpretI64(0x3E66376972BEA4D0N)
-    let lg2 = WasmF64.reinterpretI64(0x3FE62E42FEFA39EFN)
-    let lg2_h = WasmF64.reinterpretI64(0x3FE62E4300000000N)
-    let lg2_l = WasmF64.reinterpretI64(0xBE205C610CA86C39N)
-    let ovt = WasmF64.reinterpretI64(0x3C971547652B82FEN)
-    let cp = WasmF64.reinterpretI64(0x3FEEC709DC3A03FDN)
-    let cp_h = WasmF64.reinterpretI64(0x3FEEC709E0000000N)
-    let cp_l = WasmF64.reinterpretI64(0xBE3E2FE0145B01F5N)
-    let ivln2 = WasmF64.reinterpretI64(0x3FF71547652B82FEN)
-    let ivln2_h = WasmF64.reinterpretI64(0x3FF7154760000000N)
-    let ivln2_l = WasmF64.reinterpretI64(0x3E54AE0BF85DDF44N)
-    let inv3 = WasmF64.reinterpretI64(0x3FD5555555555555N)
-    use WasmI32.{
-      (==),
-      (!=),
-      (>=),
-      (<=),
-      (&),
-      (|),
-      (>),
-      (<),
-      (<<),
-      (>>),
-      (-),
-      (+),
-    }
-    use WasmI64.{ (>>) as shrSWasmI64 }
-    let u_ = WasmI64.reinterpretF64(x)
-    let hx = WasmI32.wrapI64(shrSWasmI64(u_, 32N))
-    let lx = WasmI32.wrapI64(u_)
-    let u_ = WasmI64.reinterpretF64(y)
-    let hy = WasmI32.wrapI64(shrSWasmI64(u_, 32N))
-    let ly = WasmI32.wrapI64(u_)
-    let mut ix = hx & 0x7FFFFFFFn
-    let iy = hy & 0x7FFFFFFFn
-    if ((iy | ly) == 0n) { // x**0 = 1, even if x is NaN
-      return 1
-    } else if (
-      // Either Argument is Nan
-      ix > 0x7FF00000n ||
-      ix == 0x7FF00000n && lx != 0n ||
-      iy > 0x7FF00000n ||
-      iy == 0x7FF00000n && ly != 0n
-    ) {
-      use WasmF64.{ (+) }
-      return WasmI32.toGrain(newFloat64(x + y)): Number
-    }
-    let mut yisint = 0n
-    let mut k = 0n
-    if (hx < 0n) {
-      if (iy >= 0x43400000n) {
-        yisint = 2n
-      } else if (iy >= 0x3FF00000n) {
-        k = (iy >> 20n) - 0x3FFn
-        let mut offset = 0n
-        let mut _ly = 0n
-        if (k > 20n) {
-          offset = 52n - k
-          _ly = ly
-        } else {
-          offset = 20n - k
-          _ly = iy
-        }
-        let jj = _ly >> offset
-        if (jj << offset == _ly) yisint = 2n - (jj & 1n)
-      }
-    }
-    if (ly == 0n) {
-      if (iy == 0x7FF00000n) { // y is +- inf
-        if ((ix - 0x3FF00000n | lx) == 0n) { // C: (-1)**+-inf is 1, JS: NaN
-          return NaN
-        } else if (ix >= 0x3FF00000n) { // (|x|>1)**+-inf = inf,0
-          if (hy >= 0n)
-            return WasmI32.toGrain(newFloat64(y)): Number
-          else
-            return 0.0
-        } else { // (|x|<1)**+-inf = 0,inf
-          if (hy >= 0n)
-            return 0.0
-          else
-            return WasmI32.toGrain(newFloat64(y * -1.0W)): Number
-        }
-      } else if (iy == 0x3FF00000n) {
-        if (hy >= 0n)
-          return WasmI32.toGrain(newFloat64(x)): Number
-        else
-          return WasmI32.toGrain(newFloat64(1.0W / x)): Number
-      } else if (hy == 0x3FE00000n) {
-        return WasmI32.toGrain(newFloat64(x * x)): Number
-      } else if (hy == 0x3FE00000n) {
-        if (hx >= 0n) {
-          return WasmI32.toGrain(newFloat64(WasmF64.sqrt(x))): Number
-        }
-      }
-    }
-    let mut ax = WasmF64.abs(x)
-    let mut z = 0.0W
-    if (lx == 0n && (ix == 0n || ix == 0x7FF00000n || ix == 0x3FF00000n)) {
-      z = ax
-      if (hy < 0n) z = 1.0W / z
-      if (hx < 0n) {
-        if ((ix - 0x3FF00000n | yisint) == 0n) {
-          use WasmF64.{ (-) }
-          let d = z - z
-          z = d / d
-        } else if (yisint == 1n) {
-          z *= -1.0W
-        }
-      }
-      return WasmI32.toGrain(newFloat64(z)): Number
-    }
-    let mut s = 1.0W
-    if (hx < 0n) {
-      if (yisint == 0n) {
-        return NaN
-      } else if (yisint == 1n) {
-        s = -1.0W
-      }
-    }
-    let mut t1 = 0.0W
-    and t2 = 0.0W
-    and p_h = 0.0W
-    and p_l = 0.0W
-    and r = 0.0W
-    and t = 0.0W
-    and u = 0.0W
-    and v = 0.0W
-    and w = 0.0W
-    let mut j = 0n
-    and n = 0n
-    if (iy > 0x41E00000n) {
-      if (iy > 0x43F00000n) {
-        if (ix <= 0x3FEFFFFFn) {
-          let output = if (hy < 0n) huge * huge else tiny * tiny
-          return WasmI32.toGrain(newFloat64(output)): Number
-        } else if (ix >= 0x3FF00000n) {
-          let output = if (hy > 0n) huge * huge else tiny * tiny
-          return WasmI32.toGrain(newFloat64(output)): Number
-        }
-      }
-      if (ix < 0x3FEFFFFFn) {
-        if (hy < 0n) {
-          return WasmI32.toGrain(newFloat64(s * huge * huge)): Number
-        } else {
-          return WasmI32.toGrain(newFloat64(s * tiny * tiny)): Number
-        }
-      } else if (ix > 0x3FF00000n) {
-        if (hy > 0n) {
-          return WasmI32.toGrain(newFloat64(s * huge * huge)): Number
-        } else {
-          return WasmI32.toGrain(newFloat64(s * tiny * tiny)): Number
-        }
-      } else {
-        use WasmF64.{ (-), (+) }
-        use WasmI64.{ (&) }
-        t = ax - 1.0W
-        w = t * t * (0.5W - t * (inv3 - t * 0.25W))
-        u = ivln2_h * t
-        v = t * ivln2_l - w * ivln2
-        t1 = u + v
-        t1 = WasmF64.reinterpretI64(
-          WasmI64.reinterpretF64(t1) & 0xFFFFFFFF00000000N
-        )
-        t2 = v - (t1 - u)
-      }
-    } else {
-      let mut ss = 0.0W
-      and s2 = 0.0W
-      and s_h = 0.0W
-      and s_l = 0.0W
-      and t_h = 0.0W
-      and t_l = 0.0W
-      n = 0n
-      if (ix < 0x00100000n) {
-        use WasmI64.{ (>>>) }
-        ax *= two53
-        n -= 53n
-        ix = WasmI32.wrapI64(WasmI64.reinterpretF64(ax) >>> 32N)
-      }
-      n += (ix >> 20n) - 0x3FFn
-      j = ix & 0x000FFFFFn
-      ix = j | 0x3FF00000n
-      if (j <= 0x3988En) {
-        k = 0n
-      } else if (j < 0xBB67An) {
-        k = 1n
-      } else {
-        k = 0n
-        n += 1n
-        ix -= 0x00100000n
-      }
-      use WasmI64.{ (&), (|), (<<) }
-      ax = WasmF64.reinterpretI64(
-        WasmI64.reinterpretF64(ax) & 0xFFFFFFFFN | WasmI64.extendI32S(ix) << 32N
-      )
-      let bp = if (k != 0n) 1.5W else 1.0W
-      use WasmF64.{ (+), (-) }
-      u = ax - bp
-      v = 1.0W / (ax + bp)
-      ss = u * v
-      s_h = ss
-      s_h = WasmF64.reinterpretI64(
-        WasmI64.reinterpretF64(s_h) & 0xFFFFFFFF00000000N
-      )
-      use WasmI32.{ (+), (|), (<<) as shlWasmI64 }
-      t_h = WasmF64.reinterpretI64(
-        WasmI64.extendI32S(
-          (ix >> 1n | 0x20000000n) + 0x00080000n + shlWasmI64(k, 18n)
-        ) <<
-          32N
-      )
-      use WasmF64.{ (+) }
-      t_l = ax - (t_h - bp)
-      s_l = v * (u - s_h * t_h - s_h * t_l)
-      s2 = ss * ss
-      //formatter-ignore
-      r = s2 * s2 * (l1 + s2 * (l2 + s2 * (l3 + s2 * (l4 + s2 * (l5 + s2 * l6)))))
-      r += s_l * (s_h + ss)
-      s2 = s_h * s_h
-      t_h = 3.0W + s2 + r
-      t_h = WasmF64.reinterpretI64(
-        WasmI64.reinterpretF64(t_h) & 0xFFFFFFFF00000000N
-      )
-      t_l = r - (t_h - 3.0W - s2)
-      u = s_h * t_h
-      v = s_l * t_h + t_l * ss
-      p_h = u + v
-      p_h = WasmF64.reinterpretI64(
-        WasmI64.reinterpretF64(p_h) & 0xFFFFFFFF00000000N
-      )
-      p_l = v - (p_h - u)
-      let z_h = cp_h * p_h
-      let dp_l = if (k != 0n) dp_l1 else 0.0W
-      let z_l = cp_l * p_h + p_l * cp + dp_l
-      t = WasmF64.convertI32S(n)
-      let dp_h = if (k != 0n) dp_h1 else 0.0W
-      t1 = z_h + z_l + dp_h + t
-      t1 = WasmF64.reinterpretI64(
-        WasmI64.reinterpretF64(t1) & 0xFFFFFFFF00000000N
-      )
-      t2 = z_l - (t1 - t - dp_h - z_h)
-    }
-    use WasmF64.{ (>), (-), (+) }
-    use WasmI64.{ (&), (>>), (<<) }
-    let y1 = WasmF64.reinterpretI64(
-      WasmI64.reinterpretF64(y) & 0xFFFFFFFF00000000N
-    )
-    p_l = (y - y1) * t1 + y * t2
-    p_h = y1 * t1
-    z = p_l + p_h
-    let u_ = WasmI64.reinterpretF64(z)
-    let j = WasmI32.wrapI64(u_ >> 32N)
-    let i = WasmI32.wrapI64(u_)
-    use WasmI32.{ (-) as addWasmI32, (&) }
-    if (j >= 0x40900000n) {
-      if ((addWasmI32(j, 0x40900000n) | i) != 0n) {
-        return WasmI32.toGrain(newFloat64(s * huge * huge)): Number
-      } else if (p_l + ovt > z - p_h) {
-        return WasmI32.toGrain(newFloat64(s * huge * huge)): Number
-      }
-    } else if ((j & 0x7FFFFFFFn) >= 0x4090CC00n) {
-      use WasmF64.{ (<=) }
-      if (addWasmI32(j, 0xC090CC00n | i) != 0n) {
-        return WasmI32.toGrain(newFloat64(s * tiny * tiny)): Number
-      } else if (p_l <= z - p_h) {
-        return WasmI32.toGrain(newFloat64(s * tiny * tiny)): Number
-      }
-    }
-    use WasmI32.{ (&), (>>), (-), (+), (>), (*), (<<), (^) }
-    let i = j & 0x7FFFFFFFn
-    k = (i >> 20n) - 0x3FFn
-    n = 0n
-    if (i > 0x3FE00000n) {
-      use WasmI64.{ (<<) }
-      n = j + (0x00100000n >> (k + 1n))
-      k = ((n & 0x7FFFFFFFn) >> 20n) - 0x3FFn
-      t = 0.0W
-      t = WasmF64.reinterpretI64(
-        WasmI64.extendI32S(n & (0x000FFFFFn >> k ^ -1n)) << 32N
-      )
-      n = (n & 0x000FFFFFn | 0x00100000n) >> (20n - k)
-      if (j < 0n) n *= -1n
-      use WasmF64.{ (-) }
-      p_h -= t
-    }
-    use WasmI64.{ (&), (|) }
-    use WasmF64.{ (*), (+), (-) }
-    t = p_l + p_h
-    t = WasmF64.reinterpretI64(WasmI64.reinterpretF64(t) & 0xFFFFFFFF00000000N)
-    u = t * lg2_h
-    v = (p_l - (t - p_h)) * lg2 + t * lg2_l
-    z = u + v
-    w = v - (z - u)
-    t = z * z
-    t1 = z - t * (p1 + t * (p2 + t * (p3 + t * (p4 + t * p5))))
-    r = z * t1 / (t1 - 2.0W) - (w + z * w)
-    z = 1.0W - (r - z)
-    use WasmI32.{ (+) }
-    let j = WasmI32.wrapI64(shrSWasmI64(WasmI64.reinterpretF64(z), 32N)) +
-      (n << 20n)
-    if (j >> 20n <= 0n) {
-      z = scalbn(z, n)
-    } else {
-      use WasmI64.{ (<<) }
-      z = WasmF64.reinterpretI64(
-        WasmI64.reinterpretF64(z) & 0xFFFFFFFFN | WasmI64.extendI32S(j) << 32N
-      )
-    }
-    WasmI32.toGrain(newFloat64(s * z)): Number
+    WasmI32.toGrain(newFloat64(powf(x, y))): Number
   }
 
   ignore(base)

--- a/stdlib/runtime/numbers.md
+++ b/stdlib/runtime/numbers.md
@@ -1285,6 +1285,12 @@ Returns:
 |----|-----------|
 |`WasmF64`|The result of x * 2^n|
 
+### Numbers.**powf**
+
+```grain
+powf : (x: WasmF64, y: WasmF64) => WasmF64
+```
+
 ### Numbers.**(\*\*)**
 
 <details>


### PR DESCRIPTION
This pr adds the `power` function `2.0d ** 2.0d` to the `Float32` and `Float64` libraries, this uses the same algorithm we use for `Number.pow` without the extra overhead for the different number types, a future improvement we could make is having a separate algorithm for `float32` for better performance.