### PR TITLE
fix(grainfmt): Correct formatting of nested constraints

### DIFF
--- a/compiler/src/formatting/fmt.re
+++ b/compiler/src/formatting/fmt.re
@@ -2515,13 +2515,21 @@ let print_expression = (fmt, ~infix_wrap=d => group(indent(d)), expr) => {
          )
     | PExpConstraint(inner_expr, typ) =>
       (
-        switch (needs_grouping(~parent=expr, ~side=Left, inner_expr)) {
-        | ParenGrouping =>
+        switch (
+          inner_expr.pexp_desc,
+          needs_grouping(~parent=expr, ~side=Left, inner_expr),
+        ) {
+        | (PExpConstraint(_, _), typ) =>
           parens(
             indent(break ++ fmt.print_expression(fmt, inner_expr)) ++ break,
           )
-        | FormatterGrouping => group(fmt.print_expression(fmt, inner_expr))
-        | None => fmt.print_expression(fmt, inner_expr)
+        | (_, ParenGrouping) =>
+          parens(
+            indent(break ++ fmt.print_expression(fmt, inner_expr)) ++ break,
+          )
+        | (_, FormatterGrouping) =>
+          group(fmt.print_expression(fmt, inner_expr))
+        | (_, None) => fmt.print_expression(fmt, inner_expr)
         }
       )
       ++ string(":")

--- a/compiler/src/formatting/fmt.re
+++ b/compiler/src/formatting/fmt.re
@@ -258,6 +258,13 @@ let needs_grouping = (~parent, ~side: infix_side, expr) => {
   | (PExpConstant(PConstNumber(PConstNumberRational(_))), _)
       when op_precedence('/') <= precedence(parent) =>
     ParenGrouping
+  | (PExpConstraint(_, _), _)
+      when
+        switch (parent.pexp_desc) {
+        | PExpConstraint(_, _) => true
+        | _ => false
+        } =>
+    ParenGrouping
   | _ => FormatterGrouping
   };
 };
@@ -2515,21 +2522,13 @@ let print_expression = (fmt, ~infix_wrap=d => group(indent(d)), expr) => {
          )
     | PExpConstraint(inner_expr, typ) =>
       (
-        switch (
-          inner_expr.pexp_desc,
-          needs_grouping(~parent=expr, ~side=Left, inner_expr),
-        ) {
-        | (PExpConstraint(_, _), typ) =>
+        switch (needs_grouping(~parent=expr, ~side=Left, inner_expr)) {
+        | ParenGrouping =>
           parens(
             indent(break ++ fmt.print_expression(fmt, inner_expr)) ++ break,
           )
-        | (_, ParenGrouping) =>
-          parens(
-            indent(break ++ fmt.print_expression(fmt, inner_expr)) ++ break,
-          )
-        | (_, FormatterGrouping) =>
-          group(fmt.print_expression(fmt, inner_expr))
-        | (_, None) => fmt.print_expression(fmt, inner_expr)
+        | FormatterGrouping => group(fmt.print_expression(fmt, inner_expr))
+        | None => fmt.print_expression(fmt, inner_expr)
         }
       )
       ++ string(":")

--- a/compiler/test/grainfmt/constraints.expected.gr
+++ b/compiler/test/grainfmt/constraints.expected.gr
@@ -11,3 +11,5 @@ let test = test => {
 
 // Regression #2244
 (1: Number): Number
+
+((1: Number): Number): Number

--- a/compiler/test/grainfmt/constraints.expected.gr
+++ b/compiler/test/grainfmt/constraints.expected.gr
@@ -8,3 +8,6 @@ let test = test => {
     print(i)
   }, test: List<Number>)
 }
+
+// Regression #2244
+(1: Number): Number

--- a/compiler/test/grainfmt/constraints.input.gr
+++ b/compiler/test/grainfmt/constraints.input.gr
@@ -11,3 +11,5 @@ let test = test => {
 
 // Regression #2244
 (1: Number): Number
+
+((1: Number): Number): Number

--- a/compiler/test/grainfmt/constraints.input.gr
+++ b/compiler/test/grainfmt/constraints.input.gr
@@ -8,3 +8,6 @@ let test = test => {
     print(i)
   }, test: List<Number>)
 }
+
+// Regression #2244
+(1: Number): Number


### PR DESCRIPTION
This fixes a small bug where `(1: Number): Number` was being formatted into `1: Number: Number` which is a parsing issue.

Closes: #2244 