### PR TITLE
feat(grainfmt): Add inline flag to grainfmt

### DIFF
--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -223,7 +223,10 @@ program
   .command("format <file|dir>")
   .description("format a grain file")
   .forwardOption("-o <file|dir>", "output file or directory")
-  .forwardOption("--inline", "Writes the formatted output back to the source location")
+  .forwardOption(
+    "--inline",
+    "Writes the formatted output back to the source location"
+  )
   .action(exec.grainformat);
 
 program.parse(argsToProcess);

--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -223,6 +223,7 @@ program
   .command("format <file|dir>")
   .description("format a grain file")
   .forwardOption("-o <file|dir>", "output file or directory")
+  .forwardOption("--inline", "output the file inline")
   .action(exec.grainformat);
 
 program.parse(argsToProcess);

--- a/cli/bin/grain.js
+++ b/cli/bin/grain.js
@@ -223,7 +223,7 @@ program
   .command("format <file|dir>")
   .description("format a grain file")
   .forwardOption("-o <file|dir>", "output file or directory")
-  .forwardOption("--inline", "output the file inline")
+  .forwardOption("--inline", "Writes the formatted output back to the source location")
   .action(exec.grainformat);
 
 program.parse(argsToProcess);

--- a/compiler/grainformat/grainformat.re
+++ b/compiler/grainformat/grainformat.re
@@ -16,7 +16,7 @@ type io_params = {
   output: option(MaybeExistingFileOrDirectory.t),
   /** Output the formated file inline */
   [@name "inline"] [@docv "FILE"]
-  inline: bool
+  inline: bool,
 };
 
 let get_program_string = filename => {
@@ -64,7 +64,6 @@ let format_code =
     ) => {
   switch (output) {
   | Some(outfile) =>
-    // TODO: If output_file == input_file && output == input don't write formating
     let outfile = Filepath.to_string(outfile);
     // TODO: This crashes if you do something weird like `-o stdout/map.gr/foo`
     // because `foo` doesn't exist so it tries to mkdir it and raises
@@ -123,7 +122,7 @@ let enumerate_runs = opts =>
   | (_, Some(_), true) =>
     `Error((
       false,
-      "Output cannot be specified when performing inline formatting"
+      "Output cannot be specified when performing inline formatting",
     ))
   // Regular
   | (File(input_file_path), None, false) =>
@@ -141,11 +140,19 @@ let enumerate_runs = opts =>
       false,
       "Directory input must be used with `-o` flag to specify output directory",
     ))
-  | (Directory(input_dir_path), Some(Exists(Directory(output_dir_path))), false) =>
+  | (
+      Directory(input_dir_path),
+      Some(Exists(Directory(output_dir_path))),
+      false,
+    ) =>
     `Ok(enumerate_directory(input_dir_path, output_dir_path))
   | (Directory(input_dir_path), Some(NotExists(output_dir_path)), false) =>
     `Ok(enumerate_directory(input_dir_path, output_dir_path))
-  | (File(input_file_path), Some(Exists(Directory(output_dir_path))), false) =>
+  | (
+      File(input_file_path),
+      Some(Exists(Directory(output_dir_path))),
+      false,
+    ) =>
     `Error((
       false,
       "Using a file as input cannot be combined with directory output",

--- a/stdlib/package.json
+++ b/stdlib/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "clean": "del-cli \"**/*.wasm\" \"**/*.wat\" \"**/*.gro\" \"**/*.modsig\"",
     "doc": "grain doc ./ -o ./ --current-version=$(grain -v)",
-    "format": "grain format ./ -o ./"
+    "format": "grain format ./ --inline"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
This adds the `--inline` flag to the `grain format` command specifically useful with tools like [Treefmt](https://treefmt.com/latest/reference/formatter-spec/). Usage of the command is as such, `grain format input.gr --inline` which will write the formatted code back to `input.gr` this also works on directories. 