### PR TITLE
chore(runtime): Avoid branches in `164abs` and `164neg` in `runtime/numbers`

### DIFF
--- a/stdlib/runtime/numbers.gr
+++ b/stdlib/runtime/numbers.gr
@@ -1602,8 +1602,9 @@ let numberDivide = (x, y) => {
 
 @unsafe
 let i64abs = x => {
-  use WasmI64.{ (-), (>=) }
-  if (x >= 0N) x else 0N - x
+  use WasmI64.{ (^), (>>), (-) }
+  let mask = x >> 31N
+  (x ^ mask) - mask
 }
 
 @unsafe

--- a/stdlib/runtime/numbers.gr
+++ b/stdlib/runtime/numbers.gr
@@ -218,19 +218,14 @@ let rec gcdHelp = (x, y) => {
 
 @unsafe
 let gcd = (x, y) => {
-  use WasmI64.{ (<) }
+  use WasmI64.{ (-), (>>), (^) }
   // Algorithm above breaks on negatives, so
   // we make sure that they are positive at the beginning
-  let x = if (x < 0N) {
-    i64neg(x)
-  } else {
-    x
-  }
-  let y = if (y < 0N) {
-    i64neg(y)
-  } else {
-    y
-  }
+  let xMask = x >> 31N
+  let x = (x ^ xMask) - xMask
+  let yMask = y >> 31N
+  let y = (y ^ yMask) - yMask
+
   gcdHelp(x, y)
 }
 


### PR DESCRIPTION
This is a small pr that changes the way we do `abs` and `neg` in the runtime for some of our helpers, normally this would not matter but given we call `gcd` a lot it makes sense to avoid branching.