### PR TITLE
feat(runtime): Optimize `==` for lists 

### DIFF
--- a/compiler/test/stdlib/pervasives.test.gr
+++ b/compiler/test/stdlib/pervasives.test.gr
@@ -75,3 +75,9 @@ record Comparable2 {
 }
 assert compare({ a: 1, b: true, c: void }, { a: 1, b: true, c: void }) == 0
 assert compare({ a: 1, b: true, c: void }, { a: 1, b: false, c: void }) > 0
+
+// Large list equality, regression #2247
+let rec make_list = (n, acc) => {
+  if (n == 0) acc else make_list(n - 1, [n, ...acc])
+}
+assert make_list(500_000, []) == make_list(500_000, [])

--- a/compiler/test/suites/basic_functionality.re
+++ b/compiler/test/suites/basic_functionality.re
@@ -377,6 +377,6 @@ describe("basic functionality", ({test, testSkip}) => {
     ~config_fn=smallestFileConfig,
     "smallest_grain_program",
     "",
-    6494,
+    6503,
   );
 });

--- a/stdlib/runtime/equal.gr
+++ b/stdlib/runtime/equal.gr
@@ -24,38 +24,36 @@ let rec heapEqualHelp = (heapTag, xptr, yptr) => {
     t when t == Tags._GRAIN_ADT_HEAP_TAG => {
       // Check if the same constructor variant
       if (WasmI32.load(xptr, 12n) != WasmI32.load(yptr, 12n)) {
-        false
-      } else {
-        let xarity = WasmI32.load(xptr, 16n)
-        let yarity = WasmI32.load(yptr, 16n)
+        return false
+      }
+      let xarity = WasmI32.load(xptr, 16n)
+      let yarity = WasmI32.load(yptr, 16n)
 
-        // Cycle check
-        if ((xarity & cycleMarker) == cycleMarker) {
-          true
-        } else {
-          WasmI32.store(xptr, xarity ^ cycleMarker, 16n)
-          WasmI32.store(yptr, yarity ^ cycleMarker, 16n)
+      // Cycle check
+      if ((xarity & cycleMarker) == cycleMarker) {
+        return true
+      }
 
-          let mut result = true
+      WasmI32.store(xptr, xarity ^ cycleMarker, 16n)
+      WasmI32.store(yptr, yarity ^ cycleMarker, 16n)
 
-          let bytes = xarity * 4n
-          for (let mut i = 0n; i < bytes; i += 4n) {
-            if (
-              !equalHelp(
-                WasmI32.load(xptr + i, 20n),
-                WasmI32.load(yptr + i, 20n)
-              )
-            ) {
-              result = false
-              break
-            }
-          }
+      let bytes = xarity * 4n
+      for (let mut i = 0n; i < bytes; i += 4n) {
+        if (
+          !equalHelp(
+            WasmI32.load(xptr + i, 20n),
+            WasmI32.load(yptr + i, 20n)
+          )
+        ) {
           WasmI32.store(xptr, xarity, 16n)
           WasmI32.store(yptr, yarity, 16n)
-
-          result
+          return false
         }
       }
+      WasmI32.store(xptr, xarity, 16n)
+      WasmI32.store(yptr, yarity, 16n)
+
+      return true
     },
     t when t == Tags._GRAIN_RECORD_HEAP_TAG => {
       let xlength = WasmI32.load(xptr, 12n)
@@ -63,27 +61,26 @@ let rec heapEqualHelp = (heapTag, xptr, yptr) => {
 
       // Cycle check
       if ((xlength & cycleMarker) == cycleMarker) {
-        true
-      } else {
-        WasmI32.store(xptr, xlength ^ cycleMarker, 12n)
-        WasmI32.store(yptr, ylength ^ cycleMarker, 12n)
-
-        let mut result = true
-
-        let bytes = xlength * 4n
-        for (let mut i = 0n; i < bytes; i += 4n) {
-          if (
-            !equalHelp(WasmI32.load(xptr + i, 16n), WasmI32.load(yptr + i, 16n))
-          ) {
-            result = false
-            break
-          }
-        }
-        WasmI32.store(xptr, xlength, 12n)
-        WasmI32.store(yptr, ylength, 12n)
-
-        result
+        return true
       }
+
+      WasmI32.store(xptr, xlength ^ cycleMarker, 12n)
+      WasmI32.store(yptr, ylength ^ cycleMarker, 12n)
+
+      let bytes = xlength * 4n
+      for (let mut i = 0n; i < bytes; i += 4n) {
+        if (
+          !equalHelp(WasmI32.load(xptr + i, 16n), WasmI32.load(yptr + i, 16n))
+        ) {
+          WasmI32.store(xptr, xlength, 12n)
+          WasmI32.store(yptr, ylength, 12n)
+          return false
+        }
+      }
+      WasmI32.store(xptr, xlength, 12n)
+      WasmI32.store(yptr, ylength, 12n)
+
+      return true
     },
     t when t == Tags._GRAIN_ARRAY_HEAP_TAG => {
       let xlength = WasmI32.load(xptr, 4n)
@@ -91,37 +88,39 @@ let rec heapEqualHelp = (heapTag, xptr, yptr) => {
 
       // Check if the same length
       if (xlength != ylength) {
-        false
-      } else if ((xlength & cycleMarker) == cycleMarker) {
-        // Cycle check
-        true
-      } else {
-        WasmI32.store(xptr, xlength ^ cycleMarker, 4n)
-        WasmI32.store(yptr, ylength ^ cycleMarker, 4n)
-
-        let mut result = true
-        let bytes = xlength * 4n
-        for (let mut i = 0n; i < bytes; i += 4n) {
-          if (
-            !equalHelp(WasmI32.load(xptr + i, 8n), WasmI32.load(yptr + i, 8n))
-          ) {
-            result = false
-            break
-          }
-        }
-
-        WasmI32.store(xptr, xlength, 4n)
-        WasmI32.store(yptr, ylength, 4n)
-
-        result
+        return false
       }
+
+      // Cycle check
+      if ((xlength & cycleMarker) == cycleMarker) {
+        return true
+      }
+
+      WasmI32.store(xptr, xlength ^ cycleMarker, 4n)
+      WasmI32.store(yptr, ylength ^ cycleMarker, 4n)
+
+      let bytes = xlength * 4n
+      for (let mut i = 0n; i < bytes; i += 4n) {
+        if (
+          !equalHelp(WasmI32.load(xptr + i, 8n), WasmI32.load(yptr + i, 8n))
+        ) {
+          WasmI32.store(xptr, xlength, 4n)
+          WasmI32.store(yptr, ylength, 4n)
+          return false
+        }
+      }
+
+      WasmI32.store(xptr, xlength, 4n)
+      WasmI32.store(yptr, ylength, 4n)
+
+      return true
     },
     t when t == Tags._GRAIN_STRING_HEAP_TAG || t == Tags._GRAIN_BYTES_HEAP_TAG => {
       let xlength = WasmI32.load(xptr, 4n)
       let ylength = WasmI32.load(yptr, 4n)
 
       // Check if the same length
-      if (xlength != ylength) {
+      return if (xlength != ylength) {
         false
       } else {
         Memory.compare(xptr + 8n, yptr + 8n, xlength) == 0n
@@ -132,44 +131,42 @@ let rec heapEqualHelp = (heapTag, xptr, yptr) => {
       let ysize = WasmI32.load(yptr, 4n)
 
       if ((xsize & cycleMarker) == cycleMarker) {
-        true
+        return true
       } else {
         WasmI32.store(xptr, xsize ^ cycleMarker, 4n)
         WasmI32.store(yptr, ysize ^ cycleMarker, 4n)
 
-        let mut result = true
         let bytes = xsize * 4n
         for (let mut i = 0n; i < bytes; i += 4n) {
           if (
             !equalHelp(WasmI32.load(xptr + i, 8n), WasmI32.load(yptr + i, 8n))
           ) {
-            result = false
-            break
+            WasmI32.store(xptr, xsize, 4n)
+            WasmI32.store(yptr, ysize, 4n)
+            return false
           }
         }
 
         WasmI32.store(xptr, xsize, 4n)
         WasmI32.store(yptr, ysize, 4n)
 
-        result
+        return true
       }
     },
     t when t == Tags._GRAIN_UINT32_HEAP_TAG || t == Tags._GRAIN_INT32_HEAP_TAG => {
       let xval = WasmI32.load(xptr, 4n)
       let yval = WasmI32.load(yptr, 4n)
-      xval == yval
+      return xval == yval
     },
     // Float32 is handled by equalHelp directly
     t when t == Tags._GRAIN_UINT64_HEAP_TAG => {
       use WasmI64.{ (==) }
       let xval = WasmI64.load(xptr, 8n)
       let yval = WasmI64.load(yptr, 8n)
-      xval == yval
+      return xval == yval
     },
-    _ => {
-      // No other implementation
-      xptr == yptr
-    },
+    // No other implementation
+    _ => return xptr == yptr,
   }
 }
 and equalHelp = (x, y) => {

--- a/stdlib/runtime/equal.gr
+++ b/stdlib/runtime/equal.gr
@@ -47,7 +47,6 @@ let rec heapEqualHelp = (heapTag, xptr, yptr) => {
 
       // Handle lists seperately
       if (WasmI32.load(xptr, 8n) == _LIST_ID) {
-        if (xVariantTag != yVariantTag) return false // Different list lengths
         if (xVariantTag >> 1n == 1n) return true // End of list
 
         if (!equalHelp(WasmI32.load(xptr, 20n), WasmI32.load(yptr, 20n))) {

--- a/stdlib/runtime/equal.gr
+++ b/stdlib/runtime/equal.gr
@@ -45,7 +45,7 @@ let rec heapEqualHelp = (heapTag, xptr, yptr) => {
         return false
       }
 
-      // Handle lists seperately
+      // Handle lists separately to avoid stack overflow
       if (WasmI32.load(xptr, 8n) == _LIST_ID) {
         if (xVariantTag >> 1n == 1n) return true // End of list
 

--- a/stdlib/runtime/equal.gr
+++ b/stdlib/runtime/equal.gr
@@ -47,22 +47,14 @@ let rec heapEqualHelp = (heapTag, xptr, yptr) => {
 
       // Handle lists seperately
       if (WasmI32.load(xptr, 8n) == _LIST_ID) {
-        let mut xptr = xptr
-        let mut yptr = yptr
-        while (true) {
-          if (xVariantTag != yVariantTag) return false // Different list lengths
-          if (xVariantTag >> 1n == 1n) break // End of list
+        if (xVariantTag != yVariantTag) return false // Different list lengths
+        if (xVariantTag >> 1n == 1n) return true // End of list
 
-          if (!equalHelp(WasmI32.load(xptr, 20n), WasmI32.load(yptr, 20n))) {
-            return false
-          }
-
-          xptr = WasmI32.load(xptr, 24n)
-          yptr = WasmI32.load(yptr, 24n)
-          xVariantTag = WasmI32.load(xptr, 12n)
-          yVariantTag = WasmI32.load(yptr, 12n)
+        if (!equalHelp(WasmI32.load(xptr, 20n), WasmI32.load(yptr, 20n))) {
+          return false
         }
-        return true
+
+        return equalHelp(WasmI32.load(xptr, 24n), WasmI32.load(yptr, 24n))
       } else {
         let xarity = WasmI32.load(xptr, 16n)
         let yarity = WasmI32.load(yptr, 16n)

--- a/stdlib/runtime/equal.gr
+++ b/stdlib/runtime/equal.gr
@@ -3,7 +3,19 @@ module Equal
 
 from "runtime/unsafe/memory" include Memory
 from "runtime/unsafe/wasmi32" include WasmI32
-use WasmI32.{ (==), (!=), (&), (^), (+), (-), (*), (<), remS as (%), (<<) }
+use WasmI32.{
+  (==),
+  (!=),
+  (&),
+  (^),
+  (+),
+  (-),
+  (*),
+  (<),
+  remS as (%),
+  (<<),
+  (>>),
+}
 from "runtime/unsafe/wasmi64" include WasmI64
 from "runtime/unsafe/wasmf32" include WasmF32
 from "runtime/unsafe/tags" include Tags
@@ -14,6 +26,10 @@ primitive (!) = "@not"
 primitive (||) = "@or"
 primitive (&&) = "@and"
 primitive ignore = "@ignore"
+primitive builtinId = "@builtin.id"
+
+@unsafe
+let _LIST_ID = WasmI32.fromGrain(builtinId("List"))
 
 @unsafe
 let cycleMarker = 0x80000000n
@@ -23,37 +39,57 @@ let rec heapEqualHelp = (heapTag, xptr, yptr) => {
   match (heapTag) {
     t when t == Tags._GRAIN_ADT_HEAP_TAG => {
       // Check if the same constructor variant
-      if (WasmI32.load(xptr, 12n) != WasmI32.load(yptr, 12n)) {
+      let mut xVariantTag = WasmI32.load(xptr, 12n)
+      let mut yVariantTag = WasmI32.load(yptr, 12n)
+      if (xVariantTag != yVariantTag) {
         return false
       }
-      let xarity = WasmI32.load(xptr, 16n)
-      let yarity = WasmI32.load(yptr, 16n)
 
-      // Cycle check
-      if ((xarity & cycleMarker) == cycleMarker) {
+      // Handle lists seperately
+      if (WasmI32.load(xptr, 8n) == _LIST_ID) {
+        let mut xptr = xptr
+        let mut yptr = yptr
+        while (true) {
+          if (xVariantTag != yVariantTag) return false // Different list lengths
+          if (xVariantTag >> 1n == 1n) break // End of list
+
+          if (!equalHelp(WasmI32.load(xptr, 20n), WasmI32.load(yptr, 20n))) {
+            return false
+          }
+
+          xptr = WasmI32.load(xptr, 24n)
+          yptr = WasmI32.load(yptr, 24n)
+          xVariantTag = WasmI32.load(xptr, 12n)
+          yVariantTag = WasmI32.load(yptr, 12n)
+        }
+        return true
+      } else {
+        let xarity = WasmI32.load(xptr, 16n)
+        let yarity = WasmI32.load(yptr, 16n)
+
+        // Cycle check
+        if ((xarity & cycleMarker) == cycleMarker) {
+          return true
+        }
+
+        WasmI32.store(xptr, xarity ^ cycleMarker, 16n)
+        WasmI32.store(yptr, yarity ^ cycleMarker, 16n)
+
+        let bytes = xarity * 4n
+        for (let mut i = 0n; i < bytes; i += 4n) {
+          if (
+            !equalHelp(WasmI32.load(xptr + i, 20n), WasmI32.load(yptr + i, 20n))
+          ) {
+            WasmI32.store(xptr, xarity, 16n)
+            WasmI32.store(yptr, yarity, 16n)
+            return false
+          }
+        }
+        WasmI32.store(xptr, xarity, 16n)
+        WasmI32.store(yptr, yarity, 16n)
+
         return true
       }
-
-      WasmI32.store(xptr, xarity ^ cycleMarker, 16n)
-      WasmI32.store(yptr, yarity ^ cycleMarker, 16n)
-
-      let bytes = xarity * 4n
-      for (let mut i = 0n; i < bytes; i += 4n) {
-        if (
-          !equalHelp(
-            WasmI32.load(xptr + i, 20n),
-            WasmI32.load(yptr + i, 20n)
-          )
-        ) {
-          WasmI32.store(xptr, xarity, 16n)
-          WasmI32.store(yptr, yarity, 16n)
-          return false
-        }
-      }
-      WasmI32.store(xptr, xarity, 16n)
-      WasmI32.store(yptr, yarity, 16n)
-
-      return true
     },
     t when t == Tags._GRAIN_RECORD_HEAP_TAG => {
       let xlength = WasmI32.load(xptr, 12n)
@@ -101,9 +137,7 @@ let rec heapEqualHelp = (heapTag, xptr, yptr) => {
 
       let bytes = xlength * 4n
       for (let mut i = 0n; i < bytes; i += 4n) {
-        if (
-          !equalHelp(WasmI32.load(xptr + i, 8n), WasmI32.load(yptr + i, 8n))
-        ) {
+        if (!equalHelp(WasmI32.load(xptr + i, 8n), WasmI32.load(yptr + i, 8n))) {
           WasmI32.store(xptr, xlength, 4n)
           WasmI32.store(yptr, ylength, 4n)
           return false


### PR DESCRIPTION
This optimizes `==` for specifically for lists and also refactors it to use early return. Instead of the recursive approach used in the general case for adt's because we know lists will always have two elements (item, nextItemPtr) we handle it in an iterative manner avoiding the stack overflow.

**Notes**:
* The smallest program size increased because `==` is bundled to every grain program.
* `==` would now lock with a cyclic list, however from my understanding such a list would be impossible to build in grain. 
  * If we want to handle cycles we can but it adds overhead as we need to go back through the scanned items and do the unmarking after.
  * This will all need to get refactored with the wasm gc changes we plan to make so I think it's fine to take the perf improvement for now.
* We should be able to support any list size now however it seems we start running into issues with `List.init` around `5005` elements.


Closes: #2246 