### PR TITLE
feat(compiler): Use program location for `_gmain`

### DIFF
--- a/compiler/src/codegen/compcore.re
+++ b/compiler/src/codegen/compcore.re
@@ -3245,7 +3245,7 @@ let compile_main = (wasm_mod, env, prog) => {
             body: prog.main_body,
             stack_size: prog.main_body_stack_size,
             attrs: [],
-            func_loc: Grain_parsing.Location.dummy_loc,
+            func_loc: prog.prog_loc,
           },
         );
       };


### PR DESCRIPTION
Tiny pr just changing the location of `_gmain` from a `dummy_loc` to the program location which seems slightly more accurate. 

I'm not sure if this counts as breaking or not.


Closes: #2174 