### PR TITLE
chore(compiler): Cleanup unused errors

### DIFF
--- a/compiler/src/typed/checkertypes.re
+++ b/compiler/src/typed/checkertypes.re
@@ -25,7 +25,6 @@ type type_forcing_context =
   | If_no_else_branch
   | Loop_conditional
   | Loop_body
-  | Assert_condition
   | Sequence_left_hand_side
   | Assign_not_box
   | Assign_not_array

--- a/compiler/src/typed/checkertypes.rei
+++ b/compiler/src/typed/checkertypes.rei
@@ -15,7 +15,6 @@ type type_forcing_context =
   | If_no_else_branch
   | Loop_conditional
   | Loop_body
-  | Assert_condition
   | Sequence_left_hand_side
   | Assign_not_box
   | Assign_not_array

--- a/compiler/src/typed/disambiguation.re
+++ b/compiler/src/typed/disambiguation.re
@@ -442,7 +442,6 @@ let report_type_expected_explanation = (expl, ppf) =>
     fprintf(ppf, "the result of a conditional with no else branch")
   | Loop_conditional => fprintf(ppf, "the condition of a loop")
   | Loop_body => fprintf(ppf, "the body of a loop")
-  | Assert_condition => fprintf(ppf, "the condition of an assertion")
   | Sequence_left_hand_side =>
     fprintf(ppf, "the left-hand side of a sequence")
   | Assign_not_box => fprintf(ppf, "the left-hand side of a box assignment")

--- a/compiler/src/typed/typecore.rei
+++ b/compiler/src/typed/typecore.rei
@@ -69,13 +69,10 @@ let name_pattern: (string, list(Typedtree.match_branch)) => Ident.t;
 
 type error =
   | Arity_mismatch(type_expr, option(Checkertypes.type_forcing_context))
-  | Polymorphic_label(Identifier.t)
   | Constructor_arity_mismatch(Identifier.t, int, int)
   | Label_mismatch(Identifier.t, list((type_expr, type_expr)))
   | Pattern_type_clash(list((type_expr, type_expr)))
   | Or_pattern_type_clash(Ident.t, list((type_expr, type_expr)))
-  | Multiply_bound_variable(string)
-  | Orpat_vars(Ident.t, list(Ident.t))
   | Expr_type_clash(
       list((type_expr, type_expr)),
       option(Checkertypes.type_forcing_context),
@@ -88,40 +85,6 @@ type error =
   | Label_missing(list(Ident.t))
   | Label_not_mutable(Identifier.t)
   | Assign_not_mutable(Identifier.t)
-  | Wrong_name(
-      string,
-      Checkertypes.type_expected,
-      string,
-      Path.t,
-      string,
-      list(string),
-    )
-  | Name_type_mismatch(
-      string,
-      Identifier.t,
-      (Path.t, Path.t),
-      list((Path.t, Path.t)),
-    )
-  | Invalid_format(string)
-  | Undefined_method(type_expr, string, option(list(string)))
-  | Undefined_inherited_method(string, list(string))
-  | Virtual_class(Identifier.t)
-  | Private_type(type_expr)
-  | Private_label(Identifier.t, type_expr)
-  | Unbound_instance_variable(string, list(string))
-  | Instance_variable_not_mutable(bool, string)
-  | Not_subtype(
-      list((type_expr, type_expr)),
-      list((type_expr, type_expr)),
-    )
-  | Outside_class
-  | Value_multiply_overridden(string)
-  | Coercion_failure(
-      type_expr,
-      type_expr,
-      list((type_expr, type_expr)),
-      bool,
-    )
   | Not_a_function(type_expr, option(Checkertypes.type_forcing_context))
   | Function_label_mismatch({
       got: argument_label,
@@ -129,30 +92,11 @@ type error =
       expected_type: type_expr,
       explanation: option(Checkertypes.type_forcing_context),
     })
-  | Scoping_let_module(string, type_expr)
-  | Masked_instance_variable(Identifier.t)
-  | Not_a_variant_type(Identifier.t)
-  | Incoherent_label_order
   | Less_general(string, list((type_expr, type_expr)))
-  | Modules_not_allowed
-  | Cannot_infer_signature
-  | Not_a_packed_module(type_expr)
-  | Recursive_local_constraint(list((type_expr, type_expr)))
-  | Unexpected_existential
   | Unqualified_gadt_pattern(Path.t, string)
-  | Invalid_interval
-  | Invalid_for_loop_index
-  | No_value_clauses
-  | Exception_pattern_below_toplevel
   | Inlined_record_escape
   | Inlined_record_misuse(Identifier.t, string, string)
-  | Invalid_extension_constructor_payload
-  | Not_an_extension_constructor
-  | Literal_overflow(string)
-  | Unknown_literal(string, char)
   | Illegal_letrec_pat
-  | Illegal_letrec_expr
-  | Illegal_class_expr
   | Unbound_value_missing_rec(Identifier.t, Location.t);
 
 exception Error(Location.t, Env.t, error);

--- a/compiler/src/typed/typemod.re
+++ b/compiler/src/typed/typemod.re
@@ -46,7 +46,6 @@ type error =
   | Implementation_is_required(string)
   | Interface_not_compiled(string)
   | Not_allowed_in_functor_body
-  | Not_a_packed_module(type_expr)
   | Incomplete_packed_module(type_expr)
   | Scoping_pack(Identifier.t, type_expr)
   | Recursive_module_require_explicit_type
@@ -1199,13 +1198,6 @@ let report_error = ppf =>
       ppf,
       "@[This expression creates fresh types.@ %s@]",
       "It is not allowed inside applicative functors.",
-    )
-  | Not_a_packed_module(ty) =>
-    fprintf(
-      ppf,
-      "This expression is not a packed module. It has type@ %a",
-      type_expr,
-      ty,
     )
   | Incomplete_packed_module(ty) =>
     fprintf(

--- a/compiler/src/typed/typemod.rei
+++ b/compiler/src/typed/typemod.rei
@@ -24,7 +24,6 @@ type error =
   | Implementation_is_required(string)
   | Interface_not_compiled(string)
   | Not_allowed_in_functor_body
-  | Not_a_packed_module(type_expr)
   | Incomplete_packed_module(type_expr)
   | Scoping_pack(Identifier.t, type_expr)
   | Recursive_module_require_explicit_type

--- a/compiler/src/typed/typepat.re
+++ b/compiler/src/typed/typepat.re
@@ -1206,7 +1206,6 @@ let report_type_expected_explanation = (expl, ppf) =>
     fprintf(ppf, "the result of a conditional with no else branch")
   | Loop_conditional => fprintf(ppf, "the condition of a loop")
   | Loop_body => fprintf(ppf, "the body of a loop")
-  | Assert_condition => fprintf(ppf, "the condition of an assertion")
   | Sequence_left_hand_side =>
     fprintf(ppf, "the left-hand side of a sequence")
   | Assign_not_box => fprintf(ppf, "the left-hand side of a box assignment")


### PR DESCRIPTION
This just cleans up some legacy errors we had lying around but have not been using. 