### PR TITLE
fix(grainfmt): Fix formatting of function types with a single tuple arg

### DIFF
--- a/compiler/src/formatting/fmt.re
+++ b/compiler/src/formatting/fmt.re
@@ -2702,8 +2702,7 @@ let print_type = (fmt, {ptyp_desc, ptyp_loc}) => {
           ptyp_arg_label: Unlabeled,
           ptyp_arg_type: {
             ptyp_desc:
-              PTyAny | PTyVar(_) | PTyArrow(_, _) | PTyConstr(_, _) |
-              PTyPoly(_, _),
+              PTyAny | PTyVar(_) | PTyArrow(_, _) | PTyConstr(_, []),
           },
         } as param,
       ],

--- a/compiler/src/formatting/fmt.re
+++ b/compiler/src/formatting/fmt.re
@@ -2696,7 +2696,19 @@ let print_type = (fmt, {ptyp_desc, ptyp_loc}) => {
       )
       ++ break,
     )
-  | PTyArrow([{ptyp_arg_label: Unlabeled} as param], return) =>
+  | PTyArrow(
+      [
+        {
+          ptyp_arg_label: Unlabeled,
+          ptyp_arg_type: {
+            ptyp_desc:
+              PTyAny | PTyVar(_) | PTyArrow(_, _) | PTyConstr(_, _) |
+              PTyPoly(_, _),
+          },
+        } as param,
+      ],
+      return,
+    ) =>
     fmt.print_parsed_type_argument(fmt, param)
     ++ string(" =>")
     ++ fmt.print_comment_range(

--- a/compiler/test/grainfmt/lambda.expected.gr
+++ b/compiler/test/grainfmt/lambda.expected.gr
@@ -9,6 +9,9 @@ y => {
   let z = 2
 }
 
+// Regression #2229
+let foo: ((a, b)) => Void = a => void
+
 let testfna = forEachCodePoint(c => /* arg */ void)
 
 let testfn = forEachCodePoint(c => /* arg */ {

--- a/compiler/test/grainfmt/lambda.input.gr
+++ b/compiler/test/grainfmt/lambda.input.gr
@@ -7,6 +7,9 @@ y => {
   let z = 2
 }
 
+// Regression #2229
+let foo: ((a, b)) => Void = a => void
+
 let testfna = forEachCodePoint(c /* arg */ => void)
 
 let testfn = forEachCodePoint(c /* arg */ => { 


### PR DESCRIPTION
This fixes formatting of single argument tuple function types such as `((a, b) => Void` before they were being formatted to `(a, b) => Void`, this is because we drop parens around single argument lambda's but we need to keep them in the case of a pattern.



Closes: #2229 