### PR TITLE
feat(stdlib): `isAscii`,`isAsciiControl`,`isAsciiWhitespace` to `Char`

### DIFF
--- a/compiler/test/stdlib/char.test.gr
+++ b/compiler/test/stdlib/char.test.gr
@@ -87,6 +87,14 @@ assert !('a' >= 'b')
 assert 'a' >= 'a'
 assert 'B' >= 'B'
 
+// isAscii
+assert Char.isAscii('1')
+assert Char.isAscii('a')
+assert Char.isAscii(';')
+assert Char.isAscii(' ')
+assert Char.isAscii('\n')
+assert !Char.isAscii('🌾')
+
 // isAsciiDigit
 assert Char.isAsciiDigit('1')
 assert !Char.isAsciiDigit('a')
@@ -97,6 +105,24 @@ assert !Char.isAsciiAlpha('1')
 assert Char.isAsciiAlpha('a')
 assert Char.isAsciiAlpha('Z')
 assert !Char.isAsciiAlpha('λ')
+
+// isAsciiControl
+assert Char.isAsciiControl('\n')
+assert Char.isAsciiControl('\t')
+assert Char.isAsciiControl('\u{007F}')
+assert !Char.isAsciiControl(' ')
+assert !Char.isAsciiControl('a')
+assert !Char.isAsciiControl('🌾')
+
+// isAsciiWhitespace
+assert Char.isAsciiWhitespace(' ')
+assert Char.isAsciiWhitespace('\t')
+assert Char.isAsciiWhitespace('\n')
+assert Char.isAsciiWhitespace('\r')
+assert Char.isAsciiWhitespace('\x0C')
+assert !Char.isAsciiWhitespace('a')
+assert !Char.isAsciiWhitespace('1')
+assert !Char.isAsciiWhitespace('🌾')
 
 // toAsciiLowercase
 assert Char.toAsciiLowercase('A') == 'a'

--- a/stdlib/char.gr
+++ b/stdlib/char.gr
@@ -315,11 +315,25 @@ provide let (>=) = (x: Char, y: Char) => {
 }
 
 /**
+ * Checks if the character is an ASCII character.
+ *
+ * @param char: The character to check
+ * @returns `true` if the character is an ASCII character or `false` otherwise
+ *
+ * @example assert Char.isAscii('1')
+ * @example assert Char.isAscii('a')
+ * @example assert !Char.isAscii('🌾')
+ *
+ * @since v0.7.0
+ */
+provide let isAscii = char => char <= '\u{007F}' // usv <= 0x7F
+
+/**
  * Checks if the character is an ASCII digit.
  *
  * @param char: The character to check
  * @returns `true` if the character is an ASCII digit or `false` otherwise
- * 
+ *
  * @example assert Char.isAsciiDigit('1')
  * @example assert !Char.isAsciiDigit('a')
  *
@@ -342,13 +356,48 @@ provide let isAsciiAlpha = char =>
   char >= 'a' && char <= 'z' || char >= 'A' && char <= 'Z'
 
 /**
+ * Checks if the character is an ASCII control character.
+ *
+ * @param char: The character to check
+ * @returns `true` if the character is an ASCII control character or `false` otherwise
+ *
+ * @example assert Char.isAsciiControl('\t')
+ * @example assert Char.isAsciiControl('\n')
+ * @example assert !Char.isAsciiControl('1')
+ * @example assert !Char.isAsciiControl('a')
+ *
+ * @since v0.7.0
+ */
+provide let isAsciiControl = char => char <= '\u{001F}' || char == '\u{007F}'
+
+/**
+ * Checks if the character is an ASCII whitespace character.
+ *
+ * @param char: The character to check
+ * @returns `true` if the character is an ASCII whitespace character or `false` otherwise
+ *
+ * @example assert Char.isAsciiWhitespace('\t')
+ * @example assert Char.isAsciiWhitespace('\n')
+ * @example assert !Char.isAsciiWhitespace('1')
+ * @example assert !Char.isAsciiWhitespace('a')
+ *
+ * @since v0.7.0
+ */
+provide let isAsciiWhitespace = char => {
+  match (char) {
+    '\t' | '\n' | '\x0C' | '\r' | ' ' => true,
+    _ => false,
+  }
+}
+
+/**
  * Converts the character to ASCII lowercase if it is an ASCII uppercase character.
- * 
+ *
  * @param char: The character to convert
  * @returns The lowercased character
- * 
+ *
  * @example assert Char.toAsciiLowercase('B') == 'b'
- * 
+ *
  * @since v0.6.0
  */
 provide let toAsciiLowercase = char => {
@@ -361,12 +410,12 @@ provide let toAsciiLowercase = char => {
 
 /**
  * Converts the character to ASCII uppercase if it is an ASCII lowercase character.
- * 
+ *
  * @param char: The character to convert
  * @returns The uppercased character
- * 
+ *
  * @example assert Char.toAsciiUppercase('b') == 'B'
- * 
+ *
  * @since v0.6.0
  */
 provide let toAsciiUppercase = char => {

--- a/stdlib/char.md
+++ b/stdlib/char.md
@@ -447,6 +447,45 @@ use Char.{ (>=) }
 assert 'a' >= 'a'
 ```
 
+### Char.**isAscii**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+isAscii : (char: Char) => Bool
+```
+
+Checks if the character is an ASCII character.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`char`|`Char`|The character to check|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Bool`|`true` if the character is an ASCII character or `false` otherwise|
+
+Examples:
+
+```grain
+assert Char.isAscii('1')
+```
+
+```grain
+assert Char.isAscii('a')
+```
+
+```grain
+assert !Char.isAscii('🌾')
+```
+
 ### Char.**isAsciiDigit**
 
 <details disabled>
@@ -515,6 +554,92 @@ assert Char.isAsciiAlpha('a')
 
 ```grain
 assert !Char.isAsciiAlpha('1')
+```
+
+### Char.**isAsciiControl**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+isAsciiControl : (char: Char) => Bool
+```
+
+Checks if the character is an ASCII control character.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`char`|`Char`|The character to check|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Bool`|`true` if the character is an ASCII control character or `false` otherwise|
+
+Examples:
+
+```grain
+assert Char.isAsciiControl('\t')
+```
+
+```grain
+assert Char.isAsciiControl('\n')
+```
+
+```grain
+assert !Char.isAsciiControl('1')
+```
+
+```grain
+assert !Char.isAsciiControl('a')
+```
+
+### Char.**isAsciiWhitespace**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+isAsciiWhitespace : (char: Char) => Bool
+```
+
+Checks if the character is an ASCII whitespace character.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`char`|`Char`|The character to check|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Bool`|`true` if the character is an ASCII whitespace character or `false` otherwise|
+
+Examples:
+
+```grain
+assert Char.isAsciiWhitespace('\t')
+```
+
+```grain
+assert Char.isAsciiWhitespace('\n')
+```
+
+```grain
+assert !Char.isAsciiWhitespace('1')
+```
+
+```grain
+assert !Char.isAsciiWhitespace('a')
 ```
 
 ### Char.**toAsciiLowercase**


### PR DESCRIPTION
I've been working in rust a little bit and found the variety of ascii functions super helpful notably `isAscii` and `isAsciiWhitespace`, this pr just adds a few more little utility functions for use in the char library.


Question: Would it make sense to move all of the ascii related functions both in this pr and the existing ones to an `Ascii` submodule. (If we do this I will probably also move over a few of the other common ascii group methods like isPunctuation).