### PR TITLE
feat(stdlib): Add `Array.tryInit`

### DIFF
--- a/compiler/test/stdlib/array.test.gr
+++ b/compiler/test/stdlib/array.test.gr
@@ -7,6 +7,21 @@ from "range" include Range
 
 let arr = [> 1, 2, 3]
 
+// Array.make
+assert Array.make(5, 10) == [> 10, 10, 10, 10, 10]
+assert Array.make(0, 10) == [>]
+
+// Array.init
+assert Array.init(5, n => n + 3) == [> 3, 4, 5, 6, 7]
+assert Array.init(0, n => n + 3) == [>]
+
+// Array.tryInit
+assert Array.tryInit(5, n => Ok(n + 3)) == Ok([> 3, 4, 5, 6, 7])
+assert Array.tryInit(0, n => Ok(n + 3)) == Ok([>])
+assert Array.tryInit(3, n => if (n == 1) Err("stop") else Ok(n)) == Err("stop")
+assert Array.tryInit(0, n => if (n == 1) Err("stop") else Ok(n)) == Ok([>])
+
+
 // Array.get
 
 assert Array.get(1, arr) == 2

--- a/compiler/test/stdlib/array.test.gr
+++ b/compiler/test/stdlib/array.test.gr
@@ -21,7 +21,6 @@ assert Array.tryInit(0, n => Ok(n + 3)) == Ok([>])
 assert Array.tryInit(3, n => if (n == 1) Err("stop") else Ok(n)) == Err("stop")
 assert Array.tryInit(0, n => if (n == 1) Err("stop") else Ok(n)) == Ok([>])
 
-
 // Array.get
 
 assert Array.get(1, arr) == 2

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -130,10 +130,10 @@ provide let init = (length: Number, fn: Number => a) => {
 }
 
 /**
- * Creates a new array of the specified length where each element is
- * initialized with the result of an initializer function. The initializer
- * is called with the index of each array element. If the initializer function
- * returns `Err(_)`, the array creation is stopped and the error is returned.
+ * Creates a new array where each element is initialized with the `Ok`
+ * value result of an initializer function. The initializer is called with the
+ * index of each element. Returns the new array if all calls to the
+ * initializer succeed or the first error otherwise.
  *
  * @param length: The length of the new array
  * @param fn: The initializer function to call with each index, where the value returned will be used to initialize the element
@@ -168,7 +168,8 @@ provide let tryInit = (length: Number, fn: Number => Result<a, b>) => {
       },
       Err(e) => {
         for (let mut j = 0n; j < i; j += 4n) {
-          ignore(Memory.decRef(WasmI32.load(array, _ARRAY_START_OFFSET + j)))
+          Memory.decRef(WasmI32.load(array, _ARRAY_START_OFFSET + j))
+          Memory.free(array)
         }
         return Err(e)
       },

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -120,13 +120,61 @@ provide let init = (length: Number, fn: Number => a) => {
   let mut index = 0n
   for (let mut i = 0n; i < byteLength; i += 4n) {
     WasmI32.store(
-      array + i,
+      array,
       Memory.incRef(WasmI32.fromGrain(fn(tagSimpleNumber(index)))),
-      _ARRAY_DATA_OFFSET
+      _ARRAY_DATA_OFFSET + i
     )
     index += 1n
   }
   WasmI32.toGrain(array): Array<a>
+}
+
+/**
+ * Creates a new array of the specified length where each element is
+ * initialized with the result of an initializer function. The initializer
+ * is called with the index of each array element. If the initializer function
+ * returns `Err(_)`, the array creation is stopped and the error is returned.
+ *
+ * @param length: The length of the new array
+ * @param fn: The initializer function to call with each index, where the value returned will be used to initialize the element
+ * @returns `Ok(array)` if all elements were successfully initialized or `Err(error)` if the initializer function returned an error
+ *
+ * @throws InvalidArgument(String): When `length` is not an integer
+ * @throws InvalidArgument(String): When `length` is negative
+ *
+ * @example Array.tryInit(5, n => Ok(n + 3)) == [> 3, 4, 5, 6, 7]
+ * @example Array.tryInit(5, n => if (n == 1) Err("stop") else Ok(n)) == Err("stop")
+ *
+ * @since v0.7.0
+ */
+@unsafe
+provide let tryInit = (length: Number, fn: Number => Result<a, b>) => {
+  use WasmI32.{ (+), (*), (<) }
+  checkLength(length)
+  let length = coerceNumberToWasmI32(length)
+  let byteLength = length * 4n
+  let array = allocateArray(length)
+  let mut index = 0n
+  for (let mut i = 0n; i < byteLength; i += 4n) {
+    let value = fn(tagSimpleNumber(index))
+    match (value) {
+      Ok(value) => {
+        WasmI32.store(
+          array,
+          Memory.incRef(WasmI32.fromGrain(value)),
+          _ARRAY_START_OFFSET + i
+        )
+        index += 1n
+      },
+      Err(e) => {
+        for (let mut j = 0n; j < i; j += 4n) {
+          ignore(Memory.decRef(WasmI32.load(array, _ARRAY_START_OFFSET + j)))
+        }
+        return Err(e)
+      }
+    }
+  }
+  return Ok(WasmI32.toGrain(array): Array<a>)
 }
 
 /**

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -162,13 +162,13 @@ provide let tryInit = (length: Number, fn: Number => Result<a, b>) => {
         WasmI32.store(
           array,
           Memory.incRef(WasmI32.fromGrain(value)),
-          _ARRAY_START_OFFSET + i
+          _ARRAY_DATA_OFFSET + i
         )
         index += 1n
       },
       Err(e) => {
         for (let mut j = 0n; j < i; j += 4n) {
-          ignore(Memory.decRef(WasmI32.load(array, _ARRAY_START_OFFSET + j)))
+          ignore(Memory.decRef(WasmI32.load(array, _ARRAY_DATA_OFFSET + j)))
         }
         Memory.free(array)
         return Err(e)

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -131,12 +131,12 @@ provide let init = (length: Number, fn: Number => a) => {
 
 /**
  * Creates a new array where each element is initialized with the `Ok`
- * value result of an initializer function. The initializer is called with the
- * index of each element. Returns the new array if all calls to the
+ * result value of an initializer function. The initializer is called with the
+ * index of each element, and returns the new array if all calls to the
  * initializer succeed or the first error otherwise.
  *
  * @param length: The length of the new array
- * @param fn: The initializer function to call with each index, where the value returned will be used to initialize the element
+ * @param fn: The initializer function to call with each index, where the `Ok` value returned will be used to initialize each element
  * @returns `Ok(array)` if all elements were successfully initialized or `Err(error)` if the initializer function returned an error
  *
  * @throws InvalidArgument(String): When `length` is not an integer
@@ -168,9 +168,9 @@ provide let tryInit = (length: Number, fn: Number => Result<a, b>) => {
       },
       Err(e) => {
         for (let mut j = 0n; j < i; j += 4n) {
-          Memory.decRef(WasmI32.load(array, _ARRAY_START_OFFSET + j))
-          Memory.free(array)
+          ignore(Memory.decRef(WasmI32.load(array, _ARRAY_START_OFFSET + j)))
         }
+        Memory.free(array)
         return Err(e)
       },
     }

--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -171,7 +171,7 @@ provide let tryInit = (length: Number, fn: Number => Result<a, b>) => {
           ignore(Memory.decRef(WasmI32.load(array, _ARRAY_START_OFFSET + j)))
         }
         return Err(e)
-      }
+      },
     }
   }
   return Ok(WasmI32.toGrain(array): Array<a>)

--- a/stdlib/array.md
+++ b/stdlib/array.md
@@ -155,17 +155,17 @@ tryInit :
   (length: Number, fn: (Number => Result<a, b>)) => Result<Array<a>, b>
 ```
 
-Creates a new array of the specified length where each element is
-initialized with the result of an initializer function. The initializer
-is called with the index of each array element. If the initializer function
-returns `Err(_)`, the array creation is stopped and the error is returned.
+Creates a new array where each element is initialized with the `Ok`
+result value of an initializer function. The initializer is called with the
+index of each element, and returns the new array if all calls to the
+initializer succeed or the first error otherwise.
 
 Parameters:
 
 |param|type|description|
 |-----|----|-----------|
 |`length`|`Number`|The length of the new array|
-|`fn`|`Number => Result<a, b>`|The initializer function to call with each index, where the value returned will be used to initialize the element|
+|`fn`|`Number => Result<a, b>`|The initializer function to call with each index, where the `Ok` value returned will be used to initialize each element|
 
 Returns:
 

--- a/stdlib/array.md
+++ b/stdlib/array.md
@@ -143,6 +143,53 @@ Examples:
 Array.init(5, n => n + 3) == [> 3, 4, 5, 6, 7]
 ```
 
+### Array.**tryInit**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+tryInit :
+  (length: Number, fn: (Number => Result<a, b>)) => Result<Array<a>, b>
+```
+
+Creates a new array of the specified length where each element is
+initialized with the result of an initializer function. The initializer
+is called with the index of each array element. If the initializer function
+returns `Err(_)`, the array creation is stopped and the error is returned.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`length`|`Number`|The length of the new array|
+|`fn`|`Number => Result<a, b>`|The initializer function to call with each index, where the value returned will be used to initialize the element|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Result<Array<a>, b>`|`Ok(array)` if all elements were successfully initialized or `Err(error)` if the initializer function returned an error|
+
+Throws:
+
+`InvalidArgument(String)`
+
+* When `length` is not an integer
+* When `length` is negative
+
+Examples:
+
+```grain
+Array.tryInit(5, n => Ok(n + 3)) == [> 3, 4, 5, 6, 7]
+```
+
+```grain
+Array.tryInit(5, n => if (n == 1) Err("stop") else Ok(n)) == Err("stop")
+```
+
 ### Array.**get**
 
 <details>


### PR DESCRIPTION
This pr adds an `Array.tryInit` function to make this a bit easier. `Array.tryInit: (length: Number, fn: (index: Number) => Result<a, b>) => Result<Array<A>, b>`. This makes building arrays from result functions quite a bit easier as there was no good alternative before. I do not love the `tryInit` name but I couldn't think of anything better. 

Notes:
* I do not love the `tryInit` name, if anyone has a better one let me know
* If we like the feature and name I am happy to add it to `List` and `Array.Immutable`
  * happy todo that in this pr or a separate one
  * `Array.tryInit` is the most important as with something like a list you can just build it manually.
* I also noticed we didn't have tests for `Array.make` and `Array.init` so I added those in this pr but I am happy to move those to a separate pr if wanted. 