### PR TITLE
chore(docs): Fix typos in queue and stack documentation

### DIFF
--- a/stdlib/queue.gr
+++ b/stdlib/queue.gr
@@ -27,7 +27,7 @@ abstract record Queue<a> {
 /**
  * Creates a new queue with an initial storage of the given size. As values are
  * added or removed, the internal storage may grow or shrink. Generally, you
- * won’t need to care about the storage size of your map and can use the
+ * won’t need to care about the storage size of your queue and can use the
  * default size.
  *
  * @param size: The initial storage size of the queue

--- a/stdlib/queue.md
+++ b/stdlib/queue.md
@@ -46,7 +46,7 @@ make : (?size: Number) => Queue<a>
 
 Creates a new queue with an initial storage of the given size. As values are
 added or removed, the internal storage may grow or shrink. Generally, you
-won’t need to care about the storage size of your map and can use the
+won’t need to care about the storage size of your queue and can use the
 default size.
 
 Parameters:

--- a/stdlib/stack.gr
+++ b/stdlib/stack.gr
@@ -25,7 +25,7 @@ abstract record Stack<a> {
 /**
  * Creates a new stack with an initial storage of the given size. As values are
  * added or removed, the internal storage may grow or shrink. Generally, you
- * won’t need to care about the storage size of your map and can use the
+ * won’t need to care about the storage size of your stack and can use the
  * default size.
  *
  * @param size: The initial storage size of the stack

--- a/stdlib/stack.md
+++ b/stdlib/stack.md
@@ -46,7 +46,7 @@ make : (?size: Number) => Stack<a>
 
 Creates a new stack with an initial storage of the given size. As values are
 added or removed, the internal storage may grow or shrink. Generally, you
-won’t need to care about the storage size of your map and can use the
+won’t need to care about the storage size of your stack and can use the
 default size.
 
 Parameters:


### PR DESCRIPTION
Fixes documentation for queue and stack, both of which incorrectly mentioned map.