### PR TITLE
feat(stdlib): Implement `reinterpret` between float and int values

### DIFF
--- a/compiler/test/stdlib/float32.test.gr
+++ b/compiler/test/stdlib/float32.test.gr
@@ -26,6 +26,18 @@ assert fromNumber(0) == 0.0f
 assert toNumber(555.0f) == 555
 assert toNumber(0.0f) == 0
 
+// Float32.reinterpretInt32
+assert Float32.reinterpretInt32(0l) == 0.0f
+assert Float32.reinterpretInt32(1065353216l) == 1.0f
+assert Float32.reinterpretInt32(-1082130432l) == -1.0f
+assert Float32.reinterpretInt32(1109917696l) == 42.0f
+
+// Float32.reinterpretUint32
+assert Float32.reinterpretUint32(0ul) == 0.0f
+assert Float32.reinterpretUint32(1065353216ul) == 1.0f
+assert Float32.reinterpretUint32(3212836864ul) == -1.0f
+assert Float32.reinterpretUint32(1109917696ul) == 42.0f
+
 // Float32.pow tests are based on test cases from libc-test: http://nsz.repo.hu/git/?p=libc-test
 /*
   libc-test is licensed under the following standard MIT license:

--- a/compiler/test/stdlib/float64.test.gr
+++ b/compiler/test/stdlib/float64.test.gr
@@ -38,6 +38,17 @@ assert fromNumber(-1.7976931348623157e+309) == -Infinityd
 assert toNumber(555.0d) == 555
 assert toNumber(0.0d) == 0
 
+// Float64.reinterpretInt64
+assert Float64.reinterpretInt64(0L) == 0.0d
+assert Float64.reinterpretInt64(4607182418800017408L) == 1.0d
+assert Float64.reinterpretInt64(-4616189618054758400L) == -1.0d
+assert Float64.reinterpretInt64(4631107791820423168L) == 42.0d
+// Float64.reinterpretUint64
+assert Float64.reinterpretUint64(0uL) == 0.0d
+assert Float64.reinterpretUint64(4607182418800017408uL) == 1.0d
+assert Float64.reinterpretUint64(13830554455654793216uL) == -1.0d
+assert Float64.reinterpretUint64(4631107791820423168uL) == 42.0d
+
 // Float64.pow tests are based on test cases from libc-test: http://nsz.repo.hu/git/?p=libc-test
 /*
   libc-test is licensed under the following standard MIT license:

--- a/compiler/test/stdlib/int32.test.gr
+++ b/compiler/test/stdlib/int32.test.gr
@@ -19,6 +19,13 @@ assert fromUint32(0xfffffffful) == -1l
 
 use Int32.{ (==) }
 
+// Int32.reinterpretFloat32
+assert Int32.reinterpretFloat32(0.0f) == 0l
+assert Int32.reinterpretFloat32(1.0f) == 1065353216l
+assert Int32.reinterpretFloat32(-1.0f) == -1082130432l
+assert Int32.reinterpretFloat32(42.0f) == 1109917696l
+assert Int32.reinterpretFloat32(0.5f) == 1056964608l
+
 assert lnot(0xffffffffl) == 0l
 assert lnot(0l) == 0xffffffffl
 assert lnot(0xf0f0f0f0l) == 0x0f0f0f0fl

--- a/compiler/test/stdlib/int64.test.gr
+++ b/compiler/test/stdlib/int64.test.gr
@@ -17,6 +17,13 @@ use Int64.{ (==) }
 assert fromUint64(1uL) == 1L
 assert fromUint64(0xffffffffffffffffuL) == -1L
 
+// Int64.reinterpretFloat64
+assert Int64.reinterpretFloat64(0.0d) == 0L
+assert Int64.reinterpretFloat64(1.0d) == 4607182418800017408L
+assert Int64.reinterpretFloat64(-1.0d) == -4616189618054758400L
+assert Int64.reinterpretFloat64(42.0d) == 4631107791820423168L
+assert Int64.reinterpretFloat64(0.5d) == 4602678819172646912L
+
 assert lnot(0xffffffffffffffffL) == 0L
 assert lnot(0L) == 0xffffffffffffffffL
 assert lnot(0xf0f0f0f0f0f0f0f0L) == 0x0f0f0f0f0f0f0f0fL

--- a/compiler/test/stdlib/uint32.test.gr
+++ b/compiler/test/stdlib/uint32.test.gr
@@ -36,6 +36,13 @@ assert toNumber(0x7ffffffful) == 0x7fffffff
 assert fromInt32(1l) == 1ul
 assert fromInt32(-1l) == 0xfffffffful
 
+// UInt32.reinterpretFloat32
+assert Uint32.reinterpretFloat32(0.0f) == 0ul
+assert Uint32.reinterpretFloat32(1.0f) == 1065353216ul
+assert Uint32.reinterpretFloat32(-1.0f) == 3212836864ul
+assert Uint32.reinterpretFloat32(42.0f) == 1109917696ul
+assert Uint32.reinterpretFloat32(0.5f) == 1056964608ul
+
 assert lnot(0xfffffffful) == 0ul
 assert lnot(0ul) == 0xfffffffful
 assert lnot(0xf0f0f0f0ul) == 0x0f0f0f0ful

--- a/compiler/test/stdlib/uint64.test.gr
+++ b/compiler/test/stdlib/uint64.test.gr
@@ -38,6 +38,13 @@ assert toNumber(0x7fffffffuL) == 0x7fffffff
 assert fromInt64(1L) == 1uL
 assert fromInt64(-1L) == 0xffffffffffffffffuL
 
+// UInt64.reinterpretFloat64
+assert Uint64.reinterpretFloat64(0.0d) == 0uL
+assert Uint64.reinterpretFloat64(1.0d) == 4607182418800017408uL
+assert Uint64.reinterpretFloat64(-1.0d) == 13830554455654793216uL
+assert Uint64.reinterpretFloat64(42.0d) == 4631107791820423168uL
+assert Uint64.reinterpretFloat64(0.5d) == 4602678819172646912uL
+
 assert lnot(0xffffffffffffffffuL) == 0uL
 assert lnot(0uL) == 0xffffffffffffffffuL
 assert lnot(0xf0f0f0f0f0f0f0f0uL) == 0x0f0f0f0f0f0f0f0fuL

--- a/stdlib/float32.gr
+++ b/stdlib/float32.gr
@@ -12,6 +12,12 @@
  */
 module Float32
 
+from "runtime/unsafe/offsets" include Offsets
+use Offsets.{
+  _FLOAT32_VALUE_OFFSET as _VALUE_OFFSET,
+  _INT32_VALUE_OFFSET,
+  _UINT32_VALUE_OFFSET,
+}
 from "runtime/unsafe/wasmi32" include WasmI32
 from "runtime/unsafe/wasmf32" include WasmF32
 from "runtime/unsafe/wasmf64" include WasmF64
@@ -26,9 +32,6 @@ use Numbers.{
 }
 from "runtime/math/trig" include Trig
 use Trig.{ sin, cos, tan }
-
-@unsafe
-let _VALUE_OFFSET = 4n
 
 /**
  * Infinity represented as a Float32 value.
@@ -70,6 +73,41 @@ provide let tau = 6.2831853f
 provide let e = 2.7182817f
 
 provide { fromNumber, toNumber }
+
+/**
+ * Interprets an Int32 as a Float32.
+ *
+ * @param value: The value to convert
+ * @returns The Int32 interpreted as an Float32
+ *
+ * @example assert Float32.reinterpretInt32(1065353216l) == 1.0f
+ * @example assert Float32.reinterpretInt32(-1082130432l) == -1.0f
+ * @since v0.7.0
+ */
+@unsafe
+provide let reinterpretInt32 = (value: Int32) => {
+  let x = WasmF32.load(WasmI32.fromGrain(value), _INT32_VALUE_OFFSET)
+  let result = newFloat32(x)
+  WasmI32.toGrain(result): Float32
+}
+
+/**
+ * Interprets an Uint32 as a Float32.
+ *
+ * @param value: The value to convert
+ * @returns The Uint32 interpreted as an Float32
+ *
+ * @example assert Float32.reinterpretUint32(1065353216ul) == 1.0f
+ * @example assert Float32.reinterpretUint32(3212836864ul) == -1.0f
+ *
+ * @since v0.7.0
+ */
+@unsafe
+provide let reinterpretUint32 = (value: Uint32) => {
+  let x = WasmF32.load(WasmI32.fromGrain(value), _UINT32_VALUE_OFFSET)
+  let result = newFloat32(x)
+  WasmI32.toGrain(result): Float32
+}
 
 /**
  * Computes the sum of its operands.

--- a/stdlib/float32.md
+++ b/stdlib/float32.md
@@ -150,6 +150,76 @@ Returns:
 |----|-----------|
 |`Number`|The Float32 represented as a Number|
 
+### Float32.**reinterpretInt32**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+reinterpretInt32 : (value: Int32) => Float32
+```
+
+Interprets an Int32 as a Float32.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`value`|`Int32`|The value to convert|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Float32`|The Int32 interpreted as an Float32|
+
+Examples:
+
+```grain
+assert Float32.reinterpretInt32(1065353216l) == 1.0f
+```
+
+```grain
+assert Float32.reinterpretInt32(-1082130432l) == -1.0f
+```
+
+### Float32.**reinterpretUint32**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+reinterpretUint32 : (value: Uint32) => Float32
+```
+
+Interprets an Uint32 as a Float32.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`value`|`Uint32`|The value to convert|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Float32`|The Uint32 interpreted as an Float32|
+
+Examples:
+
+```grain
+assert Float32.reinterpretUint32(1065353216ul) == 1.0f
+```
+
+```grain
+assert Float32.reinterpretUint32(3212836864ul) == -1.0f
+```
+
 ### Float32.**(+)**
 
 <details>

--- a/stdlib/float64.gr
+++ b/stdlib/float64.gr
@@ -12,6 +12,12 @@
  */
 module Float64
 
+from "runtime/unsafe/offsets" include Offsets
+use Offsets.{
+  _FLOAT64_VALUE_OFFSET as _VALUE_OFFSET,
+  _INT64_VALUE_OFFSET,
+  _UINT64_VALUE_OFFSET,
+}
 from "runtime/unsafe/wasmi32" include WasmI32
 from "runtime/unsafe/wasmf64" include WasmF64
 use WasmF64.{ (-), (+), (*), (/), (<), (<=), (>), (>=) }
@@ -25,9 +31,6 @@ use Numbers.{
 }
 from "runtime/math/trig" include Trig
 use Trig.{ sin, cos, tan }
-
-@unsafe
-let _VALUE_OFFSET = 8n
 
 /**
  * Infinity represented as a Float64 value.
@@ -69,6 +72,42 @@ provide let tau = 6.283185307179586d
 provide let e = 2.718281828459045d
 
 provide { fromNumber, toNumber }
+
+/**
+ * Interprets an Int64 as a Float64.
+ *
+ * @param value: The value to convert
+ * @returns The Int64 interpreted as an Float64
+ *
+ * @example assert Float64.reinterpretInt64(4607182418800017408L) == 1.0d
+ * @example assert Float64.reinterpretInt64(-4616189618054758400L) == -1.0d
+ *
+ * @since v0.7.0
+ */
+@unsafe
+provide let reinterpretInt64 = (value: Int64) => {
+  let x = WasmF64.load(WasmI32.fromGrain(value), _INT64_VALUE_OFFSET)
+  let result = newFloat64(x)
+  WasmI32.toGrain(result): Float64
+}
+
+/**
+ * Interprets an Uint64 as a Float64.
+ *
+ * @param value: The value to convert
+ * @returns The Uint64 interpreted as an Float64
+ *
+ * @example assert Float64.reinterpretUint64(4607182418800017408uL) == 1.0d
+ * @example assert Float64.reinterpretUint64(13830554455654793216uL) == -1.0d
+ *
+ * @since v0.7.0
+ */
+@unsafe
+provide let reinterpretUint64 = (value: Uint64) => {
+  let x = WasmF64.load(WasmI32.fromGrain(value), _UINT64_VALUE_OFFSET)
+  let result = newFloat64(x)
+  WasmI32.toGrain(result): Float64
+}
 
 /**
  * Computes the sum of its operands.

--- a/stdlib/float64.md
+++ b/stdlib/float64.md
@@ -150,6 +150,76 @@ Returns:
 |----|-----------|
 |`Number`|The Float64 represented as a Number|
 
+### Float64.**reinterpretInt64**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+reinterpretInt64 : (value: Int64) => Float64
+```
+
+Interprets an Int64 as a Float64.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`value`|`Int64`|The value to convert|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Float64`|The Int64 interpreted as an Float64|
+
+Examples:
+
+```grain
+assert Float64.reinterpretInt64(4607182418800017408L) == 1.0d
+```
+
+```grain
+assert Float64.reinterpretInt64(-4616189618054758400L) == -1.0d
+```
+
+### Float64.**reinterpretUint64**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+reinterpretUint64 : (value: Uint64) => Float64
+```
+
+Interprets an Uint64 as a Float64.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`value`|`Uint64`|The value to convert|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Float64`|The Uint64 interpreted as an Float64|
+
+Examples:
+
+```grain
+assert Float64.reinterpretUint64(4607182418800017408uL) == 1.0d
+```
+
+```grain
+assert Float64.reinterpretUint64(13830554455654793216uL) == -1.0d
+```
+
 ### Float64.**(+)**
 
 <details>

--- a/stdlib/int32.gr
+++ b/stdlib/int32.gr
@@ -10,6 +10,12 @@
  */
 module Int32
 
+from "runtime/unsafe/offsets" include Offsets
+use Offsets.{
+  _UINT32_VALUE_OFFSET as _VALUE_OFFSET,
+  _UINT32_VALUE_OFFSET,
+  _FLOAT32_VALUE_OFFSET,
+}
 from "runtime/unsafe/wasmi32" include WasmI32
 use WasmI32.{
   (+),
@@ -40,9 +46,6 @@ use Numbers.{
   coerceInt32ToNumber as toNumber,
 }
 
-@unsafe
-let _VALUE_OFFSET = 4n
-
 provide { fromNumber, toNumber }
 
 /**
@@ -57,7 +60,25 @@ provide { fromNumber, toNumber }
  */
 @unsafe
 provide let fromUint32 = (number: Uint32) => {
-  let x = WasmI32.load(WasmI32.fromGrain(number), _VALUE_OFFSET)
+  let x = WasmI32.load(WasmI32.fromGrain(number), _UINT32_VALUE_OFFSET)
+  let result = newInt32(x)
+  WasmI32.toGrain(result): Int32
+}
+
+/**
+ * Interprets a Float32 as an Int32.
+ *
+ * @param value: The value to convert
+ * @returns The Float32 interpreted as an Int32
+ *
+ * @example Int32.reinterpretFloat32(1.0f) == 1065353216l
+ * @example Int32.reinterpretFloat32(-1.0f) == -1065353216l
+ *
+ * @since v0.7.0
+ */
+@unsafe
+provide let reinterpretFloat32 = (value: Float32) => {
+  let x = WasmI32.load(WasmI32.fromGrain(value), _FLOAT32_VALUE_OFFSET)
   let result = newInt32(x)
   WasmI32.toGrain(result): Int32
 }

--- a/stdlib/int32.md
+++ b/stdlib/int32.md
@@ -106,6 +106,41 @@ Examples:
 Int32.fromUint32(1ul) == 1l
 ```
 
+### Int32.**reinterpretFloat32**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+reinterpretFloat32 : (value: Float32) => Int32
+```
+
+Interprets a Float32 as an Int32.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`value`|`Float32`|The value to convert|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Int32`|The Float32 interpreted as an Int32|
+
+Examples:
+
+```grain
+Int32.reinterpretFloat32(1.0f) == 1065353216l
+```
+
+```grain
+Int32.reinterpretFloat32(-1.0f) == -1065353216l
+```
+
 ### Int32.**incr**
 
 <details disabled>

--- a/stdlib/int64.gr
+++ b/stdlib/int64.gr
@@ -10,6 +10,13 @@
  */
 module Int64
 
+from "runtime/unsafe/offsets" include Offsets
+// TODO(#703): Use `_VALUE_OFFSET` throughout this module
+use Offsets.{
+  _INT64_VALUE_OFFSET as _VALUE_OFFSET,
+  _UINT64_VALUE_OFFSET,
+  _FLOAT64_VALUE_OFFSET,
+}
 from "runtime/unsafe/wasmi32" include WasmI32
 from "runtime/unsafe/wasmi64" include WasmI64
 use WasmI64.{ (==), (!=), (&), (|), (^), (<<), (>>), (<), (<=), (>), (>=) }
@@ -38,7 +45,25 @@ provide { fromNumber, toNumber }
  */
 @unsafe
 provide let fromUint64 = (number: Uint64) => {
-  let x = WasmI64.load(WasmI32.fromGrain(number), 8n)
+  let x = WasmI64.load(WasmI32.fromGrain(number), _UINT64_VALUE_OFFSET)
+  let result = newInt64(x)
+  WasmI32.toGrain(result): Int64
+}
+
+/**
+ * Interprets a Float64 as an Int64.
+ *
+ * @param value: The value to convert
+ * @returns The Float64 interpreted as an Int64
+ *
+ * @example assert Int64.reinterpretFloat64(1.0d) == 4607182418800017408L
+ * @example assert Int64.reinterpretFloat64(-1.0d) == -4616189618054758400L
+ *
+ * @since v0.7.0
+ */
+@unsafe
+provide let reinterpretFloat64 = (value: Float64) => {
+  let x = WasmI64.load(WasmI32.fromGrain(value), _FLOAT64_VALUE_OFFSET)
   let result = newInt64(x)
   WasmI32.toGrain(result): Int64
 }

--- a/stdlib/int64.md
+++ b/stdlib/int64.md
@@ -106,6 +106,41 @@ Examples:
 Int64.fromUint64(1uL) == 1L
 ```
 
+### Int64.**reinterpretFloat64**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+reinterpretFloat64 : (value: Float64) => Int64
+```
+
+Interprets a Float64 as an Int64.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`value`|`Float64`|The value to convert|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Int64`|The Float64 interpreted as an Int64|
+
+Examples:
+
+```grain
+assert Int64.reinterpretFloat64(1.0d) == 4607182418800017408L
+```
+
+```grain
+assert Int64.reinterpretFloat64(-1.0d) == -4616189618054758400L
+```
+
 ### Int64.**incr**
 
 <details disabled>

--- a/stdlib/runtime/unsafe/offsets.gr
+++ b/stdlib/runtime/unsafe/offsets.gr
@@ -16,3 +16,21 @@ provide let _ARRAY_ITEM_SIZE = 4n
 // Bytes
 provide let _BYTES_LEN_OFFSET = 4n
 provide let _BYTES_DATA_OFFSET = 8n
+
+// Int32
+provide let _INT32_VALUE_OFFSET = 4n
+
+// Uint32
+provide let _UINT32_VALUE_OFFSET = 4n
+
+// Float32
+provide let _FLOAT32_VALUE_OFFSET = 4n
+
+// Int64
+provide let _INT64_VALUE_OFFSET = 8n
+
+// Uint64
+provide let _UINT64_VALUE_OFFSET = 8n
+
+// Float64
+provide let _FLOAT64_VALUE_OFFSET = 8n

--- a/stdlib/runtime/unsafe/offsets.md
+++ b/stdlib/runtime/unsafe/offsets.md
@@ -50,3 +50,39 @@ _BYTES_LEN_OFFSET : WasmI32
 _BYTES_DATA_OFFSET : WasmI32
 ```
 
+### Offsets.**_INT32_VALUE_OFFSET**
+
+```grain
+_INT32_VALUE_OFFSET : WasmI32
+```
+
+### Offsets.**_UINT32_VALUE_OFFSET**
+
+```grain
+_UINT32_VALUE_OFFSET : WasmI32
+```
+
+### Offsets.**_FLOAT32_VALUE_OFFSET**
+
+```grain
+_FLOAT32_VALUE_OFFSET : WasmI32
+```
+
+### Offsets.**_INT64_VALUE_OFFSET**
+
+```grain
+_INT64_VALUE_OFFSET : WasmI32
+```
+
+### Offsets.**_UINT64_VALUE_OFFSET**
+
+```grain
+_UINT64_VALUE_OFFSET : WasmI32
+```
+
+### Offsets.**_FLOAT64_VALUE_OFFSET**
+
+```grain
+_FLOAT64_VALUE_OFFSET : WasmI32
+```
+

--- a/stdlib/uint32.gr
+++ b/stdlib/uint32.gr
@@ -6,6 +6,12 @@
  */
 module Uint32
 
+from "runtime/unsafe/offsets" include Offsets
+use Offsets.{
+  _UINT32_VALUE_OFFSET as _VALUE_OFFSET,
+  _INT32_VALUE_OFFSET,
+  _FLOAT32_VALUE_OFFSET,
+}
 from "runtime/unsafe/wasmi32" include WasmI32
 use WasmI32.{ (+), (-), (*), (&), (|), (^), (<<), (>>>), (==), (!=) }
 from "runtime/unsafe/wasmi64" include WasmI64
@@ -15,9 +21,6 @@ from "runtime/numbers" include Numbers
 use Numbers.{ reducedUnsignedInteger, coerceNumberToUnsignedWasmI32 }
 from "runtime/dataStructures" include DataStructures
 use DataStructures.{ newUint32 }
-
-@unsafe
-let _VALUE_OFFSET = 4n
 
 /**
  * Converts a Number to a Uint32.
@@ -60,7 +63,25 @@ provide let toNumber = (value: Uint32) => {
  */
 @unsafe
 provide let fromInt32 = (number: Int32) => {
-  let x = WasmI32.load(WasmI32.fromGrain(number), _VALUE_OFFSET)
+  let x = WasmI32.load(WasmI32.fromGrain(number), _INT32_VALUE_OFFSET)
+  let result = newUint32(x)
+  WasmI32.toGrain(result): Uint32
+}
+
+/**
+ * Interprets a Float32 as an Uint32.
+ *
+ * @param value: The value to convert
+ * @returns The Float32 interpreted as an Uint32
+ *
+ * @example assert Uint32.reinterpretFloat32(1.0f) == 1065353216ul
+ * @example assert Uint32.reinterpretFloat32(-1.0f) == 3212836864ul
+ *
+ * @since v0.7.0
+ */
+@unsafe
+provide let reinterpretFloat32 = (value: Float32) => {
+  let x = WasmI32.load(WasmI32.fromGrain(value), _FLOAT32_VALUE_OFFSET)
   let result = newUint32(x)
   WasmI32.toGrain(result): Uint32
 }

--- a/stdlib/uint32.md
+++ b/stdlib/uint32.md
@@ -92,6 +92,41 @@ Returns:
 |----|-----------|
 |`Uint32`|The Int32 represented as a Uint32|
 
+### Uint32.**reinterpretFloat32**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+reinterpretFloat32 : (value: Float32) => Uint32
+```
+
+Interprets a Float32 as an Uint32.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`value`|`Float32`|The value to convert|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Uint32`|The Float32 interpreted as an Uint32|
+
+Examples:
+
+```grain
+assert Uint32.reinterpretFloat32(1.0f) == 1065353216ul
+```
+
+```grain
+assert Uint32.reinterpretFloat32(-1.0f) == 3212836864ul
+```
+
 ### Uint32.**incr**
 
 <details disabled>

--- a/stdlib/uint64.gr
+++ b/stdlib/uint64.gr
@@ -6,6 +6,12 @@
  */
 module Uint64
 
+from "runtime/unsafe/offsets" include Offsets
+use Offsets.{
+  _UINT64_VALUE_OFFSET as _VALUE_OFFSET,
+  _INT64_VALUE_OFFSET,
+  _FLOAT64_VALUE_OFFSET,
+}
 from "runtime/unsafe/wasmi32" include WasmI32
 from "runtime/unsafe/wasmi64" include WasmI64
 use WasmI64.{ (==), (!=), (&), (|), (^), (+), (-), (*), (<<), (>>>) }
@@ -15,10 +21,6 @@ from "runtime/numbers" include Numbers
 use Numbers.{ reducedUnsignedInteger, coerceNumberToUnsignedWasmI64 }
 from "runtime/dataStructures" include DataStructures
 use DataStructures.{ newUint64 }
-
-// First 8 bytes of 64-bit unsigned int are heap tag and 32 bits of padding
-@unsafe
-let _VALUE_OFFSET = 8n
 
 /**
  * Converts a Number to a Uint64.
@@ -61,7 +63,25 @@ provide let toNumber = (value: Uint64) => {
  */
 @unsafe
 provide let fromInt64 = (number: Int64) => {
-  let x = WasmI64.load(WasmI32.fromGrain(number), 8n)
+  let x = WasmI64.load(WasmI32.fromGrain(number), _INT64_VALUE_OFFSET)
+  let result = newUint64(x)
+  WasmI32.toGrain(result): Uint64
+}
+
+/**
+ * Interprets a Float64 as an Uint64.
+ *
+ * @param value: The value to convert
+ * @returns The Float64 interpreted as an Uint64
+ *
+ * @example assert Uint64.reinterpretFloat64(1.0d) == 4607182418800017408uL
+ * @example assert Uint64.reinterpretFloat64(-1.0d) == 13830554455654793216uL
+ *
+ * @since v0.7.0
+ */
+@unsafe
+provide let reinterpretFloat64 = (value: Float64) => {
+  let x = WasmI64.load(WasmI32.fromGrain(value), _FLOAT64_VALUE_OFFSET)
   let result = newUint64(x)
   WasmI32.toGrain(result): Uint64
 }

--- a/stdlib/uint64.md
+++ b/stdlib/uint64.md
@@ -92,6 +92,41 @@ Returns:
 |----|-----------|
 |`Uint64`|The Int64 represented as a Uint64|
 
+### Uint64.**reinterpretFloat64**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+reinterpretFloat64 : (value: Float64) => Uint64
+```
+
+Interprets a Float64 as an Uint64.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`value`|`Float64`|The value to convert|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Uint64`|The Float64 interpreted as an Uint64|
+
+Examples:
+
+```grain
+assert Uint64.reinterpretFloat64(1.0d) == 4607182418800017408uL
+```
+
+```grain
+assert Uint64.reinterpretFloat64(-1.0d) == 13830554455654793216uL
+```
+
 ### Uint64.**incr**
 
 <details disabled>


### PR DESCRIPTION
This implements the following functions:
- `Int32.reinterpretFloat32`
- `UInt32.reinterpretFloat32`
- `Int64.reinterpretFloat64`
- `UInt64.reinterpretFloat64`
- `Float32.reinterpretInt32`
- `Float32.reinterpretUint32`
- `Float64.reinterpretInt64`
- `Float64.reinterpretUint64`
These act pretty similarly to their lower level wasm counterparts. 

Note: While I was working I also did some cleanup related to #703 though I'm happy to undo that if we decide it doesn't fit into this pr.

Closes: #2250 