### PR TITLE
feat(stdlib): Add `Buffer.resize(len, buf)`

### DIFF
--- a/compiler/test/stdlib/buffer.test.gr
+++ b/compiler/test/stdlib/buffer.test.gr
@@ -185,6 +185,19 @@ assert Buffer.getInt8(0, buf) == 1s
 let bytes = Buffer.toBytes(buf)
 assert Bytes.length(bytes) == 1
 
+// Buffer.resize
+let buf = Buffer.make(0)
+assert Buffer.length(buf) == 0
+Buffer.resize(0, buf)
+assert Buffer.length(buf) == 0
+Buffer.resize(8, buf)
+assert Buffer.length(buf) == 8
+Buffer.setInt8(7, 2s, buf)
+Buffer.resize(16, buf)
+assert Buffer.length(buf) == 16
+Buffer.resize(8, buf)
+assert Buffer.length(buf) == 8
+
 // it should convert a buffer to bytes
 let buf = Buffer.make(0)
 Buffer.addInt8(0s, buf)

--- a/stdlib/buffer.gr
+++ b/stdlib/buffer.gr
@@ -244,6 +244,40 @@ provide let truncate = (length, buffer) => {
 }
 
 /**
+ * Resizes a buffer to the given length.
+ *
+ * This operation only resizes the underlying byte sequence if the new length is greater than the current length.
+ *
+ * @param length: The number of bytes to resize the buffer to
+ * @param buffer: The buffer to truncate
+ *
+ * @throws IndexOutOfBounds: When the `length` is negative
+ *
+ * @example
+ * let buf = Buffer.make(0)
+ * Buffer.resize(4, buf)
+ * assert Buffer.length(buf) == 4
+ *
+ * @example
+ * let buf = Buffer.make(16)
+ * Buffer.resize(8, buf)
+ * assert Buffer.length(buf) == 8
+ *
+ * @since v0.7.0
+ */
+@unsafe
+provide let resize = (length, buffer) => {
+  if (length < 0) {
+    throw IndexOutOfBounds
+  } else if (length < buffer.len) {
+    truncate(length, buffer)
+  } else if (length > buffer.len) {
+    autogrow(length - buffer.len, buffer)
+    buffer.len = length
+  }
+}
+
+/**
  * Returns a copy of the current contents of the buffer as a byte sequence.
  *
  * @param buffer: The buffer to copy into a byte sequence

--- a/stdlib/buffer.md
+++ b/stdlib/buffer.md
@@ -215,6 +215,48 @@ Buffer.truncate(1, buf)
 assert Buffer.length(buf) == 1
 ```
 
+### Buffer.**resize**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+resize : (length: Number, buffer: Buffer) => Void
+```
+
+Resizes a buffer to the given length.
+
+This operation only resizes the underlying byte sequence if the new length is greater than the current length.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`length`|`Number`|The number of bytes to resize the buffer to|
+|`buffer`|`Buffer`|The buffer to truncate|
+
+Throws:
+
+`IndexOutOfBounds`
+
+* When the `length` is negative
+
+Examples:
+
+```grain
+let buf = Buffer.make(0)
+Buffer.resize(4, buf)
+assert Buffer.length(buf) == 4
+```
+
+```grain
+let buf = Buffer.make(16)
+Buffer.resize(8, buf)
+assert Buffer.length(buf) == 8
+```
+
 ### Buffer.**toBytes**
 
 <details disabled>


### PR DESCRIPTION
This pr implements `Buffer.resize`, it either resizes the buffer to the given length or truncates it to the set length. This is mostly useful for scenarios where buffer is being used in combo with `get` and `set` functions.

Closes: #2258 
