### PR TITLE
fix(stdlib): Correct sign bit in `_rempio` when computing trig reduction

### DIFF
--- a/compiler/test/stdlib/number.test.gr
+++ b/compiler/test/stdlib/number.test.gr
@@ -987,7 +987,7 @@ assert Number.isClose( // Note: We lose a lot of precision here do to ieee754 re
 ) // Max F64
 assert Number.isClose(
   Number.sin(-1.7976931348623157e+308),
-  0.00496,
+  -0.00496,
   absoluteTolerance=1e7
 ) // Max F64
 assert Number.isNaN(Number.sin(Infinity))
@@ -1051,7 +1051,7 @@ assert Number.isClose( // Note: We lose a lot of precision here do to ieee754 re
 ) // Max F64
 assert Number.isClose(
   Number.tan(-1.7976931348623157e+308),
-  -0.00496201587,
+  0.00496201587,
   absoluteTolerance=1e7
 ) // Max F64
 assert Number.isNaN(Number.tan(Infinity))

--- a/stdlib/runtime/math/rempio2.gr
+++ b/stdlib/runtime/math/rempio2.gr
@@ -170,7 +170,7 @@ provide let rempio2 = (x: WasmF64, i: WasmI64, sign: Bool) => {
   let ix = WasmI32.wrapI64(i >>> 32N) & 0x7FFFFFFFn
 
   if (ix < 0x4002D97Cn) { // |x| < 3pi/4, special case with n=+-1
-    if (sign) {
+    if (!sign) {
       let z = x - pio2_1
       let mut y0 = 0.0W
       let mut y1 = 0.0W

--- a/stdlib/runtime/math/trig.gr
+++ b/stdlib/runtime/math/trig.gr
@@ -64,6 +64,8 @@ provide let cos = (x: WasmF64) => { // see: musl/src/math/cos.c
 
   // Get high word of x
   let ix = WasmI32.wrapI64(i >>> 32N)
+  use WasmI32.{ (>>>) }
+  let sign = ix >>> 31n == 1n
   let ix = ix & 0x7FFFFFFFn
 
   // |x| ~< pi/4
@@ -78,8 +80,7 @@ provide let cos = (x: WasmF64) => { // see: musl/src/math/cos.c
   if (ix >= 0x7FF00000n) return x - x
 
   // argument reduction needed
-  use WasmI32.{ (>>>) }
-  let (n, y0, y1) = rempio2(x, i, ix >>> 31n == 0n)
+  let (n, y0, y1) = rempio2(x, i, sign)
   let n = fromInt32(n)
   let y0 = fromFloat64(y0)
   let y1 = fromFloat64(y1)
@@ -100,6 +101,8 @@ provide let tan = (x: WasmF64) => { // see: musl/src/math/tan.c
   let i = WasmI64.reinterpretF64(x)
   // Get high word of x
   let ix = WasmI32.wrapI64(i >>> 32N)
+  use WasmI32.{ (>>>) }
+  let sign = ix >>> 31n == 1n
   let ix = ix & 0x7FFFFFFFn
 
   // |x| ~< pi/4
@@ -113,8 +116,7 @@ provide let tan = (x: WasmF64) => { // see: musl/src/math/tan.c
   // tan(Inf or NaN) is NaN
   if (ix >= 0x7FF00000n) return x - x
 
-  use WasmI32.{ (>>>) }
-  let (n, y0, y1) = rempio2(x, i, ix >>> 31n == 0n)
+  let (n, y0, y1) = rempio2(x, i, sign)
   let n = fromInt32(n)
   let y0 = fromFloat64(y0)
   let y1 = fromFloat64(y1)

--- a/stdlib/runtime/math/trig.gr
+++ b/stdlib/runtime/math/trig.gr
@@ -26,6 +26,8 @@ provide let sin = (x: WasmF64) => { // see: musl/src/math/sin.c
   let i = WasmI64.reinterpretF64(x)
   // Get high word of x
   let ix = WasmI32.wrapI64(i >>> 32N)
+  use WasmI32.{ (>>>) }
+  let sign = ix >>> 31n == 1n
   let ix = ix & 0x7FFFFFFFn
 
   // |x| ~< pi/4
@@ -40,8 +42,7 @@ provide let sin = (x: WasmF64) => { // see: musl/src/math/sin.c
   if (ix >= 0x7FF00000n) return x - x
 
   // argument reduction needed
-  use WasmI32.{ (>>>) }
-  let (n, y0, y1) = rempio2(x, i, ix >>> 31n == 0n)
+  let (n, y0, y1) = rempio2(x, i, sign)
   let n = fromInt32(n)
   let y0 = fromFloat64(y0)
   let y1 = fromFloat64(y1)


### PR DESCRIPTION
I noticed that we were getting a little bit of extra error when computing trig functions, which I traced the values against the c implementation I noticed that the sign bit was not working correctly, this changes the sign to be calculated before clearing the high bits.

For anyone concerned this was not affecting accuracy very much compared to most use cases of trig functions but it is important that we are producing an accurate output if we are using the trig functions to compute other math functions where the error stacks more.