### PR TITLE
chore(stdlib): Correct small spelling mistake in `Array` docs

### DIFF
--- a/stdlib/array.gr
+++ b/stdlib/array.gr
@@ -1942,7 +1942,7 @@ provide module Immutable {
    *
    * @param fn: The function to call on each element, where the returned value indicates if the element satisfies the condition
    * @param array: The array to check
-   * @returns `true` if all elements satify the condition or `false` otherwise
+   * @returns `true` if all elements satisfy the condition or `false` otherwise
    *
    * @example
    * use Array.{ module Immutable }

--- a/stdlib/array.md
+++ b/stdlib/array.md
@@ -2440,7 +2440,7 @@ Returns:
 
 |type|description|
 |----|-----------|
-|`Bool`|`true` if all elements satify the condition or `false` otherwise|
+|`Bool`|`true` if all elements satisfy the condition or `false` otherwise|
 
 Examples:
 


### PR DESCRIPTION
Tiny correction to a spelling mistake found in the docs for the `Array` module.