### PR TITLE
chore(docs): Clean up pre 0.6 examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,10 +35,10 @@ It can sometimes be helpful to run small Grain programs directly to test some fu
 
 ### Standard library
 
-It's usually easiest to create a small Grain program that imports your library to try it out, like so:
+It's usually easiest to create a small Grain program that includes your library to try it out, like so:
 
 ```grain
-import Array from "array"
+from "array" include Array
 
 let appended = Array.append([> 1, 2, 3], [> 4, 5, 6])
 print(appended)
@@ -47,7 +47,7 @@ print(appended)
 The tests for the standard library are located in `compiler/test/stdlib`. Since the standard library tests are written in Grain, rather than running the whole test suite, you can just run them directly:
 
 ```bash
-grain compiler/test/stdlib/array.test.gr
+grain compiler/test/stdlib/array.test.gr --stdlib stdlib
 ```
 
 If there's no error, you're all set.

--- a/stdlib/int32.gr
+++ b/stdlib/int32.gr
@@ -663,7 +663,7 @@ let rec expBySquaring = (y, x, n) => {
  * @returns The base raised to the given power
  *
  * @example
- * from Int32 use { (**) }
+ * use Int32.{ (**) }
  * assert 2l ** 3l == 8l
  *
  * @since v0.6.0

--- a/stdlib/int32.md
+++ b/stdlib/int32.md
@@ -1172,7 +1172,7 @@ Returns:
 Examples:
 
 ```grain
-from Int32 use { (**) }
+use Int32.{ (**) }
 assert 2l ** 3l == 8l
 ```
 

--- a/stdlib/int64.gr
+++ b/stdlib/int64.gr
@@ -654,7 +654,7 @@ let rec expBySquaring = (y, x, n) => {
  * @returns The base raised to the given power
  *
  * @example
- * from Int64 use { (**) }
+ * use Int64.{ (**) }
  * assert 2L ** 3L == 8L
  *
  * @since v0.6.0

--- a/stdlib/int64.md
+++ b/stdlib/int64.md
@@ -1172,7 +1172,7 @@ Returns:
 Examples:
 
 ```grain
-from Int64 use { (**) }
+use Int64.{ (**) }
 assert 2L ** 3L == 8L
 ```
 

--- a/stdlib/number.gr
+++ b/stdlib/number.gr
@@ -83,7 +83,7 @@ provide let e = 2.718281828459045
  * @returns The sum of the two operands
  *
  * @example
- * from Number use { (+) }
+ * use Number.{ (+) }
  * assert 1 + 2 == 3
  *
  * @since v0.6.0
@@ -99,7 +99,7 @@ provide let (+) = (+)
  * @returns The difference of the two operands
  *
  * @example
- * from Number use { (-) }
+ * use Number.{ (-) }
  * assert 5 - 2 == 3
  *
  * @since v0.6.0
@@ -115,7 +115,7 @@ provide let (-) = (-)
  * @returns The product of the two operands
  *
  * @example
- * from Number use { (*) }
+ * use Number.{ (*) }
  * assert 5 * 4 == 20
  *
  * @since v0.6.0
@@ -131,7 +131,7 @@ provide let (*) = (*)
  * @returns The quotient of the two operands
  *
  * @example
- * from Number use { (/) }
+ * use Number.{ (/) }
  * assert 10 / 2.5 == 4
  *
  * @since v0.6.0
@@ -147,7 +147,7 @@ provide let (/) = (/)
  * @returns The base raised to the given power
  *
  * @example
- * from Number use { (**) }
+ * use Number.{ (**) }
  * assert 10 ** 2 == 100
  *
  * @since v0.6.0

--- a/stdlib/number.md
+++ b/stdlib/number.md
@@ -157,7 +157,7 @@ Returns:
 Examples:
 
 ```grain
-from Number use { (+) }
+use Number.{ (+) }
 assert 1 + 2 == 3
 ```
 
@@ -197,7 +197,7 @@ Returns:
 Examples:
 
 ```grain
-from Number use { (-) }
+use Number.{ (-) }
 assert 5 - 2 == 3
 ```
 
@@ -237,7 +237,7 @@ Returns:
 Examples:
 
 ```grain
-from Number use { (*) }
+use Number.{ (*) }
 assert 5 * 4 == 20
 ```
 
@@ -277,7 +277,7 @@ Returns:
 Examples:
 
 ```grain
-from Number use { (/) }
+use Number.{ (/) }
 assert 10 / 2.5 == 4
 ```
 
@@ -317,7 +317,7 @@ Returns:
 Examples:
 
 ```grain
-from Number use { (**) }
+use Number.{ (**) }
 assert 10 ** 2 == 100
 ```
 


### PR DESCRIPTION
Some of our stdlib examples were still using the pre 0.6 syntax this corrects them.