### PR TITLE
chore: Enable colors on actions runner

### DIFF
--- a/compiler/test/TestFramework.re
+++ b/compiler/test/TestFramework.re
@@ -53,6 +53,13 @@ let clean_output = output =>
   };
 
 let () = {
+  let github_actions =
+    try(Unix.getenv("GITHUB_ACTIONS") == "true") {
+    | Not_found => false
+    };
+  if (github_actions) {
+    Pastel.setMode(Pastel.Terminal);
+  };
   /*** Override default stdlib location to use development version of stdlib */
   let stdlib_dir = Unix.getenv("GRAIN_STDLIB");
   let stdlib_dir = Filepath.String.derelativize(stdlib_dir);


### PR DESCRIPTION
This enables color in the output of our test framework on the github actions runners.
Check it out [the test for this pr](https://github.com/grain-lang/grain/actions/runs/11774522218/job/32793241118)
![image](https://github.com/user-attachments/assets/ad1c9503-fbf2-48b8-ac1e-bdb2e646cb48)
