### PR TITLE
chore(compiler): Clean up duplicate `Warnings.is_active` checks

### DIFF
--- a/compiler/src/parsing/well_formedness.re
+++ b/compiler/src/parsing/well_formedness.re
@@ -850,18 +850,14 @@ let array_index_non_integer = (errs, super) => {
       switch (number_type) {
       | PConstNumberFloat({txt}) =>
         let warning = Warnings.ArrayIndexNonInteger(txt);
-        if (Warnings.is_active(warning)) {
-          Location.prerr_warning(loc, warning);
-        };
+        Location.prerr_warning(loc, warning);
       | PConstNumberRational({
           numerator: {txt: numerator},
           denominator: {txt: denominator},
         }) =>
         let warning =
           Warnings.ArrayIndexNonInteger(numerator ++ "/" ++ denominator);
-        if (Grain_utils.Warnings.is_active(warning)) {
-          Location.prerr_warning(loc, warning);
-        };
+        Location.prerr_warning(loc, warning);
       | _ => ()
       }
     | _ => ()

--- a/compiler/src/typed/parmatch.re
+++ b/compiler/src/typed/parmatch.re
@@ -2033,10 +2033,7 @@ let do_check_partial = (~pred, loc, casel: list(match_branch), pss) =>
      */
     switch (casel) {
     | [] => ()
-    | _ =>
-      if (Warnings.is_active(Warnings.AllClausesGuarded)) {
-        Location.prerr_warning(loc, Warnings.AllClausesGuarded);
-      }
+    | _ => Location.prerr_warning(loc, Warnings.AllClausesGuarded)
     };
     Partial;
   | [ps, ..._] =>

--- a/compiler/src/typed/typed_well_formedness.re
+++ b/compiler/src/typed/typed_well_formedness.re
@@ -273,9 +273,7 @@ module WellFormednessArg: TypedtreeIter.IteratorArgument = {
               Printf.sprintf("%s.(%s)", typeName, func),
               typeName,
             );
-          if (Grain_utils.Warnings.is_active(warning)) {
-            Grain_parsing.Location.prerr_warning(exp_loc, warning);
-          };
+          Grain_parsing.Location.prerr_warning(exp_loc, warning);
         }
       // Check: Warn if using Pervasives print on WasmXX types
       | TExpApp(
@@ -296,9 +294,7 @@ module WellFormednessArg: TypedtreeIter.IteratorArgument = {
         | Some({arg_expr}) =>
           let typeName = resolve_unsafe_type(arg_expr);
           let warning = Grain_utils.Warnings.PrintUnsafe(typeName);
-          if (Grain_utils.Warnings.is_active(warning)) {
-            Grain_parsing.Location.prerr_warning(exp_loc, warning);
-          };
+          Grain_parsing.Location.prerr_warning(exp_loc, warning);
         | _ => ()
         }
       // Check: Warn if using Pervasives toString on WasmXX types
@@ -323,9 +319,7 @@ module WellFormednessArg: TypedtreeIter.IteratorArgument = {
         | Some({arg_expr}) =>
           let typeName = resolve_unsafe_type(arg_expr);
           let warning = Grain_utils.Warnings.ToStringUnsafe(typeName);
-          if (Grain_utils.Warnings.is_active(warning)) {
-            Grain_parsing.Location.prerr_warning(exp_loc, warning);
-          };
+          Grain_parsing.Location.prerr_warning(exp_loc, warning);
         | _ => ()
         }
       // Check: Warn if using XXXX.fromNumber(<literal>)
@@ -381,9 +375,7 @@ module WellFormednessArg: TypedtreeIter.IteratorArgument = {
           };
         let warning =
           Grain_utils.Warnings.FromNumberLiteral(mod_type, modname, n_str);
-        if (Grain_utils.Warnings.is_active(warning)) {
-          Grain_parsing.Location.prerr_warning(exp_loc, warning);
-        };
+        Grain_parsing.Location.prerr_warning(exp_loc, warning);
       | _ => ()
       };
       // Check: Forbid usage of WasmXX types outside of disableGC context


### PR DESCRIPTION
Just some tiny cleanup, `Location.prerr_warning` checks `Warnings.is_active` [source here](https://github.com/grain-lang/grain/blob/3cf6021b7c7a228542fd300e9bf33c5b63bcc42d/compiler/src/parsing/location.re#L416) before actually emitting the error so doing it in these locations just makes things slower and adds code noise.