### PR TITLE
fix(lsp): Ensure file changes update lsp state

### DIFF
--- a/compiler/src/language_server/code_file.re
+++ b/compiler/src/language_server/code_file.re
@@ -48,6 +48,7 @@ let warning_to_diagnostic =
 };
 
 let compile = (file, src) => {
+  reset_compiler_state();
   Module_resolution.load_dependency_graph_from_string(file, src);
   let to_compile = Module_resolution.get_out_of_date_dependencies();
   List.iter(


### PR DESCRIPTION
This fixes the issues we were having with the lsp where it wouldn't update when you made changes, upon some investigation and a `git bisect` I noticed that things stopped working in #2105 as we stopped reseting the compiler state when handling changes, this causes the parsetree cache to be hit and our changed module to never be reparsed. 

I wanted to add a regression test for this but It doesn't look like our lsp test suite is setup in a way that would make that easy.