### PR TITLE
fix(grainc): Correct behaviour of `-o` flag

### DIFF
--- a/compiler/grainc/grainc.re
+++ b/compiler/grainc/grainc.re
@@ -88,11 +88,7 @@ let grainc = (single_file_mode, name, outfile) => {
     compile_file(name);
 
     if (Grain_utils.Config.statically_link^) {
-      let main_object =
-        Option.value(
-          ~default=Compile.default_object_filename(name),
-          outfile,
-        );
+      let main_object = Compile.default_object_filename(name);
       let outfile =
         Option.value(~default=Compile.default_wasm_filename(name), outfile);
       let dependencies = Module_resolution.get_dependencies();


### PR DESCRIPTION
I noticed that `grain compile test.gr -o test.wasm` with any program was failing, it turned out to be a simple issue we were passing the outfile to figure out the name of the objfile when we should be passing the actual file name, and only using the outfile for the wasm output.

Closes: #2269 