### PR TITLE
feat(runtime): Prevent stack overflow while collecting large lists

### DIFF
--- a/compiler/test/suites/basic_functionality.re
+++ b/compiler/test/suites/basic_functionality.re
@@ -377,6 +377,6 @@ describe("basic functionality", ({test, testSkip}) => {
     ~config_fn=smallestFileConfig,
     "smallest_grain_program",
     "",
-    6503,
+    6494,
   );
 });

--- a/compiler/test/suites/basic_functionality.re
+++ b/compiler/test/suites/basic_functionality.re
@@ -377,6 +377,6 @@ describe("basic functionality", ({test, testSkip}) => {
     ~config_fn=smallestFileConfig,
     "smallest_grain_program",
     "",
-    6540,
+    6503,
   );
 });

--- a/compiler/test/suites/gc.re
+++ b/compiler/test/suites/gc.re
@@ -139,7 +139,7 @@ describe("garbage collection", ({test, testSkip}) => {
     "OK\n",
   );
   assertRunGC(
-    "long_lists",
+    "medium_lists",
     350,
     {|
     from "list" include List
@@ -167,6 +167,20 @@ describe("garbage collection", ({test, testSkip}) => {
     print(loop(25)) // <- eats up a lot of heap
     |},
     "true\n",
+  );
+  assertRun(
+    "large_lists",
+    {|
+    let rec make_list = (n, acc) => {
+      if (n == 0) {
+        acc
+      } else {
+        make_list(n - 1, [1, ...acc])
+      }
+    }
+    assert make_list(500_000, []) != []
+    |},
+    "",
   );
   assertFileRun("memory_grow1", "memoryGrow", "1000000000000\n");
   assertMemoryLimitedFileRun(

--- a/stdlib/runtime/gc.gr
+++ b/stdlib/runtime/gc.gr
@@ -94,9 +94,9 @@ let rec decRef = (userPtr: WasmI32, ignoreZeros: Bool) => {
 
       if (WasmI32.eqz(refCount)) {
         /*
-         * Note: We dangerously call free before decRefChildren to allow for
-         *       tco optimization. This works because `free` only merges the
-         *       empty blocks and does not actually zero out the memory.
+         * Note: We call free before decRefChildren to allow for a tail call.
+         * This is okay because no allocations occur while we traverse the
+         * structure and free does not mangle the data.
          */
         free(userPtr)
         decRefChildren(userPtr)
@@ -137,7 +137,7 @@ and decRefChildren = (userPtr: WasmI32) => {
     t when t == Tags._GRAIN_ARRAY_HEAP_TAG || t == Tags._GRAIN_TUPLE_HEAP_TAG => {
       decRefChildrenHelp(userPtr, 4n, 8n)
     },
-    // No travelsal necessary for other tags
+    // No traversal necessary for other tags
     _ => void,
   }
 }

--- a/stdlib/runtime/gc.gr
+++ b/stdlib/runtime/gc.gr
@@ -25,6 +25,7 @@ from "runtime/unsafe/panic" include Panic
 from "runtime/unsafe/wasmi32" include WasmI32
 use WasmI32.{ (+), (-), (*), (&), (==), (!=) }
 
+primitive (!) = "@not"
 primitive (&&) = "@and"
 primitive (||) = "@or"
 primitive ignore = "@ignore"
@@ -75,7 +76,7 @@ provide let incRef = (userPtr: WasmI32) => {
   userPtr
 }
 
-let rec decRef = (userPtr: WasmI32, parentPtr: WasmI32, ignoreZeros: Bool) => {
+let rec decRef = (userPtr: WasmI32, ignoreZeros: Bool) => {
   if (WasmI32.eqz(userPtr & Tags._GRAIN_GENERIC_TAG_MASK) && userPtr != 0n) {
     let refCount = getRefCount(userPtr)
     // if (_DEBUG) {
@@ -84,9 +85,7 @@ let rec decRef = (userPtr: WasmI32, parentPtr: WasmI32, ignoreZeros: Bool) => {
     // }
 
     if (WasmI32.eqz(refCount)) {
-      if (ignoreZeros) {
-        parentPtr
-      } else {
+      if (!ignoreZeros) {
         throwDecRefError()
       }
     } else {
@@ -100,18 +99,13 @@ let rec decRef = (userPtr: WasmI32, parentPtr: WasmI32, ignoreZeros: Bool) => {
          *       empty blocks and does not actually zero out the memory.
          */
         free(userPtr)
-        decRefChildren(userPtr, parentPtr)
-      } else {
-        parentPtr
+        decRefChildren(userPtr)
       }
     }
-  } else {
-    parentPtr
   }
 }
 and decRefChildrenHelp = (
   userPtr: WasmI32,
-  parentPtr: WasmI32,
   arityOffset: WasmI32,
   offset: WasmI32,
 ) => {
@@ -119,39 +113,36 @@ and decRefChildrenHelp = (
   if (arity != 0n) {
     let maxOffset = (arity - 1n) * 4n
     for (let mut i = 0n; WasmI32.ltU(i, maxOffset); i += 4n) {
-      ignore(decRef(WasmI32.load(userPtr + i, offset), parentPtr, false))
+      decRef(WasmI32.load(userPtr + i, offset), false)
     }
-    decRef(WasmI32.load(userPtr + maxOffset, offset), parentPtr, false)
-  } else {
-    parentPtr
+    decRef(WasmI32.load(userPtr + maxOffset, offset), false)
   }
 }
-and decRefChildren = (userPtr: WasmI32, parentPtr: WasmI32) => {
+and decRefChildren = (userPtr: WasmI32) => {
   match (WasmI32.load(userPtr, 0n)) {
     t when t == Tags._GRAIN_BOXED_NUM_HEAP_TAG => {
       let tag = WasmI32.load(userPtr, 4n)
       if (userPtr == Tags._GRAIN_RATIONAL_BOXED_NUM_TAG) {
         // decRef underlying BigInts
-        ignore(decRef(WasmI32.load(userPtr, 8n), parentPtr, false))
-        ignore(decRef(WasmI32.load(userPtr, 12n), parentPtr, false))
+        decRef(WasmI32.load(userPtr, 8n), false)
+        decRef(WasmI32.load(userPtr, 12n), false)
       }
-      parentPtr
     },
     t when t == Tags._GRAIN_ADT_HEAP_TAG => {
-      decRefChildrenHelp(userPtr, parentPtr, 16n, 20n)
+      decRefChildrenHelp(userPtr, 16n, 20n)
     },
-    t when t == Tags._GRAIN_RECORD_HEAP_TAG => {
-      decRefChildrenHelp(userPtr, parentPtr, 12n, 16n)
+    t when t == Tags._GRAIN_RECORD_HEAP_TAG || t == Tags._GRAIN_LAMBDA_HEAP_TAG => {
+      decRefChildrenHelp(userPtr, 12n, 16n)
     },
     t when t == Tags._GRAIN_ARRAY_HEAP_TAG || t == Tags._GRAIN_TUPLE_HEAP_TAG => {
-      decRefChildrenHelp(userPtr, parentPtr, 4n, 8n)
-    },
-    t when t == Tags._GRAIN_LAMBDA_HEAP_TAG => {
-      decRefChildrenHelp(userPtr, parentPtr, 12n, 16n)
+      decRefChildrenHelp(userPtr, 4n, 8n)
     },
     // No travelsal necessary for other tags
-    _ => parentPtr,
+    _ => void,
   }
 }
 
-provide let decRef = userPtr => decRef(userPtr, userPtr, false)
+provide let decRef = userPtr => {
+  decRef(userPtr, false)
+  userPtr
+}

--- a/stdlib/runtime/gc.gr
+++ b/stdlib/runtime/gc.gr
@@ -75,7 +75,7 @@ provide let incRef = (userPtr: WasmI32) => {
   userPtr
 }
 
-let rec decRef = (userPtr: WasmI32, ignoreZeros: Bool) => {
+let rec decRef = (userPtr: WasmI32, parentPtr: WasmI32, ignoreZeros: Bool) => {
   if (WasmI32.eqz(userPtr & Tags._GRAIN_GENERIC_TAG_MASK) && userPtr != 0n) {
     let refCount = getRefCount(userPtr)
     // if (_DEBUG) {
@@ -85,7 +85,7 @@ let rec decRef = (userPtr: WasmI32, ignoreZeros: Bool) => {
 
     if (WasmI32.eqz(refCount)) {
       if (ignoreZeros) {
-        userPtr
+        parentPtr
       } else {
         throwDecRefError()
       }
@@ -94,59 +94,64 @@ let rec decRef = (userPtr: WasmI32, ignoreZeros: Bool) => {
       setRefCount(userPtr, refCount)
 
       if (WasmI32.eqz(refCount)) {
-        decRefChildren(userPtr)
+        /*
+         * Note: We dangerously call free before decRefChildren to allow for
+         *       tco optimization. This works because `free` only merges the
+         *       empty blocks and does not actually zero out the memory.
+         */
         free(userPtr)
+        decRefChildren(userPtr, parentPtr)
+      } else {
+        parentPtr
       }
-
-      userPtr
     }
   } else {
-    userPtr
+    parentPtr
   }
 }
-and decRefChildren = (userPtr: WasmI32) => {
+and decRefChildrenHelp = (
+  userPtr: WasmI32,
+  parentPtr: WasmI32,
+  arityOffset: WasmI32,
+  offset: WasmI32,
+) => {
+  let arity = WasmI32.load(userPtr, arityOffset)
+  if (arity != 0n) {
+    let maxOffset = (arity - 1n) * 4n
+    for (let mut i = 0n; WasmI32.ltU(i, maxOffset); i += 4n) {
+      ignore(decRef(WasmI32.load(userPtr + i, offset), parentPtr, false))
+    }
+    decRef(WasmI32.load(userPtr + maxOffset, offset), parentPtr, false)
+  } else {
+    parentPtr
+  }
+}
+and decRefChildren = (userPtr: WasmI32, parentPtr: WasmI32) => {
   match (WasmI32.load(userPtr, 0n)) {
     t when t == Tags._GRAIN_BOXED_NUM_HEAP_TAG => {
       let tag = WasmI32.load(userPtr, 4n)
       if (userPtr == Tags._GRAIN_RATIONAL_BOXED_NUM_TAG) {
         // decRef underlying BigInts
-        ignore(decRef(WasmI32.load(userPtr, 8n), false))
-        ignore(decRef(WasmI32.load(userPtr, 12n), false))
+        ignore(decRef(WasmI32.load(userPtr, 8n), parentPtr, false))
+        ignore(decRef(WasmI32.load(userPtr, 12n), parentPtr, false))
       }
+      parentPtr
     },
     t when t == Tags._GRAIN_ADT_HEAP_TAG => {
-      let arity = WasmI32.load(userPtr, 16n)
-      let maxOffset = arity * 4n
-      for (let mut i = 0n; WasmI32.ltU(i, maxOffset); i += 4n) {
-        ignore(decRef(WasmI32.load(userPtr + i, 20n), false))
-      }
+      decRefChildrenHelp(userPtr, parentPtr, 16n, 20n)
     },
     t when t == Tags._GRAIN_RECORD_HEAP_TAG => {
-      let arity = WasmI32.load(userPtr, 12n)
-      let maxOffset = arity * 4n
-      for (let mut i = 0n; WasmI32.ltU(i, maxOffset); i += 4n) {
-        ignore(decRef(WasmI32.load(userPtr + i, 16n), false))
-      }
+      decRefChildrenHelp(userPtr, parentPtr, 12n, 16n)
     },
     t when t == Tags._GRAIN_ARRAY_HEAP_TAG || t == Tags._GRAIN_TUPLE_HEAP_TAG => {
-      let arity = WasmI32.load(userPtr, 4n)
-      let maxOffset = arity * 4n
-      for (let mut i = 0n; WasmI32.ltU(i, maxOffset); i += 4n) {
-        ignore(decRef(WasmI32.load(userPtr + i, 8n), false))
-      }
+      decRefChildrenHelp(userPtr, parentPtr, 4n, 8n)
     },
     t when t == Tags._GRAIN_LAMBDA_HEAP_TAG => {
-      let arity = WasmI32.load(userPtr, 12n)
-      let maxOffset = arity * 4n
-      for (let mut i = 0n; WasmI32.ltU(i, maxOffset); i += 4n) {
-        ignore(decRef(WasmI32.load(userPtr + i, 16n), false))
-      }
+      decRefChildrenHelp(userPtr, parentPtr, 12n, 16n)
     },
-    _ => {
-      // No travelsal necessary for other tags
-      void
-    },
+    // No travelsal necessary for other tags
+    _ => parentPtr,
   }
 }
 
-provide let decRef = userPtr => decRef(userPtr, false)
+provide let decRef = userPtr => decRef(userPtr, userPtr, false)


### PR DESCRIPTION
### Summary
This pr prevents stack overflows during the collection of large and extremely large lists.


## Notes
* Smallest program size decreased because of increased code sharing in `decRefChildren`
* All data structures now support extremely deep nested objects in the final position.
  
----

### Problem
While working on #2247 I noticed that `decRef` was overflowing the stack with lists that were only around `1350` elements.

### Solution (For those interested)
The reason for this is that `decRef` and `decRefChildren` were not tco optimized, so the two options were to either handle lists separately or find a way to optimize `decRef` for tail calls. I decided on the second approach as it is more generic and provides improvements for other data structures as well.

The way I went about this was with a slightly cursed but valid modification where we `free` the parent before the children, this only works because we immediately `decRef` the children and when we `free` we don't zero the memory but instead  just merge the blocks which will leave our child pointers unaffected. When freeing children we free most of the children in a loop and then free the final child outside of the loop in the tail position of `decRefChildren` allowing for the tco optimization. Initially this bloated our smallest program size by 100 bytes but I noticed that we are doing effectively the same operations for all dataTypes so I combined everything into a shared helper function that actually reduced our bundle size by `47` bytes.

## Why not handle lists separately
Handling lists separately would have certainly been easier and if we are not up for the changes I made here it is still a viable approach however, it would add overhead to every ADT decRef and likely result in a hundred or so additional bytes being added to our smallest program size.