### PR TITLE
feat(stdlib): `List.Associative` Submodule

### DIFF
--- a/compiler/test/stdlib/list.test.gr
+++ b/compiler/test/stdlib/list.test.gr
@@ -270,14 +270,9 @@ assert sort(compare=compareLengths, list) ==
 assert sort(compare=compareLengths, ["a", "a", "a", "a"]) ==
   ["a", "a", "a", "a"]
 
-
 // List.Associative
 module Associative {
-  let data = [
-   ("name", "Alice"),
-   ("name", "Bob"),
-   ("age", "30"),
-  ]
+  let data = [("name", "Alice"), ("name", "Bob"), ("age", "30")]
 
   // List.Associative.has
   assert List.Associative.has("name", data)
@@ -296,7 +291,9 @@ module Associative {
   assert List.Associative.set("age", "31", []) == [("age", "31")]
 
   // List.Associative.remove
-  assert List.Associative.remove("name", data) == [("name", "Bob"), ("age", "30")]
-  assert List.Associative.remove("age", data) == [("name", "Alice"), ("name", "Bob")]
+  assert List.Associative.remove("name", data) ==
+    [("name", "Bob"), ("age", "30")]
+  assert List.Associative.remove("age", data) ==
+    [("name", "Alice"), ("name", "Bob")]
   assert List.Associative.remove("age", []) == []
 }

--- a/compiler/test/stdlib/list.test.gr
+++ b/compiler/test/stdlib/list.test.gr
@@ -269,3 +269,34 @@ assert sort(compare=compareLengths, list) ==
   ["a", "a", "ab", "abc", "abcd", "abcde"]
 assert sort(compare=compareLengths, ["a", "a", "a", "a"]) ==
   ["a", "a", "a", "a"]
+
+
+// List.Associative
+module Associative {
+  let data = [
+   ("name", "Alice"),
+   ("name", "Bob"),
+   ("age", "30"),
+  ]
+
+  // List.Associative.has
+  assert List.Associative.has("name", data)
+  assert !List.Associative.has("age", [])
+
+  // List.Associative.get
+  assert List.Associative.get("name", data) == Some("Alice")
+  assert List.Associative.get("age", []) == None
+  assert List.Associative.get("age", data) == Some("30")
+
+  // List.Associative.set
+  assert List.Associative.set("name", "Charlie", data) ==
+    [("name", "Charlie"), ("name", "Bob"), ("age", "30")]
+  assert List.Associative.set("age", "31", data) ==
+    [("name", "Alice"), ("name", "Bob"), ("age", "31")]
+  assert List.Associative.set("age", "31", []) == [("age", "31")]
+
+  // List.Associative.remove
+  assert List.Associative.remove("name", data) == [("name", "Bob"), ("age", "30")]
+  assert List.Associative.remove("age", data) == [("name", "Alice"), ("name", "Bob")]
+  assert List.Associative.remove("age", []) == []
+}

--- a/stdlib/list.gr
+++ b/stdlib/list.gr
@@ -972,3 +972,129 @@ provide let sort = (compare=compare, list) => {
 
   mergesort(list)
 }
+
+/**
+ * Utilities for working with lists of key-key value pairs.
+ *
+ * @example
+ * let data = [
+ *  ("name", "Alice"),
+ *  ("age", "30"),
+ * ]
+ * assert List.Associative.get("name", data) == Some("Alice")
+ *
+ * @since v0.7.0
+ */
+provide module Associative {
+  /**
+   * Checks if the given key is present in the list of key-value pairs.
+   *
+   * @param key: The key to search for
+   * @param list: The list of key-value pairs
+   *
+   * @returns `true` if the key is found or `false` otherwise
+   *
+   * @example
+   * let data = [
+   *   ("name", "Alice"),
+   *   ("age", "30"),
+   * ]
+   * assert List.Associative.has("name", data) == true
+   * @example List.Associative.has("age", []) == false
+   *
+   * @since v0.7.0
+   */
+  provide let rec has = (key, list) => {
+    match (list) {
+      [] => false,
+      [(k, _), ...rest] when key == k => true,
+      [_, ...rest] => has(key, rest),
+    }
+  }
+  /**
+   * Provides the first value in the list of key-value pairs that matches the given key.
+   *
+   * @param key: The key to search for
+   * @param list: The list of key-value pairs
+   *
+   * @returns `Some(value)` if the key is found or `None` otherwise
+   *
+   * @example
+   * let data = [
+   *  ("name", "Alice"),
+   *  ("name", "Bob"),
+   *  ("age", "30"),
+   * ]
+   * assert List.Associative.get("name", data) == Some("Alice")
+   *
+   * @example List.Associative.get("age", []) == None
+   *
+   * @since v0.7.0
+   */
+  provide let rec get = (key, list) => {
+    match (list) {
+      [] => None,
+      [(k, v), ...rest] when key == k => Some(v),
+      [_, ...rest] => get(key, rest),
+    }
+  }
+
+  /**
+   * Provides a new list with the first value in the list of key-value pairs that matches the given key replaced.
+   * If the key is not found the item is appended to the list.
+   *
+   * @param key: The key to replace
+   * @param value: The new value to set
+   * @param list: The list of key-value pairs
+   *
+   * @returns The new list with the key-value pair replaced
+   *
+   * @example
+   * let data = [
+   *  ("name", "Alice"),
+   *  ("name", "Bob"),
+   *  ("age", "30"),
+   * ]
+   * assert List.Associative.set("name", "Charlie", data) == [("name", "Charlie"), ("name", "Bob"), ("age", "30")]
+   *
+   * @example List.Associative.set("age", "30", [("name", "Alice")]) == [("name", "Alice"), ("age", "30")]
+   *
+   * @since v0.7.0
+   */
+  provide let rec set = (key, value, list) => {
+    match (list) {
+      [] => [ (key, value) ],
+      [(k, _), ...rest] when key == k => [(k, value), ...rest],
+      [first, ...rest] => [first, ...set(key, value, rest)],
+    }
+  }
+
+  /**
+   * Provides a new list with the first value in the list of key-value pairs that matches the given key removed.
+   * If the key is not found, the list is returned unchanged.
+   *
+   * @param key: The key to remove
+   * @param list: The list of key-value pairs
+   *
+   * @returns The new list with the key-value pair removed
+   *
+   * @example
+   * let data = [
+   *   ("name", "Alice"),
+   *   ("name", "Bob"),
+   *   ("age", "30"),
+   * ]
+   * assert List.Associative.remove("name", data) == [("name", "Bob"), ("age", "30")]
+   *
+   * @example List.Associative.remove("age", [("name", "Alice")]) == []
+   *
+   * @since v0.7.0
+   */
+  provide let rec remove = (key, list) => {
+    match (list) {
+      [] => [],
+      [(k, v), ...rest] when key == k => rest,
+      [first, ...rest] => [first, ...remove(key, rest)],
+    }
+  }
+}

--- a/stdlib/list.gr
+++ b/stdlib/list.gr
@@ -1012,7 +1012,7 @@ provide module Associative {
     }
   }
   /**
-   * Provides the first value in the list of key-value pairs that matches the given key.
+   * Retrieves the first value in the list of key-value pairs that matches the given key.
    *
    * @param key: The key to search for
    * @param list: The list of key-value pairs
@@ -1040,14 +1040,14 @@ provide module Associative {
   }
 
   /**
-   * Provides a new list with the first value in the list of key-value pairs that matches the given key replaced.
+   * Creates a new list with the first value in the list of key-value pairs that matches the key replaced.
    * If the key is not found the item is appended to the list.
    *
    * @param key: The key to replace
    * @param value: The new value to set
    * @param list: The list of key-value pairs
    *
-   * @returns The new list with the key-value pair replaced
+   * @returns A new list with the key-value pair replaced
    *
    * @example
    * let data = [
@@ -1070,7 +1070,7 @@ provide module Associative {
   }
 
   /**
-   * Provides a new list with the first value in the list of key-value pairs that matches the given key removed.
+   * Creates a new list with the first value in the list of key-value pairs that matches the key removed.
    * If the key is not found, the list is returned unchanged.
    *
    * @param key: The key to remove

--- a/stdlib/list.gr
+++ b/stdlib/list.gr
@@ -1063,7 +1063,7 @@ provide module Associative {
    */
   provide let rec set = (key, value, list) => {
     match (list) {
-      [] => [ (key, value) ],
+      [] => [(key, value)],
       [(k, _), ...rest] when key == k => [(k, value), ...rest],
       [first, ...rest] => [first, ...set(key, value, rest)],
     }

--- a/stdlib/list.md
+++ b/stdlib/list.md
@@ -1395,7 +1395,7 @@ No other changes yet.
 get : (key: a, list: List<(a, b)>) => Option<b>
 ```
 
-Provides the first value in the list of key-value pairs that matches the given key.
+Retrieves the first value in the list of key-value pairs that matches the given key.
 
 Parameters:
 
@@ -1436,7 +1436,7 @@ No other changes yet.
 set : (key: a, value: b, list: List<(a, b)>) => List<(a, b)>
 ```
 
-Provides a new list with the first value in the list of key-value pairs that matches the given key replaced.
+Creates a new list with the first value in the list of key-value pairs that matches the key replaced.
 If the key is not found the item is appended to the list.
 
 Parameters:
@@ -1451,7 +1451,7 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`List<(a, b)>`|The new list with the key-value pair replaced|
+|`List<(a, b)>`|A new list with the key-value pair replaced|
 
 Examples:
 
@@ -1479,7 +1479,7 @@ No other changes yet.
 remove : (key: a, list: List<(a, b)>) => List<(a, b)>
 ```
 
-Provides a new list with the first value in the list of key-value pairs that matches the given key removed.
+Creates a new list with the first value in the list of key-value pairs that matches the key removed.
 If the key is not found, the list is returned unchanged.
 
 Parameters:

--- a/stdlib/list.md
+++ b/stdlib/list.md
@@ -1323,3 +1323,190 @@ Returns:
 |----|-----------|
 |`List<a>`|The sorted list|
 
+## List.Associative
+
+Utilities for working with lists of key-key value pairs.
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+let data = [
+ ("name", "Alice"),
+ ("age", "30"),
+]
+assert List.Associative.get("name", data) == Some("Alice")
+```
+
+### Values
+
+Functions and constants included in the List.Associative module.
+
+#### List.Associative.**has**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+has : (key: a, list: List<(a, b)>) => Bool
+```
+
+Checks if the given key is present in the list of key-value pairs.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`key`|`a`|The key to search for|
+|`list`|`List<(a, b)>`|The list of key-value pairs|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Bool`|`true` if the key is found or `false` otherwise|
+
+Examples:
+
+```grain
+let data = [
+  ("name", "Alice"),
+  ("age", "30"),
+]
+assert List.Associative.has("name", data) == true
+```
+
+```grain
+List.Associative.has("age", []) == false
+```
+
+#### List.Associative.**get**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+get : (key: a, list: List<(a, b)>) => Option<b>
+```
+
+Provides the first value in the list of key-value pairs that matches the given key.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`key`|`a`|The key to search for|
+|`list`|`List<(a, b)>`|The list of key-value pairs|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Option<b>`|`Some(value)` if the key is found or `None` otherwise|
+
+Examples:
+
+```grain
+let data = [
+ ("name", "Alice"),
+ ("name", "Bob"),
+ ("age", "30"),
+]
+assert List.Associative.get("name", data) == Some("Alice")
+```
+
+```grain
+List.Associative.get("age", []) == None
+```
+
+#### List.Associative.**set**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+set : (key: a, value: b, list: List<(a, b)>) => List<(a, b)>
+```
+
+Provides a new list with the first value in the list of key-value pairs that matches the given key replaced.
+If the key is not found the item is appended to the list.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`key`|`a`|The key to replace|
+|`value`|`b`|The new value to set|
+|`list`|`List<(a, b)>`|The list of key-value pairs|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`List<(a, b)>`|The new list with the key-value pair replaced|
+
+Examples:
+
+```grain
+let data = [
+ ("name", "Alice"),
+ ("name", "Bob"),
+ ("age", "30"),
+]
+assert List.Associative.set("name", "Charlie", data) == [("name", "Charlie"), ("name", "Bob"), ("age", "30")]
+```
+
+```grain
+List.Associative.set("age", "30", [("name", "Alice")]) == [("name", "Alice"), ("age", "30")]
+```
+
+#### List.Associative.**remove**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+remove : (key: a, list: List<(a, b)>) => List<(a, b)>
+```
+
+Provides a new list with the first value in the list of key-value pairs that matches the given key removed.
+If the key is not found, the list is returned unchanged.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`key`|`a`|The key to remove|
+|`list`|`List<(a, b)>`|The list of key-value pairs|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`List<(a, b)>`|The new list with the key-value pair removed|
+
+Examples:
+
+```grain
+let data = [
+  ("name", "Alice"),
+  ("name", "Bob"),
+  ("age", "30"),
+]
+assert List.Associative.remove("name", data) == [("name", "Bob"), ("age", "30")]
+```
+
+```grain
+List.Associative.remove("age", [("name", "Alice")]) == []
+```
+


### PR DESCRIPTION
This pr adds a `List.Assocative` submodule which contains functions for working with key-value pairs in lists.

```
let data = [
  ("name", "Alice"),
  ("name", "Bob"),
  ("age", "30"),
]
assert List.Associative.get("name", data) == Some("Alice")
```

### Use case
This is similar to the associative list methods in ocaml https://ocaml.org/manual/5.2/api/List.html#1_Associationlists


I wasn't quite sure if we wanted this in the standard library or not but I think the pattern occurs enough with record information that it makes sense. A few examples being `Map.toList`, `JSONObject`.
Currently duplicates are ignored and the first item is always treated as the one your referring too.

### Alternative proposal 
An alternative proposal to this pr is we implement a new `Collection` module, where collections are of type `abstract type Collection<key, value> = List<(key, value)>` and then in that case we can handle the duplication semantics when you do `List.toCollection`, I think this might be overkill though.