### PR TITLE
feat(stdlib): Add `Path.updateExtension`

### DIFF
--- a/compiler/test/stdlib/path.test.gr
+++ b/compiler/test/stdlib/path.test.gr
@@ -285,3 +285,10 @@ assert Path.removeExtension(fs("file.tar.gz")) == fs("file")
 assert Path.removeExtension(fs("/test/")) == fs("/test/")
 assert Path.removeExtension(fs("/test/test")) == fs("/test/test")
 assert Path.removeExtension(fs(".gitignore")) == fs(".gitignore")
+
+// Path.updateExtension
+assert Path.updateExtension(fs("file.txt"), "ext") == fs("file.ext")
+assert Path.updateExtension(fs("file.txt"), "") == fs("file.")
+assert Path.updateExtension(fs(".gitignore"), "ext") == fs(".gitignore.ext")
+assert Path.updateExtension(fs("./dir/file"), "ext") == fs("dir/file.ext")
+assert Path.updateExtension(fs("./dir/"), "ext") == fs("dir/")

--- a/stdlib/path.gr
+++ b/stdlib/path.gr
@@ -745,6 +745,31 @@ provide let removeExtension = (path: Path) => {
   }
 }
 
+/**
+ * Updates the file extension of the given path.
+ *
+ * @param path: The path to modify
+ * @param extension: The new extension
+ * @returns The modified path
+ *
+ * @example updateExtension(fromString("file.txt"), "ext") == fromString("file.ext")
+ * @example updateExtension(fromString("file.txt"), "") == fromString("file.")
+ * @example updateExtension(fromString(".gitignore"), "ext") == fromString(".gitignore.ext")
+ * @example updateExtension(fromString("./dir/file"), "ext") == fromString("dir/file.ext")
+ * @example updateExtension(fromString("./dir/"), "ext") == fromString("dir/")
+ *
+ * @since v7.0.0
+ */
+provide let updateExtension = (path: Path, extension: String) => {
+  match (pathInfo(path)) {
+    (base, File, [name, ...rest]) as pathInfo => {
+      let (name, _) = stemExtHelper(pathInfo)
+      toPath((base, File, [name ++ "." ++ extension, ...rest]))
+    },
+    _ => path,
+  }
+}
+
 // should only be used on absolute paths
 let rootHelper = (path: PathInfo) => match (path) {
   (Abs(root), _, _) => root,

--- a/stdlib/path.md
+++ b/stdlib/path.md
@@ -680,6 +680,54 @@ removeExtension(fromString("./dir/file")) == fromString("dir/file")
 removeExtension(fromString("./dir/")) == fromString("dir/")
 ```
 
+### Path.**updateExtension**
+
+<details disabled>
+<summary tabindex="-1">Added in <code>next</code></summary>
+No other changes yet.
+</details>
+
+```grain
+updateExtension: (path: Path, extension: String) => Path
+```
+
+Updates the file extension of the given path.
+
+Parameters:
+
+|param|type|description|
+|-----|----|-----------|
+|`path`|`Path`|The path to modify|
+|`extension`|`String`|The new extension|
+
+Returns:
+
+|type|description|
+|----|-----------|
+|`Path`|The modified path|
+
+Examples:
+
+```grain
+updateExtension(fromString("file.txt"), "ext") == fromString("file.ext")
+```
+
+```grain
+updateExtension(fromString("file.txt"), "") == fromString("file.")
+```
+
+```grain
+updateExtension(fromString(".gitignore"), "ext") == fromString(".gitignore.ext")
+```
+
+```grain
+updateExtension(fromString("./dir/file"), "ext") == fromString("dir/file.ext")
+```
+
+```grain
+updateExtension(fromString("./dir/"), "ext") == fromString("dir/")
+```
+
 ### Path.**root**
 
 <details disabled>


### PR DESCRIPTION
This adds `Path.updateExtension` so users can set the current extension.

Edge Cases:
* Regular, we just chop the extension and then append `.<ext>` to the end
* Directory, we don't set the extension
* Empty extension sets something like `file.ext` to `file.`, this seems weird but I think it's the best option if a user actually wants to clear the extension they should use `removeExtension`.

Note: One thing I noticed is our examples for `Path` omit the `Path.` which means unless you do` use Path.*` (which I don't think we encourage) the examples are not runnable off the bat, I think we should fix this in a seperate pr for consistency across the stdlib.