### PR TITLE
feat(stdlib): Add `Char.encodedLength`

### DIFF
--- a/compiler/test/stdlib/char.test.gr
+++ b/compiler/test/stdlib/char.test.gr
@@ -41,18 +41,18 @@ assert Char.toString('f') == "f"
 assert Char.toString('💯') == "💯"
 
 // byteCount
-assert Char.byteCount(Char.UTF8, 'a') == 1
-assert Char.byteCount(Char.UTF8, '©') == 2
-assert Char.byteCount(Char.UTF8, '☃') == 3
-assert Char.byteCount(Char.UTF8, '🌾') == 4
-assert Char.byteCount(Char.UTF16, 'a') == 1
-assert Char.byteCount(Char.UTF16, '©') == 1
-assert Char.byteCount(Char.UTF16, '☃') == 1
-assert Char.byteCount(Char.UTF16, '🌾') == 2
-assert Char.byteCount(Char.UTF32, 'a') == 4
-assert Char.byteCount(Char.UTF32, '©') == 4
-assert Char.byteCount(Char.UTF32, '☃') == 4
-assert Char.byteCount(Char.UTF32, '🌾') == 4
+assert Char.encodedLength(Char.UTF8, 'a') == 1
+assert Char.encodedLength(Char.UTF8, '©') == 2
+assert Char.encodedLength(Char.UTF8, '☃') == 3
+assert Char.encodedLength(Char.UTF8, '🌾') == 4
+assert Char.encodedLength(Char.UTF16, 'a') == 1
+assert Char.encodedLength(Char.UTF16, '©') == 1
+assert Char.encodedLength(Char.UTF16, '☃') == 1
+assert Char.encodedLength(Char.UTF16, '🌾') == 2
+assert Char.encodedLength(Char.UTF32, 'a') == 4
+assert Char.encodedLength(Char.UTF32, '©') == 4
+assert Char.encodedLength(Char.UTF32, '☃') == 4
+assert Char.encodedLength(Char.UTF32, '🌾') == 4
 
 // issue #927
 let chars = [> '\u{1F3F4}', '\u{E0067}']

--- a/compiler/test/stdlib/char.test.gr
+++ b/compiler/test/stdlib/char.test.gr
@@ -40,6 +40,20 @@ assert Char.code(Char.pred(Char.fromCode(0xE000))) == 0xD7FF
 assert Char.toString('f') == "f"
 assert Char.toString('💯') == "💯"
 
+// byteCount
+assert Char.byteCount(Char.UTF8, 'a') == 1
+assert Char.byteCount(Char.UTF8, '©') == 2
+assert Char.byteCount(Char.UTF8, '☃') == 3
+assert Char.byteCount(Char.UTF8, '🌾') == 4
+assert Char.byteCount(Char.UTF16, 'a') == 1
+assert Char.byteCount(Char.UTF16, '©') == 1
+assert Char.byteCount(Char.UTF16, '☃') == 1
+assert Char.byteCount(Char.UTF16, '🌾') == 2
+assert Char.byteCount(Char.UTF32, 'a') == 4
+assert Char.byteCount(Char.UTF32, '©') == 4
+assert Char.byteCount(Char.UTF32, '☃') == 4
+assert Char.byteCount(Char.UTF32, '🌾') == 4
+
 // issue #927
 let chars = [> '\u{1F3F4}', '\u{E0067}']
 let mut charPosition = 0

--- a/stdlib/char.gr
+++ b/stdlib/char.gr
@@ -190,14 +190,14 @@ provide enum Encoding {
  * @param char: The character
  * @returns The byte count of the character in the given encoding
  *
- * @example Char.byteCount(Char.UTF8, 'a') == 1
- * @example Char.byteCount(Char.UTF8, '🌾') == 4
- * @example Char.byteCount(Char.UTF16, '©') == 1
+ * @example Char.encodedLength(Char.UTF8, 'a') == 1
+ * @example Char.encodedLength(Char.UTF8, '🌾') == 4
+ * @example Char.encodedLength(Char.UTF16, '©') == 1
  *
  * @since v0.7.0
  */
 @unsafe
-provide let byteCount = (encoding, char: Char) => {
+provide let encodedLength = (encoding, char: Char) => {
   let usv = untagChar(char)
   let utf8ByteCount = usvEncodeLength(usv)
   let utf8ByteCount = tagSimpleNumber(utf8ByteCount)

--- a/stdlib/char.gr
+++ b/stdlib/char.gr
@@ -184,9 +184,9 @@ provide enum Encoding {
 }
 
 /**
- * Returns the byte count of the given character in the given encoding.
+ * Returns the byte count of a character if encoded in the given encoding.
  *
- * @param encoding: The encoding to use
+ * @param encoding: The encoding to check
  * @param char: The character
  * @returns The byte count of the character in the given encoding
  *

--- a/stdlib/char.gr
+++ b/stdlib/char.gr
@@ -173,6 +173,42 @@ provide let toString = (char: Char) => {
 }
 
 /**
+ * Byte encodings
+ *
+ * @since v0.7.0
+ */
+provide enum Encoding {
+  UTF8,
+  UTF16,
+  UTF32,
+}
+
+/**
+ * Returns the byte count of the given character in the given encoding.
+ *
+ * @param encoding: The encoding to use
+ * @param char: The character
+ * @returns The byte count of the character in the given encoding
+ *
+ * @example Char.byteCount(Char.UTF8, 'a') == 1
+ * @example Char.byteCount(Char.UTF8, '🌾') == 4
+ * @example Char.byteCount(Char.UTF16, '©') == 1
+ *
+ * @since v0.7.0
+ */
+@unsafe
+provide let byteCount = (encoding, char: Char) => {
+  let usv = untagChar(char)
+  let utf8ByteCount = usvEncodeLength(usv)
+  let utf8ByteCount = tagSimpleNumber(utf8ByteCount)
+  match (encoding) {
+    UTF32 => 4,
+    UTF16 => if (utf8ByteCount == 4) 2 else 1,
+    UTF8 => utf8ByteCount,
+  }
+}
+
+/**
  * Checks if the first character is less than the second character by Unicode scalar value.
  *
  * @param x: The first character

--- a/stdlib/char.md
+++ b/stdlib/char.md
@@ -317,13 +317,13 @@ No other changes yet.
 encodedLength : (encoding: Encoding, char: Char) => Number
 ```
 
-Returns the byte count of the given character in the given encoding.
+Returns the byte count of a character if encoded in the given encoding.
 
 Parameters:
 
 |param|type|description|
 |-----|----|-----------|
-|`encoding`|`Encoding`|The encoding to use|
+|`encoding`|`Encoding`|The encoding to check|
 |`char`|`Char`|The character|
 
 Returns:

--- a/stdlib/char.md
+++ b/stdlib/char.md
@@ -306,7 +306,7 @@ Char.toString('a') == "a"
 Char.toString('🌾') == "🌾"
 ```
 
-### Char.**byteCount**
+### Char.**encodedLength**
 
 <details disabled>
 <summary tabindex="-1">Added in <code>next</code></summary>
@@ -314,7 +314,7 @@ No other changes yet.
 </details>
 
 ```grain
-byteCount : (encoding: Encoding, char: Char) => Number
+encodedLength : (encoding: Encoding, char: Char) => Number
 ```
 
 Returns the byte count of the given character in the given encoding.
@@ -335,15 +335,15 @@ Returns:
 Examples:
 
 ```grain
-Char.byteCount(Char.UTF8, 'a') == 1
+Char.encodedLength(Char.UTF8, 'a') == 1
 ```
 
 ```grain
-Char.byteCount(Char.UTF8, '🌾') == 4
+Char.encodedLength(Char.UTF8, '🌾') == 4
 ```
 
 ```grain
-Char.byteCount(Char.UTF16, '©') == 1
+Char.encodedLength(Char.UTF16, '©') == 1
 ```
 
 ### Char.**(<)**

--- a/stdlib/char.md
+++ b/stdlib/char.md
@@ -27,6 +27,27 @@ from "char" include Char
 '🌾'
 ```
 
+## Types
+
+Type declarations included in the Char module.
+
+### Char.**Encoding**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+enum Encoding {
+  UTF8,
+  UTF16,
+  UTF32,
+}
+```
+
+Byte encodings
+
 ## Values
 
 Functions and constants included in the Char module.
@@ -283,6 +304,46 @@ Char.toString('a') == "a"
 
 ```grain
 Char.toString('🌾') == "🌾"
+```
+
+### Char.**byteCount**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+byteCount : (encoding: Encoding, char: Char) => Number
+```
+
+Returns the byte count of the given character in the given encoding.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`encoding`|`Encoding`|The encoding to use|
+|`char`|`Char`|The character|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Number`|The byte count of the character in the given encoding|
+
+Examples:
+
+```grain
+Char.byteCount(Char.UTF8, 'a') == 1
+```
+
+```grain
+Char.byteCount(Char.UTF8, '🌾') == 4
+```
+
+```grain
+Char.byteCount(Char.UTF16, '©') == 1
 ```
 
 ### Char.**(<)**


### PR DESCRIPTION
This adds `Char.byteCount` which can be used with a specified encoding to get the encoded length of a char.

Example use case for this is stepping through a byte array when you do `Byte.getChar` you have no clue how far to advance for the next char without this.