### PR TITLE
feat(cli): Support node v22 and v23

### DIFF
--- a/cli/bin/grainrun.js
+++ b/cli/bin/grainrun.js
@@ -10,7 +10,11 @@ const v8 = require("v8");
  *
  * This seems to work for our needs with Node 18, but we should be cautious when updating.
  */
-v8.setFlagsFromString("--experimental-wasm-return-call");
+if (
+  !process.versions.node.startsWith("22.") &&
+  !process.versions.node.startsWith("23.")
+)
+  v8.setFlagsFromString("--experimental-wasm-return-call");
 
 const { readFile } = require("fs/promises");
 const { WASI } = require("wasi");

--- a/cli/bin/grainrun.js
+++ b/cli/bin/grainrun.js
@@ -8,7 +8,7 @@ const v8 = require("v8");
  *   This method should be used with care. Changing settings after the VM has started may result
  *   in unpredictable behavior, including crashes and data loss; or it may simply do nothing.
  *
- * This seems to work for our needs with Node 18, but we should be cautious when updating.
+ * This is valid in Node 18, 19, 20, and 21.
  */
 if (process.version.match(/^v(18|19|20|21)\./))
   v8.setFlagsFromString("--experimental-wasm-return-call");

--- a/cli/bin/grainrun.js
+++ b/cli/bin/grainrun.js
@@ -11,8 +11,10 @@ const v8 = require("v8");
  * This seems to work for our needs with Node 18, but we should be cautious when updating.
  */
 if (
-  !process.versions.node.startsWith("22.") &&
-  !process.versions.node.startsWith("23.")
+  process.versions.node.startsWith("18.") ||
+  process.versions.node.startsWith("19.") ||
+  process.versions.node.startsWith("20.") ||
+  process.versions.node.startsWith("21.")
 )
   v8.setFlagsFromString("--experimental-wasm-return-call");
 

--- a/cli/bin/grainrun.js
+++ b/cli/bin/grainrun.js
@@ -10,12 +10,7 @@ const v8 = require("v8");
  *
  * This seems to work for our needs with Node 18, but we should be cautious when updating.
  */
-if (
-  process.versions.node.startsWith("18.") ||
-  process.versions.node.startsWith("19.") ||
-  process.versions.node.startsWith("20.") ||
-  process.versions.node.startsWith("21.")
-)
+if (process.version.match(/^v(18|19|20|21)\./))
   v8.setFlagsFromString("--experimental-wasm-return-call");
 
 const { readFile } = require("fs/promises");


### PR DESCRIPTION
I don't know if this is the best title for this but before if you tried to run the grain cli with node `v22` or above it would error because the `--experimental-wasm-return-call` flag was used, this just checks if we are on those versions and doesn't apply the flag as the behaviour is the default.


I think this pr might be controversial the goal here isn't to change the version of js we use with the pkg binaries just to allow newer versions of node to be used when you've built the compiler from source.