### PR TITLE
fix(compiler): Correct `Include_module_name_mismatch` error

### DIFF
--- a/compiler/src/typed/typemod.re
+++ b/compiler/src/typed/typemod.re
@@ -27,7 +27,7 @@ module String = Misc.Stdlib.String;
 type error =
   | Cannot_apply(module_type)
   | Not_included(list(Includemod.error))
-  | Include_module_name_mismatch(string, string)
+  | Include_module_name_mismatch(string, string, string)
   | Cannot_eliminate_dependency(module_type)
   | Signature_expected
   | Structure_expected(module_type)
@@ -83,7 +83,11 @@ let include_module = (env, sod) => {
       Error(
         sod.pinc_module.loc,
         env,
-        Include_module_name_mismatch(sod.pinc_module.txt, mod_name),
+        Include_module_name_mismatch(
+          sod.pinc_path.txt,
+          sod.pinc_module.txt,
+          mod_name,
+        ),
       ),
     );
   };
@@ -1095,12 +1099,13 @@ let report_error = ppf =>
       Includemod.report_error,
       errs,
     )
-  | Include_module_name_mismatch(provided_name, actual_name) =>
+  | Include_module_name_mismatch(path, provided_name, actual_name) =>
     fprintf(
       ppf,
-      "This statement includes module %s, but the file at the path defines module %s. Did you mean `include %s as %s`?",
+      "This statement includes module %s, but the file at the path defines module %s. Did you mean `from \"%s\" include %s as %s`?",
       provided_name,
       actual_name,
+      path,
       actual_name,
       provided_name,
     )

--- a/compiler/src/typed/typemod.rei
+++ b/compiler/src/typed/typemod.rei
@@ -5,7 +5,7 @@ open Typedtree;
 type error =
   | Cannot_apply(module_type)
   | Not_included(list(Includemod.error))
-  | Include_module_name_mismatch(string, string)
+  | Include_module_name_mismatch(string, string, string)
   | Cannot_eliminate_dependency(module_type)
   | Signature_expected
   | Structure_expected(module_type)

--- a/compiler/test/suites/includes.re
+++ b/compiler/test/suites/includes.re
@@ -106,8 +106,8 @@ describe("includes", ({test, testSkip}) => {
   );
   assertCompileError(
     "include_module_error",
-    "from \"provideAll\" include Foo; Foo.foo",
-    "This statement includes module Foo, but the file at the path defines module ProvideAll. Did you mean `include ProvideAll as Foo`?",
+    {|from "provideAll" include Foo; Foo.foo|},
+    {|This statement includes module Foo, but the file at the path defines module ProvideAll. Did you mean `from "provideAll.gr" include ProvideAll as Foo`?|},
   );
   /* use well-formedness errors */
   assertCompileError(


### PR DESCRIPTION
I noticed the error message was still using the `v0.6.0` preview syntax so this updates it to the correct release syntax. 

I'm not a major fan of the fact that in the test where we are including `provideAll` it says `provideAll.gr` but our other tests seem to follow similar behaviour and It would require a lot of rework to improve that.