### PR TITLE
feat(compiler): Improve exhaustive warning for lists

### DIFF
--- a/compiler/src/typed/printpat.re
+++ b/compiler/src/typed/printpat.re
@@ -91,11 +91,29 @@ let rec pretty_val = (ppf, v) =>
         fprintf(ppf, "@[{%a%t}@]", pretty_lvals, filtered_lvs, elision_mark);
       };
     | TPatConstant(c) => fprintf(ppf, "%s", pretty_const(c))
-    | TPatConstruct(_, cstr, args) =>
-      if (List.length(args) > 0) {
-        fprintf(ppf, "@[%s(%a)@]", cstr.cstr_name, pretty_vals(","), args);
+    | TPatConstruct(_, {cstr_name}, args) =>
+      if (cstr_name == "[...]") {
+        fprintf(
+          ppf,
+          "@[[%a]@]",
+          pretty_vals(","),
+          List.rev(
+            List.fold_left(
+              (acc, arg) =>
+                switch (arg.pat_desc) {
+                | TPatConstruct(_, {cstr_name: "[...]"}, args) =>
+                  List.concat([args, acc])
+                | _ => [arg, ...acc]
+                },
+              [],
+              args,
+            ),
+          ),
+        );
+      } else if (List.length(args) > 0) {
+        fprintf(ppf, "@[%s(%a)@]", cstr_name, pretty_vals(","), args);
       } else {
-        fprintf(ppf, "@[%s@]", cstr.cstr_name);
+        fprintf(ppf, "@[%s@]", cstr_name);
       }
     | TPatAlias(v, x, _) =>
       fprintf(ppf, "@[(%a@ as %a)@]", pretty_val, v, Ident.print, x)


### PR DESCRIPTION
This pr improves the way we print exhaustiveness warnings for list constructors an example can be seen below:
![Screenshot 2024-12-22 at 8 22 40 PM](https://github.com/user-attachments/assets/e7953aa2-27ca-43d5-a3e0-393a4cb08239)

As a side note, and without looking into this I wonder if it would make sense or if we should at least open an issue to move from a custom printer here to somehow using the formatter, we do have a function to convert from the typedtree nodes back into the parsetree nodes which we should be able to pipe into the formatter this would maintain a consistent

Closes: #2217 