### PR TITLE
fix(grainfmt): Correct formatting of submodules ending with comments

### DIFF
--- a/compiler/src/formatting/fmt.re
+++ b/compiler/src/formatting/fmt.re
@@ -3396,6 +3396,7 @@ let print_module_declaration = (fmt, {pmod_name, pmod_stmts, pmod_loc}) => {
              prev =>
                fmt.print_comment_range(
                  fmt,
+                 ~block_end=true,
                  ~lead=space,
                  prev.ptop_loc,
                  enclosing_end_location(pmod_loc),

--- a/compiler/test/grainfmt/comments.expected.gr
+++ b/compiler/test/grainfmt/comments.expected.gr
@@ -660,3 +660,8 @@ let [/*foo */] = 5
 2
 1 /* abc */ /2
 1 /* abc */ / /* xyz */ 2
+
+// Regression for #2287
+module Bar {
+  1 // foo
+}

--- a/compiler/test/grainfmt/comments.input.gr
+++ b/compiler/test/grainfmt/comments.input.gr
@@ -508,3 +508,9 @@ let [ /*foo */] = 5
 2
 1/* abc *//2
 1/* abc */ / /* xyz */2
+
+
+// Regression for #2287
+module Bar {
+  1 // foo
+}


### PR DESCRIPTION
This corrects the formatting of cases like:
```gr
module Foo {
  foo // foo
}
```
Previously we were adding a new hardline at the end each time the formatter was run, it seems we were not correctly handling the linebreak calculation as were not printing the comment range as if it were at the end of a block. 

Closes: #2287 