### PR TITLE
feat(graindoc): Add bind information to errors

### DIFF
--- a/compiler/test/graindoc/invalidAttr.input.gr
+++ b/compiler/test/graindoc/invalidAttr.input.gr
@@ -1,0 +1,10 @@
+module InvalidAttr
+
+provide enum Invalid {
+  /**
+   * Value
+   *
+   * @param 0: This should fail
+   */
+  InvalidVar,
+}

--- a/compiler/test/graindoc/missingLabeledParamType.input.gr
+++ b/compiler/test/graindoc/missingLabeledParamType.input.gr
@@ -1,0 +1,9 @@
+module MissingLabeledParam
+
+/**
+ * This is a test function
+ *
+ * @param value: This should be val
+ *
+ */
+provide let missing = val => void

--- a/compiler/test/graindoc/missingUnlabeledParamType.input.gr
+++ b/compiler/test/graindoc/missingUnlabeledParamType.input.gr
@@ -1,0 +1,9 @@
+module MissingUnlabeledParamType
+
+/**
+ * This is a test function
+ *
+ * @param 0: This should be val
+ *
+ */
+provide let missing = () => void

--- a/compiler/test/suites/graindoc.re
+++ b/compiler/test/suites/graindoc.re
@@ -28,13 +28,31 @@ describe("graindoc", ({test, testSkip}) => {
   assertGrainDocError(
     "singleSince",
     "singleSince",
-    "Attribute @since is only allowed to appear once.",
+    "Attribute `@since` is only allowed to appear once on `SingleSince.test`.",
     [|"--current-version=v0.2.0"|],
   );
   assertGrainDocError(
     "singleReturn",
     "singleReturn",
-    "Attribute @returns is only allowed to appear once.",
+    "Attribute `@returns` is only allowed to appear once on `SingleReturn.test`.",
+    [|"--current-version=v0.2.0"|],
+  );
+  assertGrainDocError(
+    "missingLabeledParam",
+    "missingLabeledParamType",
+    "Unable to find a matching function parameter for `value` on `MissingLabeledParam.missing`. Make sure a parameter exists with this label or use `@param <param_index> value` for unlabeled parameters.",
+    [|"--current-version=v0.2.0"|],
+  );
+  assertGrainDocError(
+    "missingUnlabeledParam",
+    "missingUnlabeledParamType",
+    "Unable to find a type for parameter at index `0` on `MissingUnlabeledParamType.missing`. Make sure a parameter exists at this index in the parameter list.",
+    [|"--current-version=v0.2.0"|],
+  );
+  assertGrainDocError(
+    "invalidAttr",
+    "invalidAttr",
+    "Invalid attribute `@param` on `InvalidAttr.Invalid.InvalidVar`",
     [|"--current-version=v0.2.0"|],
   );
 });


### PR DESCRIPTION
This just adds the bind that is causing the issue to help with debugging. I think it would be beneficial if we had the full error location as well but I don't quite understand how our error_reporting works enough to make that change yet. 


Work towards: #1983 