### PR TITLE
chore: Update to v4 actions artifacts

### DIFF
--- a/.github/workflows/build-js.yml
+++ b/.github/workflows/build-js.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Upload pkg binary for Windows
         if: inputs.os == 'ubuntu-latest'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: ./grain.tar
           name: grain-win-x64
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload pkg binary for Mac
         if: inputs.os == 'ubuntu-latest'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: ./grain.tar
           name: grain-mac-x64
@@ -112,7 +112,7 @@ jobs:
 
       - name: Upload pkg binary for Linux
         if: inputs.os == 'ubuntu-latest'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: ./grain.tar
           name: grain-linux-x64

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -73,7 +73,7 @@ jobs:
       # Upload the artifacts before we run the tests so we
       # can download to debug if tests fail in a weird way
       - name: Upload native compiler artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: native-build-artifacts-${{ runner.os }}-${{ runner.arch }}
           path: cli/bin/*.exe

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -32,7 +32,7 @@ jobs:
           token: ${{ secrets.PUSH_TOKEN }}
 
       - name: Fetch linux binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: grain-linux-x64
 

--- a/.github/workflows/test-pkg.yml
+++ b/.github/workflows/test-pkg.yml
@@ -30,7 +30,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Fetch pkg binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: grain-${{ matrix.name }}-x64
 

--- a/.github/workflows/upload-binaries.yml
+++ b/.github/workflows/upload-binaries.yml
@@ -41,7 +41,7 @@ jobs:
           git push origin ${{ inputs.tag }} -f
 
       - name: Fetch linux binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: grain-linux-x64
 
@@ -55,7 +55,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.UPLOAD_TOKEN }}
 
       - name: Fetch mac binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: grain-mac-x64
 
@@ -69,7 +69,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.UPLOAD_TOKEN }}
 
       - name: Fetch win binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: grain-win-x64
 


### PR DESCRIPTION
This pr switches the upload artifact from v3 to v4 as v3 is going to deprecated at the end of the month [see here](https://github.com/actions/upload-artifact?tab=readme-ov-file) we were not affected by any of the breaking changes so we just had to change the version.

Separate to this:
Some of our actions are being forced to run with node v20 when we want them to run with node 18 [see here for why](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/) and you can see the deprecation warnings on our tests [here](https://github.com/spotandjake/grain/actions/runs/11785769957?pr=6) we should probably look into upgrading this.