### PR TITLE
fix(compiler): Prevent impossible string error from pattern matching

### DIFF
--- a/compiler/src/typed/parmatch.re
+++ b/compiler/src/typed/parmatch.re
@@ -1939,7 +1939,8 @@ let untype_constant =
     )
   | Const_bytes(b) =>
     Parsetree.PConstBytes(Location.mknoloc(Bytes.to_string(b)))
-  | Const_string(s) => Parsetree.PConstString(Location.mknoloc(s))
+  | Const_string(s) =>
+    Parsetree.PConstString(Location.mknoloc(Printf.sprintf("\"%s\"", s)))
   | Const_char(c) => Parsetree.PConstChar(Location.mknoloc(c))
   | Const_bool(b) => Parsetree.PConstBool(b)
   | Const_void => Parsetree.PConstVoid;

--- a/compiler/test/suites/pattern_matching.re
+++ b/compiler/test/suites/pattern_matching.re
@@ -479,4 +479,23 @@ describe("pattern matching", ({test, testSkip}) => {
     |},
     "Rec is a record constructor but a tuple constructor pattern was given.",
   );
+  //
+  assertWarning(
+    "regression_2261_str_nested_list",
+    {|
+      match ([]) {
+        ["str"] => void,
+      }
+    |},
+    Warnings.PartialMatch({|([...]("str", [...](_, _))|[...]("", _)|[])|}),
+  );
+  assertWarning(
+    "regression_2261_str_nested_arr",
+    {|
+      match ([> ]) {
+        [> "str"] => void,
+      }
+    |},
+    Warnings.PartialMatch({|([> ""]|[> ])|}),
+  );
 });

--- a/compiler/test/suites/pattern_matching.re
+++ b/compiler/test/suites/pattern_matching.re
@@ -487,7 +487,7 @@ describe("pattern matching", ({test, testSkip}) => {
         ["str"] => void,
       }
     |},
-    Warnings.PartialMatch({|([...]("str", [...](_, _))|[...]("", _)|[])|}),
+    Warnings.PartialMatch({|(["str", _, _]|["", _]|[])|}),
   );
   assertWarning(
     "regression_2261_str_nested_arr",


### PR DESCRIPTION
I noticed that when we had a non exhaustive pattern including a string such as:
```gr
module Main
match ([]) {
  ["str"] => void
}
```
we would hit an impossible error upon further investigation i noticed that we convert the constructors from typetree nodes back into ParseTree nodes and that we did not add the quotes back onto the string when we do this, I corrected that and added two small regression tests.


Closes: #2216 