### PR TITLE
fix(lsp): Correct use argument label code_action with inferred funcs

### DIFF
--- a/compiler/src/language_server/code_action.re
+++ b/compiler/src/language_server/code_action.re
@@ -96,16 +96,16 @@ let rec process_explicit_type_annotation =
 
 let rec process_named_arg_label = (uri, results: list(Sourcetree.node)) => {
   switch (results) {
-  | [Argument({arg_label, label_specified, loc}), ..._] when !label_specified =>
+  | [
+      Argument({
+        arg_label: Labeled({txt}) | Default({txt}),
+        label_specified: false,
+        loc,
+      }),
+      ..._,
+    ] =>
     let loc = {...loc, loc_end: loc.loc_start};
-    let arg_label =
-      switch (arg_label) {
-      | Unlabeled =>
-        failwith("Impossible: unlabeled argument after typechecking")
-      | Labeled({txt})
-      | Default({txt}) => txt
-      };
-    Some(named_arg_label(Utils.loc_to_range(loc), uri, arg_label));
+    Some(named_arg_label(Utils.loc_to_range(loc), uri, txt));
   | [_, ...rest] => process_named_arg_label(uri, rest)
   | _ => None
   };

--- a/compiler/test/suites/grainlsp.re
+++ b/compiler/test/suites/grainlsp.re
@@ -352,6 +352,41 @@ f(x="x")
   );
 
   assertLspOutput(
+    "code_action_add_function_label_pattern",
+    "file:///a.gr",
+    {|module A
+let f = ((a, b)) => a + b
+f((1, 2))
+    |},
+    lsp_input(
+      "textDocument/codeAction",
+      `Assoc([
+        ("textDocument", `Assoc([("uri", `String("file:///a.gr"))])),
+        ("range", lsp_range((2, 2), (2, 2))),
+        ("context", `Assoc([("diagnostics", `List([]))])),
+      ]),
+    ),
+    `Null,
+  );
+
+  assertLspOutput(
+    "code_action_add_function_inferred",
+    "file:///a.gr",
+    {|module A
+a => {a(1); void}
+    |},
+    lsp_input(
+      "textDocument/codeAction",
+      `Assoc([
+        ("textDocument", `Assoc([("uri", `String("file:///a.gr"))])),
+        ("range", lsp_range((1, 8), (1, 8))),
+        ("context", `Assoc([("diagnostics", `List([]))])),
+      ]),
+    ),
+    `Null,
+  );
+
+  assertLspOutput(
     "code_action_remove_function_block_braces_1",
     "file:///a.gr",
     {|module A


### PR DESCRIPTION
I noticed that the lsp would sometimes crash in `stdlib/path.gr` with an `Impossible error`, it seems we made the assumption that an `Unlabeled` arg cannot appear in a `TExpApp` argument however this isn't the case, things like patterns and inferred functions (passed as a param) can trigger this case.

A minimal reproduction of this issue is either `a => a(1)`, or `(((a, b)) => a + b)((1, 2))` place your cursor before the parameter in vscode.