### PR TITLE
feat(compiler): Optimize away unused recursive functions

### DIFF
--- a/compiler/src/middle_end/anf_mapper.rei
+++ b/compiler/src/middle_end/anf_mapper.rei
@@ -4,7 +4,7 @@ open Grain_typed;
 open Types;
 
 module type MapArgument = {
-  let enter_imm_expression: imm_expression => imm_expression;
+  let enter_imm_expression: (list(Ident.t), imm_expression) => imm_expression;
   let leave_imm_expression: imm_expression => imm_expression;
 
   let enter_comp_expression: comp_expression => comp_expression;

--- a/compiler/src/middle_end/optimize_dead_assignments.re
+++ b/compiler/src/middle_end/optimize_dead_assignments.re
@@ -73,9 +73,10 @@ module DAEArg: Anf_mapper.MapArgument = {
     p;
   };
 
-  let enter_imm_expression = ({imm_desc: desc} as i) => {
+  let enter_imm_expression = (contexts, {imm_desc: desc} as i) => {
     switch (desc) {
-    | ImmId(i) => mark_used(i)
+    | ImmId(i) when !List.exists(p => Ident.same(p, i), contexts) =>
+      mark_used(i)
     | _ => ()
     };
     i;

--- a/compiler/test/__snapshots__/optimizations.cd4b89ce.0.snapshot
+++ b/compiler/test/__snapshots__/optimizations.cd4b89ce.0.snapshot
@@ -1,0 +1,109 @@
+optimizations › regression_issue_1227
+((mash_code
+  ((functions ())
+   (imports
+    (((mimp_id ((name <))) (mimp_mod pervasives.gr) (mimp_name <)
+      (mimp_type
+       (MFuncImport (Managed (Unmanaged WasmI32) (Unmanaged WasmI32))
+        ((Unmanaged WasmI32))))
+      (mimp_kind MImportGrain) (mimp_setup MSetupNone) (mimp_used true))
+     ((mimp_id ((name <))) (mimp_mod pervasives.gr) (mimp_name <)
+      (mimp_type (MGlobalImport Managed true)) (mimp_kind MImportGrain)
+      (mimp_setup MCallGetter) (mimp_used true))
+     ((mimp_id ((name +))) (mimp_mod pervasives.gr) (mimp_name +)
+      (mimp_type
+       (MFuncImport (Managed (Unmanaged WasmI32) (Unmanaged WasmI32))
+        ((Unmanaged WasmI32))))
+      (mimp_kind MImportGrain) (mimp_setup MSetupNone) (mimp_used true))
+     ((mimp_id ((name +))) (mimp_mod pervasives.gr) (mimp_name +)
+      (mimp_type (MGlobalImport Managed true)) (mimp_kind MImportGrain)
+      (mimp_setup MCallGetter) (mimp_used true))))
+   (exports ())
+   (main_body
+    (((instr_desc
+       (MStore
+        (((MLocalBind 0 Managed)
+          ((instr_desc
+            (MImmediate
+             ((immediate_desc (MImmConst (MConstI32 0)))
+              (immediate_analyses ((last_usage Unknown))))))))))))
+     ((instr_desc
+       (MCleanup
+        (((instr_desc
+           (MFor
+            ((((instr_desc
+                (MStore
+                 (((MLocalBind 3 Managed)
+                   ((instr_desc
+                     (MImmediate
+                      ((immediate_desc
+                        (MIncRef
+                         ((immediate_desc
+                           (MImmBinding (MLocalBind 0 Managed)))
+                          (immediate_analyses ((last_usage Unknown))))))
+                       (immediate_analyses ((last_usage Unknown))))))))))))
+              ((instr_desc
+                (MCallKnown (func <_1125)
+                 (closure
+                  ((immediate_desc
+                    (MIncRef
+                     ((immediate_desc
+                       (MImmBinding (MGlobalBind <_1125 Managed)))
+                      (immediate_analyses ((last_usage Last))))))
+                   (immediate_analyses ((last_usage Unknown)))))
+                 (func_type ((Managed Managed) ((Unmanaged WasmI32))))
+                 (args
+                  (((immediate_desc (MImmBinding (MLocalBind 3 Managed)))
+                    (immediate_analyses ((last_usage Last))))
+                   ((immediate_desc (MImmConst (MConstI32 10)))
+                    (immediate_analyses ((last_usage Unknown)))))))))))
+            ((((instr_desc
+                (MStore
+                 (((MLocalBind 1 Managed)
+                   ((instr_desc
+                     (MImmediate
+                      ((immediate_desc
+                        (MIncRef
+                         ((immediate_desc
+                           (MImmBinding (MLocalBind 0 Managed)))
+                          (immediate_analyses ((last_usage Unknown))))))
+                       (immediate_analyses ((last_usage Unknown))))))))))))
+              ((instr_desc
+                (MStore
+                 (((MLocalBind 2 Managed)
+                   ((instr_desc
+                     (MCallKnown (func +_1122)
+                      (closure
+                       ((immediate_desc
+                         (MIncRef
+                          ((immediate_desc
+                            (MImmBinding (MGlobalBind +_1122 Managed)))
+                           (immediate_analyses ((last_usage Last))))))
+                        (immediate_analyses ((last_usage Unknown)))))
+                      (func_type ((Managed Managed) (Managed)))
+                      (args
+                       (((immediate_desc
+                          (MImmBinding (MLocalBind 1 Managed)))
+                         (immediate_analyses ((last_usage Last))))
+                        ((immediate_desc (MImmConst (MConstI32 1)))
+                         (immediate_analyses ((last_usage Unknown))))))))))))))
+              ((instr_desc
+                (MSet (MLocalBind 0 Managed)
+                 ((instr_desc
+                   (MImmediate
+                    ((immediate_desc (MImmBinding (MLocalBind 2 Managed)))
+                     (immediate_analyses ((last_usage Last))))))))))))
+            (((instr_desc
+               (MImmediate
+                ((immediate_desc
+                  (MImmConst (MConstLiteral (MConstI32 1879048190))))
+                 (immediate_analyses ((last_usage Unknown))))))))))))
+        (((immediate_desc (MImmBinding (MLocalBind 0 Managed)))
+          (immediate_analyses ((last_usage Unknown))))))))))
+   (main_body_stack_size
+    ((stack_size_ptr 4) (stack_size_i32 0) (stack_size_i64 0)
+     (stack_size_f32 0) (stack_size_f64 0)))
+   (globals ()) (function_table_elements ())
+   (global_function_table_offset ((name function_table_global)))
+   (compilation_mode Normal) (type_metadata <opaque>)))
+ (signature <opaque>))

--- a/compiler/test/suites/optimizations.re
+++ b/compiler/test/suites/optimizations.re
@@ -801,4 +801,16 @@ describe("optimizations", ({test, testSkip}) => {
     |},
     "1 plus 2\n",
   );
+  assertSnapshot(
+    "regression_issue_1227",
+    {|
+      for (let mut j = 0; j < 10; j += 1) {
+        let rec foo = () => {
+          print("never executed")
+          foo()
+        }
+        void
+      }
+    |},
+  );
 });


### PR DESCRIPTION
This corrects our unused assignment optimization to cleanup unused recursive functions.

In order todo this I collect a `context` stack while iterating the `anf_mapper` and if the given id exists within the context path we don't mark it used.
```
let rec testRec = () => {
  let rec subTest = () => {
      testRec() // contexts: subTest -> testRec
  }
}
```

Closes: #1227 