### PR TITLE
feat(compiler): Use location for `Unbound_label_with_alt` error

### DIFF
--- a/compiler/src/typed/env.re
+++ b/compiler/src/typed/env.re
@@ -2594,7 +2594,8 @@ let () =
           Module_not_found_in_module(loc, _, _, _) |
           Type_not_found_in_module(loc, _, _) |
           Unbound_module(loc, _) |
-          Unbound_label(loc, _)
+          Unbound_label(loc, _) |
+          Unbound_label_with_alt(loc, _, _)
         ) as err,
       )
         when loc != Location.dummy_loc =>


### PR DESCRIPTION
I noticed if you get a disambiguation error before it was showing the error position as the top of the module. This corrects it to show the proper location.
![Screenshot 2024-11-15 at 11 37 51 PM](https://github.com/user-attachments/assets/5ed745e4-016a-4427-bc59-4a6b939a97a5)
