### PR TITLE
fix(lsp): Prevent crash on alias module hover

### DIFF
--- a/compiler/test/suites/grainlsp.re
+++ b/compiler/test/suites/grainlsp.re
@@ -520,6 +520,34 @@ let a = 1
   );
 
   assertLspOutput(
+    "hover_val_alias",
+    "file:///a.gr",
+    {|module Main
+      module Map {
+        provide module Immutable {
+          provide let b = 1
+        }
+      }
+      use Map.{ module Immutable as M }
+      M.b
+    |},
+    lsp_input(
+      "textDocument/hover",
+      lsp_text_document_position("file:///a.gr", 7, 6),
+    ),
+    `Assoc([
+      (
+        "contents",
+        `Assoc([
+          ("kind", `String("markdown")),
+          ("value", `String("```grain\nlet b : Number\n```\n\n")),
+        ]),
+      ),
+      ("range", lsp_range((7, 6), (7, 7))),
+    ]),
+  );
+
+  assertLspOutput(
     "hover_type_definition",
     "file:///a.gr",
     {|module A


### PR DESCRIPTION
This pr prevents the lsp crash caused by #2179 by using the value path over looking up the module, I think this works well in this case however I noticed that using an aliased module with a `use` statement causes a deeper compiler crash which makes me think we should correct the behaviour in `find_module`. I don't quite know the best way about adding that but wanted to get a pr up preventing the crashes until we can investigate deeper. 

I'm not sure if we want to close #2179 with this if we do then we should probably open a seperate issue for the `use` crash. 