### PR TITLE
chore(stdlib): Add examples to `Queue` module

### DIFF
--- a/stdlib/queue.gr
+++ b/stdlib/queue.gr
@@ -7,6 +7,13 @@
  *
  * @example from "queue" include Queue
  *
+ * @example
+ * let queue = Queue.fromList([0, 1])
+ * Queue.push(2, queue)
+ * assert Queue.pop(queue) == Some(0)
+ * assert Queue.pop(queue) == Some(1)
+ * assert Queue.pop(queue) == Some(2)
+ *
  * @since v0.2.0
  */
 module Queue
@@ -33,6 +40,8 @@ abstract record Queue<a> {
  * @param size: The initial storage size of the queue
  * @returns An empty queue
  *
+ * @example Queue.make() // Creates a new queue
+ *
  * @since v0.6.0
  */
 provide let make = (size=16) => {
@@ -45,6 +54,9 @@ provide let make = (size=16) => {
  * @param queue: The queue to check
  * @returns `true` if the queue has no items or `false` otherwise
  *
+ * @example Queue.isEmpty(Queue.make()) == true
+ * @example Queue.isEmpty(Queue.fromList([1, 2])) == false
+ *
  * @since v0.6.0
  */
 provide let isEmpty = queue => queue.size == 0
@@ -55,6 +67,9 @@ provide let isEmpty = queue => queue.size == 0
  * @param queue: The queue to inspect
  * @returns The count of the items in the queue
  *
+ * @example Queue.size(Queue.make()) == 0
+ * @example Queue.size(Queue.fromList([1, 2])) == 2
+ *
  * @since v0.6.0
  */
 provide let size = queue => queue.size
@@ -64,6 +79,12 @@ provide let size = queue => queue.size
  *
  * @param queue: The queue to inspect
  * @returns `Some(value)` containing the value at the beginning of the queue or `None` otherwise.
+ *
+ * @example Queue.peek(Queue.make()) == None
+ * @example
+ * let queue = Queue.make()
+ * Queue.push(1, queue)
+ * assert Queue.peek(queue) == Some(1)
  *
  * @since v0.6.0
  */
@@ -76,6 +97,12 @@ provide let peek = queue => {
  *
  * @param value: The item to be added
  * @param queue: The queue being updated
+ *
+ * @example
+ * let queue = Queue.make()
+ * assert Queue.peek(queue) == None
+ * Queue.push(1, queue)
+ * assert Queue.peek(queue) == Some(1)
  *
  * @since v0.6.0
  */
@@ -111,6 +138,12 @@ provide let push = (value, queue) => {
  * @param queue: The queue being updated
  * @returns The element removed from the queue
  *
+ * @example
+ * let queue = Queue.make()
+ * Queue.push(1, queue)
+ * assert Queue.pop(queue) == Some(1)
+ * assert Queue.pop(queue) == None
+ *
  * @since v0.6.0
  */
 provide let pop = queue => {
@@ -126,10 +159,58 @@ provide let pop = queue => {
 }
 
 /**
+ * Clears the queue by removing all of its elements
+ *
+ * @param queue: The queue to clear
+ *
+ * @example
+ * let queue = Queue.make()
+ * Queue.push(1, queue)
+ * assert Queue.size(queue) == 1
+ * Queue.clear(queue)
+ * assert Queue.size(queue) == 0
+ *
+ * @since v0.6.0
+ */
+provide let clear = queue => {
+  queue.size = 0
+  Array.fill(None, queue.array)
+  queue.headIndex = 0
+  queue.tailIndex = 0
+}
+
+/**
+ * Produces a shallow copy of the input queue.
+ *
+ * @param queue: The queue to copy
+ * @returns A new queue containing the elements from the input
+ *
+ * @example
+ * let queue = Queue.make()
+ * Queue.push(1, queue)
+ * let copiedQueue = Queue.copy(queue)
+ * Queue.push(2, queue) // Does not affect copiedQueue
+ * assert Queue.pop(copiedQueue) == Some(1)
+ *
+ * @since v0.6.0
+ */
+provide let copy = queue => {
+  let { size, array, headIndex, tailIndex } = queue
+  { size, array: Array.copy(array), headIndex, tailIndex }
+}
+
+/**
  * Converts a queue into a list of its elements.
  *
  * @param queue: The queue to convert
  * @returns A list containing all queue values
+ *
+ * @example
+ * let queue = Queue.make()
+ * Queue.push(0, queue)
+ * Queue.push(1, queue)
+ * Queue.push(2, queue)
+ * assert Queue.toList(queue) == [0, 1, 2]
  *
  * @since v0.6.0
  */
@@ -152,6 +233,11 @@ provide let toList = queue => {
  * @param list: The list to convert
  * @returns A queue containing all list values
  *
+ * @example
+ * let queue = Queue.fromList([0, 1])
+ * assert Queue.pop(queue) == Some(0)
+ * assert Queue.pop(queue) == Some(1)
+ *
  * @since v0.6.0
  */
 provide let fromList = list => {
@@ -161,37 +247,17 @@ provide let fromList = list => {
 }
 
 /**
- * Clears the queue by removing all of its elements
- *
- * @param queue: The queue to clear
- *
- * @since v0.6.0
- */
-provide let clear = queue => {
-  queue.size = 0
-  Array.fill(None, queue.array)
-  queue.headIndex = 0
-  queue.tailIndex = 0
-}
-
-/**
- * Produces a shallow copy of the input queue.
- *
- * @param queue: The queue to copy
- * @returns A new queue containing the elements from the input
- *
- * @since v0.6.0
- */
-provide let copy = queue => {
-  let { size, array, headIndex, tailIndex } = queue
-  { size, array: Array.copy(array), headIndex, tailIndex }
-}
-
-/**
  * Converts a queue into an array of its values.
  *
  * @param queue: The queue to convert
  * @returns An array containing all values from the given queue
+ *
+ * @example
+ * let queue = Queue.make()
+ * Queue.push(0, queue)
+ * Queue.push(1, queue)
+ * Queue.push(2, queue)
+ * assert Queue.toArray(queue) == [> 0, 1, 2]
  *
  * @since v0.6.0
  */
@@ -230,6 +296,11 @@ provide let toArray = queue => {
  * @param arr: The array to convert
  * @returns A queue containing all values from the array
  *
+ * @example
+ * let queue = Queue.fromArray([> 0, 1])
+ * assert Queue.pop(queue) == Some(0)
+ * assert Queue.pop(queue) == Some(1)
+ *
  * @since v0.6.0
  */
 provide let fromArray = arr => {
@@ -255,6 +326,18 @@ provide let fromArray = arr => {
  * @param queue2: The second queue to compare
  * @returns `true` if the queues are equivalent or `false` otherwise
  *
+ * @example
+ * use Queue.{ (==) }
+ * let queue1 = Queue.fromList([0, 1, 2])
+ * let queue2 = Queue.fromList([0, 1, 2])
+ * assert queue1 == queue2
+ *
+ * @example
+ * use Queue.{ (==) }
+ * let queue1 = Queue.fromList([0, 1, 2])
+ * let queue2 = Queue.fromList([0, 1, 3])
+ * assert !(queue1 == queue2)
+ *
  * @since v0.6.0
  */
 provide let (==) = (queue1, queue2) => {
@@ -276,10 +359,24 @@ provide let (==) = (queue1, queue2) => {
 
 /**
  * An immutable queue implementation.
+ *
+ * @example
+ * let queue = Immutable.Queue.fromList([0, 1])
+ * let queue = Immutable.Queue.push(2, queue)
+ * assert Immutable.Queue.peek(queue) == Some(0)
+ * let queue = Immutable.Queue.pop(queue)
+ * assert Immutable.Queue.peek(queue) == Some(1)
+ * ignore(Queue.Immutable.pop(queue)) // Does not affect the original queue
+ * assert Immutable.Queue.peek(queue) == Some(1)
+ *
+ * @since v0.6.0
  */
 provide module Immutable {
   /**
    * An immutable FIFO (first-in-first-out) data structure.
+   *
+   * @since v0.6.0
+   * @history v0.5.4: Originally a module root API
    */
   abstract record ImmutableQueue<a> {
     forwards: List<a>,
@@ -288,6 +385,10 @@ provide module Immutable {
 
   /**
    * An empty queue.
+   *
+   * @example
+   * let queue = Queue.Immutable.empty
+   * assert Queue.Immutable.isEmpty(queue)
    *
    * @since v0.6.0
    * @history v0.5.4: Originally a module root API
@@ -302,6 +403,10 @@ provide module Immutable {
    *
    * @param queue: The queue to check
    * @returns `true` if the given queue is empty or `false` otherwise
+   *
+   * @example Queue.Immutable.isEmpty(Queue.Immutable.empty) == true
+   *
+   * @example Queue.Immutable.isEmpty(Queue.Immutable.fromList([1, 2])) == false
    *
    * @since v0.6.0
    * @history v0.2.0: Originally a module root API
@@ -318,6 +423,14 @@ provide module Immutable {
    *
    * @param queue: The queue to inspect
    * @returns `Some(value)` containing the value at the beginning of the queue, or `None` if the queue is empty
+   *
+   * @example
+   * let queue = Queue.Immutable.fromList([1, 2, 3])
+   * assert Queue.Immutable.peek(queue) == Some(1)
+   *
+   * @example
+   * let queue = Queue.Immutable.empty
+   * assert Queue.Immutable.peek(queue) == None
    *
    * @since v0.6.0
    * @history v0.2.0: Originally named `head`
@@ -339,6 +452,12 @@ provide module Immutable {
    * @param queue: The queue to update
    * @returns An updated queue
    *
+   * @example
+   * let queue = Queue.Immutable.fromList([1])
+   * assert Queue.Immutable.size(queue) == 1
+   * let queue = Queue.Immutable.push(2, queue)
+   * assert Queue.Immutable.size(queue) == 2
+   *
    * @since v0.6.0
    * @history v0.2.0: Originally named `enqueue`
    * @history v0.3.2: Deprecated `enqueue` function
@@ -357,6 +476,16 @@ provide module Immutable {
    *
    * @param queue: The queue to change
    * @returns An updated queue
+   *
+   * @example
+   * let queue = Queue.Immutable.fromList([1, 2, 3])
+   * let queue = Queue.Immutable.pop(queue)
+   * assert Queue.Immutable.peek(queue) == Some(2)
+   *
+   * @example
+   * let queue = Queue.Immutable.empty
+   * let queue = Queue.Immutable.pop(queue)
+   * assert Queue.Immutable.isEmpty(queue)
    *
    * @since v0.6.0
    * @history v0.2.0: Originally named `dequeue`
@@ -381,6 +510,9 @@ provide module Immutable {
    * @param queue: The queue to inspect
    * @returns The number of values in the queue
    *
+   * @example Queue.Immutable.size(Queue.Immutable.empty) == 0
+   * @example Queue.Immutable.size(Queue.Immutable.fromList([1, 2])) == 2
+   *
    * @since v0.6.0
    * @history v0.3.2: Originally a module root API
    */
@@ -399,6 +531,20 @@ provide module Immutable {
    * @param queue: The queue to convert
    * @returns A list containing all queue values
    *
+   * @example
+   * let queue = Queue.Immutable.empty
+   * let queue = Queue.Immutable.push(1, queue)
+   * let queue = Queue.Immutable.push(2, queue)
+   * assert Queue.Immutable.toList(queue) == [1, 2]
+   *
+   * @example
+   * let queue = Queue.Immutable.fromList([1, 2, 3])
+   * assert Queue.Immutable.toList(queue) == [1, 2, 3]
+   *
+   * @example
+   * let queue = Queue.Immutable.empty
+   * assert Queue.Immutable.toList(queue) == []
+   *
    * @since v0.6.0
    */
   provide let toList = queue => {
@@ -410,6 +556,11 @@ provide module Immutable {
    *
    * @param list: The list to convert
    * @returns A queue containing all list values
+   *
+   * @example
+   * let queue = Queue.Immutable.fromList([1, 2, 3])
+   * assert Queue.Immutable.peek(queue) == Some(1)
+   * assert Queue.Immutable.size(queue) == 3
    *
    * @since v0.6.0
    */

--- a/stdlib/queue.gr
+++ b/stdlib/queue.gr
@@ -160,7 +160,7 @@ provide let pop = queue => {
 }
 
 /**
- * Clears the queue by removing all of its elements
+ * Clears the queue by removing all of its elements.
  *
  * @param queue: The queue to clear
  *

--- a/stdlib/queue.gr
+++ b/stdlib/queue.gr
@@ -34,13 +34,14 @@ abstract record Queue<a> {
 /**
  * Creates a new queue with an initial storage of the given size. As values are
  * added or removed, the internal storage may grow or shrink. Generally, you
- * won’t need to care about the storage size of your map and can use the
+ * won’t need to care about the storage size of your queue and can use the
  * default size.
  *
  * @param size: The initial storage size of the queue
  * @returns An empty queue
  *
  * @example Queue.make() // Creates a new queue
+ * @example Queue.make(size=16) // Creates a new queue with an initial size of 16
  *
  * @since v0.6.0
  */

--- a/stdlib/queue.md
+++ b/stdlib/queue.md
@@ -260,7 +260,7 @@ No other changes yet.
 clear : (queue: Queue<a>) => Void
 ```
 
-Clears the queue by removing all of its elements
+Clears the queue by removing all of its elements.
 
 Parameters:
 

--- a/stdlib/queue.md
+++ b/stdlib/queue.md
@@ -17,6 +17,14 @@ No other changes yet.
 from "queue" include Queue
 ```
 
+```grain
+let queue = Queue.fromList([0, 1])
+Queue.push(2, queue)
+assert Queue.pop(queue) == Some(0)
+assert Queue.pop(queue) == Some(1)
+assert Queue.pop(queue) == Some(2)
+```
+
 ## Types
 
 Type declarations included in the Queue module.
@@ -61,6 +69,12 @@ Returns:
 |----|-----------|
 |`Queue<a>`|An empty queue|
 
+Examples:
+
+```grain
+Queue.make() // Creates a new queue
+```
+
 ### Queue.**isEmpty**
 
 <details disabled>
@@ -85,6 +99,16 @@ Returns:
 |type|description|
 |----|-----------|
 |`Bool`|`true` if the queue has no items or `false` otherwise|
+
+Examples:
+
+```grain
+Queue.isEmpty(Queue.make()) == true
+```
+
+```grain
+Queue.isEmpty(Queue.fromList([1, 2])) == false
+```
 
 ### Queue.**size**
 
@@ -111,6 +135,16 @@ Returns:
 |----|-----------|
 |`Number`|The count of the items in the queue|
 
+Examples:
+
+```grain
+Queue.size(Queue.make()) == 0
+```
+
+```grain
+Queue.size(Queue.fromList([1, 2])) == 2
+```
+
 ### Queue.**peek**
 
 <details disabled>
@@ -136,6 +170,18 @@ Returns:
 |----|-----------|
 |`Option<a>`|`Some(value)` containing the value at the beginning of the queue or `None` otherwise.|
 
+Examples:
+
+```grain
+Queue.peek(Queue.make()) == None
+```
+
+```grain
+let queue = Queue.make()
+Queue.push(1, queue)
+assert Queue.peek(queue) == Some(1)
+```
+
 ### Queue.**push**
 
 <details disabled>
@@ -155,6 +201,15 @@ Parameters:
 |-----|----|-----------|
 |`value`|`a`|The item to be added|
 |`queue`|`Queue<a>`|The queue being updated|
+
+Examples:
+
+```grain
+let queue = Queue.make()
+assert Queue.peek(queue) == None
+Queue.push(1, queue)
+assert Queue.peek(queue) == Some(1)
+```
 
 ### Queue.**pop**
 
@@ -181,55 +236,14 @@ Returns:
 |----|-----------|
 |`Option<a>`|The element removed from the queue|
 
-### Queue.**toList**
-
-<details disabled>
-<summary tabindex="-1">Added in <code>0.6.0</code></summary>
-No other changes yet.
-</details>
+Examples:
 
 ```grain
-toList : (queue: Queue<a>) => List<a>
+let queue = Queue.make()
+Queue.push(1, queue)
+assert Queue.pop(queue) == Some(1)
+assert Queue.pop(queue) == None
 ```
-
-Converts a queue into a list of its elements.
-
-Parameters:
-
-|param|type|description|
-|-----|----|-----------|
-|`queue`|`Queue<a>`|The queue to convert|
-
-Returns:
-
-|type|description|
-|----|-----------|
-|`List<a>`|A list containing all queue values|
-
-### Queue.**fromList**
-
-<details disabled>
-<summary tabindex="-1">Added in <code>0.6.0</code></summary>
-No other changes yet.
-</details>
-
-```grain
-fromList : (list: List<a>) => Queue<a>
-```
-
-Creates a queue from a list.
-
-Parameters:
-
-|param|type|description|
-|-----|----|-----------|
-|`list`|`List<a>`|The list to convert|
-
-Returns:
-
-|type|description|
-|----|-----------|
-|`Queue<a>`|A queue containing all list values|
 
 ### Queue.**clear**
 
@@ -249,6 +263,16 @@ Parameters:
 |param|type|description|
 |-----|----|-----------|
 |`queue`|`Queue<a>`|The queue to clear|
+
+Examples:
+
+```grain
+let queue = Queue.make()
+Queue.push(1, queue)
+assert Queue.size(queue) == 1
+Queue.clear(queue)
+assert Queue.size(queue) == 0
+```
 
 ### Queue.**copy**
 
@@ -275,6 +299,84 @@ Returns:
 |----|-----------|
 |`Queue<a>`|A new queue containing the elements from the input|
 
+Examples:
+
+```grain
+let queue = Queue.make()
+Queue.push(1, queue)
+let copiedQueue = Queue.copy(queue)
+Queue.push(2, queue) // Does not affect copiedQueue
+assert Queue.pop(copiedQueue) == Some(1)
+```
+
+### Queue.**toList**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.6.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+toList : (queue: Queue<a>) => List<a>
+```
+
+Converts a queue into a list of its elements.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`queue`|`Queue<a>`|The queue to convert|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`List<a>`|A list containing all queue values|
+
+Examples:
+
+```grain
+let queue = Queue.make()
+Queue.push(0, queue)
+Queue.push(1, queue)
+Queue.push(2, queue)
+assert Queue.toList(queue) == [0, 1, 2]
+```
+
+### Queue.**fromList**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.6.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+fromList : (list: List<a>) => Queue<a>
+```
+
+Creates a queue from a list.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`list`|`List<a>`|The list to convert|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Queue<a>`|A queue containing all list values|
+
+Examples:
+
+```grain
+let queue = Queue.fromList([0, 1])
+assert Queue.pop(queue) == Some(0)
+assert Queue.pop(queue) == Some(1)
+```
+
 ### Queue.**toArray**
 
 <details disabled>
@@ -300,6 +402,16 @@ Returns:
 |----|-----------|
 |`Array<a>`|An array containing all values from the given queue|
 
+Examples:
+
+```grain
+let queue = Queue.make()
+Queue.push(0, queue)
+Queue.push(1, queue)
+Queue.push(2, queue)
+assert Queue.toArray(queue) == [> 0, 1, 2]
+```
+
 ### Queue.**fromArray**
 
 <details disabled>
@@ -324,6 +436,14 @@ Returns:
 |type|description|
 |----|-----------|
 |`Queue<a>`|A queue containing all values from the array|
+
+Examples:
+
+```grain
+let queue = Queue.fromArray([> 0, 1])
+assert Queue.pop(queue) == Some(0)
+assert Queue.pop(queue) == Some(1)
+```
 
 ### Queue.**(==)**
 
@@ -351,15 +471,58 @@ Returns:
 |----|-----------|
 |`Bool`|`true` if the queues are equivalent or `false` otherwise|
 
+Examples:
+
+```grain
+use Queue.{ (==) }
+let queue1 = Queue.fromList([0, 1, 2])
+let queue2 = Queue.fromList([0, 1, 2])
+assert queue1 == queue2
+```
+
+```grain
+use Queue.{ (==) }
+let queue1 = Queue.fromList([0, 1, 2])
+let queue2 = Queue.fromList([0, 1, 3])
+assert !(queue1 == queue2)
+```
+
 ## Queue.Immutable
 
 An immutable queue implementation.
+
+<details disabled>
+<summary tabindex="-1">Added in <code>0.6.0</code></summary>
+No other changes yet.
+</details>
+
+```grain
+let queue = Immutable.Queue.fromList([0, 1])
+let queue = Immutable.Queue.push(2, queue)
+assert Immutable.Queue.peek(queue) == Some(0)
+let queue = Immutable.Queue.pop(queue)
+assert Immutable.Queue.peek(queue) == Some(1)
+ignore(Queue.Immutable.pop(queue)) // Does not affect the original queue
+assert Immutable.Queue.peek(queue) == Some(1)
+```
 
 ### Types
 
 Type declarations included in the Queue.Immutable module.
 
 #### Queue.Immutable.**ImmutableQueue**
+
+<details>
+<summary>Added in <code>0.6.0</code></summary>
+<table>
+<thead>
+<tr><th>version</th><th>changes</th></tr>
+</thead>
+<tbody>
+<tr><td><code>0.5.4</code></td><td>Originally a module root API</td></tr>
+</tbody>
+</table>
+</details>
 
 ```grain
 type ImmutableQueue<a>
@@ -390,6 +553,13 @@ empty : ImmutableQueue<a>
 ```
 
 An empty queue.
+
+Examples:
+
+```grain
+let queue = Queue.Immutable.empty
+assert Queue.Immutable.isEmpty(queue)
+```
 
 #### Queue.Immutable.**isEmpty**
 
@@ -422,6 +592,16 @@ Returns:
 |type|description|
 |----|-----------|
 |`Bool`|`true` if the given queue is empty or `false` otherwise|
+
+Examples:
+
+```grain
+Queue.Immutable.isEmpty(Queue.Immutable.empty) == true
+```
+
+```grain
+Queue.Immutable.isEmpty(Queue.Immutable.fromList([1, 2])) == false
+```
 
 #### Queue.Immutable.**peek**
 
@@ -457,6 +637,18 @@ Returns:
 |type|description|
 |----|-----------|
 |`Option<a>`|`Some(value)` containing the value at the beginning of the queue, or `None` if the queue is empty|
+
+Examples:
+
+```grain
+let queue = Queue.Immutable.fromList([1, 2, 3])
+assert Queue.Immutable.peek(queue) == Some(1)
+```
+
+```grain
+let queue = Queue.Immutable.empty
+assert Queue.Immutable.peek(queue) == None
+```
 
 #### Queue.Immutable.**push**
 
@@ -494,6 +686,15 @@ Returns:
 |----|-----------|
 |`ImmutableQueue<a>`|An updated queue|
 
+Examples:
+
+```grain
+let queue = Queue.Immutable.fromList([1])
+assert Queue.Immutable.size(queue) == 1
+let queue = Queue.Immutable.push(2, queue)
+assert Queue.Immutable.size(queue) == 2
+```
+
 #### Queue.Immutable.**pop**
 
 <details>
@@ -529,6 +730,20 @@ Returns:
 |----|-----------|
 |`ImmutableQueue<a>`|An updated queue|
 
+Examples:
+
+```grain
+let queue = Queue.Immutable.fromList([1, 2, 3])
+let queue = Queue.Immutable.pop(queue)
+assert Queue.Immutable.peek(queue) == Some(2)
+```
+
+```grain
+let queue = Queue.Immutable.empty
+let queue = Queue.Immutable.pop(queue)
+assert Queue.Immutable.isEmpty(queue)
+```
+
 #### Queue.Immutable.**size**
 
 <details>
@@ -561,6 +776,16 @@ Returns:
 |----|-----------|
 |`Number`|The number of values in the queue|
 
+Examples:
+
+```grain
+Queue.Immutable.size(Queue.Immutable.empty) == 0
+```
+
+```grain
+Queue.Immutable.size(Queue.Immutable.fromList([1, 2])) == 2
+```
+
 #### Queue.Immutable.**toList**
 
 <details disabled>
@@ -586,6 +811,25 @@ Returns:
 |----|-----------|
 |`List<a>`|A list containing all queue values|
 
+Examples:
+
+```grain
+let queue = Queue.Immutable.empty
+let queue = Queue.Immutable.push(1, queue)
+let queue = Queue.Immutable.push(2, queue)
+assert Queue.Immutable.toList(queue) == [1, 2]
+```
+
+```grain
+let queue = Queue.Immutable.fromList([1, 2, 3])
+assert Queue.Immutable.toList(queue) == [1, 2, 3]
+```
+
+```grain
+let queue = Queue.Immutable.empty
+assert Queue.Immutable.toList(queue) == []
+```
+
 #### Queue.Immutable.**fromList**
 
 <details disabled>
@@ -610,4 +854,12 @@ Returns:
 |type|description|
 |----|-----------|
 |`ImmutableQueue<a>`|A queue containing all list values|
+
+Examples:
+
+```grain
+let queue = Queue.Immutable.fromList([1, 2, 3])
+assert Queue.Immutable.peek(queue) == Some(1)
+assert Queue.Immutable.size(queue) == 3
+```
 

--- a/stdlib/queue.md
+++ b/stdlib/queue.md
@@ -54,7 +54,7 @@ make : (?size: Number) => Queue<a>
 
 Creates a new queue with an initial storage of the given size. As values are
 added or removed, the internal storage may grow or shrink. Generally, you
-won’t need to care about the storage size of your map and can use the
+won’t need to care about the storage size of your queue and can use the
 default size.
 
 Parameters:
@@ -73,6 +73,10 @@ Examples:
 
 ```grain
 Queue.make() // Creates a new queue
+```
+
+```grain
+Queue.make(size=16) // Creates a new queue with an initial size of 16
 ```
 
 ### Queue.**isEmpty**


### PR DESCRIPTION
This pr adds examples to the `Queue` module. I also noticed a few of the history items were missing so this corrects them and I also moved the `toList` and `fromList` closer to the `toArray` and `fromArray`.