### PR TITLE
chore: Add scripts for `stdlib format` and `stdlib doc`

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -110,13 +110,13 @@ jobs:
       - name: (stdlib) Check documentation
         if: inputs.os != 'windows-latest'
         run: |
-          grain doc stdlib -o stdlib --current-version=$(grain -v)
+          npm run stdlib doc
           git diff --exit-code --name-only
 
       # If we have a working grain CLI, we can run grainfmt on stdlib & tests
       - name: (stdlib) Check formatting
         if: inputs.os != 'windows-latest'
         run: |
-          grain format stdlib -o stdlib
+          npm run stdlib format
           grain format compiler/test/stdlib -o compiler/test/stdlib
           git diff --exit-code --name-only

--- a/stdlib/README.md
+++ b/stdlib/README.md
@@ -41,13 +41,13 @@ If you want to contribute to the `stdlib`, please consider the guidelines [here]
 To regenerate the `stdlib`` documentation you can run:
 
 ```sh
-grain doc stdlib -o stdlib --current-version=$(grain -v)
+npm run stdlib doc
 ```
 
 To format the `stdlib` you can run:
 
 ```sh
-grain format ./stdlib/ -o ./stdlib/
+npm run stdlib format
 ```
 
 To run the `stdlib` tests you can run:

--- a/stdlib/package.json
+++ b/stdlib/package.json
@@ -27,7 +27,9 @@
     "index.js"
   ],
   "scripts": {
-    "clean": "del-cli \"**/*.wasm\" \"**/*.wat\" \"**/*.gro\" \"**/*.modsig\""
+    "clean": "del-cli \"**/*.wasm\" \"**/*.wat\" \"**/*.gro\" \"**/*.modsig\"",
+    "doc": "grain doc ./ -o ./ --current-version=$(grain -v)",
+    "format": "grain format ./ -o ./"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
Small pr with two `qol` npm scripts for `npm run stdlib format` and `npm run stdlib doc`, this ensures consistency when running scripts and ensures that contributors are using the right grain version when generating docs.