### PR TITLE
feat(lsp): Implement document symbol outline

### DIFF
--- a/compiler/src/language_server/driver.re
+++ b/compiler/src/language_server/driver.re
@@ -28,6 +28,9 @@ let process = msg => {
   | TextDocumentInlayHint(id, params) when is_initialized^ =>
     Inlayhint.process(~id, ~compiled_code, ~documents, params);
     Reading;
+  | TextDocumentSymbol(id, params) when is_initialized^ =>
+    Symbol.process(~id, ~compiled_code, ~documents, params);
+    Reading;
   | TextDocumentCodeLens(id, params) when is_initialized^ =>
     Lenses.process(~id, ~compiled_code, ~documents, params);
     Reading;

--- a/compiler/src/language_server/initialize.re
+++ b/compiler/src/language_server/initialize.re
@@ -74,7 +74,7 @@ module ResponseResult = {
     },
     type_definition_provider: true,
     references_provider: false,
-    document_symbol_provider: false,
+    document_symbol_provider: true,
     code_action_provider: true,
     code_lens_provider: {
       resolve_provider: true,

--- a/compiler/src/language_server/message.re
+++ b/compiler/src/language_server/message.re
@@ -9,6 +9,7 @@ type t =
   | TextDocumentDidOpen(Protocol.uri, Code_file.DidOpen.RequestParams.t)
   | TextDocumentDidChange(Protocol.uri, Code_file.DidChange.RequestParams.t)
   | TextDocumentInlayHint(Protocol.message_id, Inlayhint.RequestParams.t)
+  | TextDocumentSymbol(Protocol.message_id, Symbol.RequestParams.t)
   | Formatting(Protocol.message_id, Formatting.RequestParams.t)
   | Goto(Protocol.message_id, Goto.goto_request_type, Goto.RequestParams.t)
   | CodeAction(Protocol.message_id, Code_action.RequestParams.t)
@@ -31,6 +32,15 @@ let of_request = (msg: Protocol.request_message): t => {
   | {method: "textDocument/inlayHint", id: Some(id), params: Some(params)} =>
     switch (Inlayhint.RequestParams.of_yojson(params)) {
     | Ok(params) => TextDocumentInlayHint(id, params)
+    | Error(msg) => Error(msg)
+    }
+  | {
+      method: "textDocument/documentSymbol",
+      id: Some(id),
+      params: Some(params),
+    } =>
+    switch (Symbol.RequestParams.of_yojson(params)) {
+    | Ok(params) => TextDocumentSymbol(id, params)
     | Error(msg) => Error(msg)
     }
   | {method: "textDocument/codeLens", id: Some(id), params: Some(params)} =>

--- a/compiler/src/language_server/message.rei
+++ b/compiler/src/language_server/message.rei
@@ -7,6 +7,7 @@ type t =
   | TextDocumentDidOpen(Protocol.uri, Code_file.DidOpen.RequestParams.t)
   | TextDocumentDidChange(Protocol.uri, Code_file.DidChange.RequestParams.t)
   | TextDocumentInlayHint(Protocol.message_id, Inlayhint.RequestParams.t)
+  | TextDocumentSymbol(Protocol.message_id, Symbol.RequestParams.t)
   | Formatting(Protocol.message_id, Formatting.RequestParams.t)
   | Goto(Protocol.message_id, Goto.goto_request_type, Goto.RequestParams.t)
   | CodeAction(Protocol.message_id, Code_action.RequestParams.t)

--- a/compiler/src/language_server/symbol.re
+++ b/compiler/src/language_server/symbol.re
@@ -1,0 +1,246 @@
+open Grain_typed;
+
+// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#documentSymbolParams
+module RequestParams = {
+  [@deriving yojson({strict: false})]
+  type t = {
+    [@key "textDocument"]
+    text_document: Protocol.text_document_identifier,
+  };
+};
+
+// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#documentSymbol
+module ResponseResult = {
+  /** A symbol kind. */
+  [@deriving (enum, yojson)]
+  type symbol_kind =
+    | [@value 1] File
+    | [@value 2] Module
+    | [@value 3] Namespace
+    | [@value 4] Package
+    | [@value 5] Class
+    | [@value 6] Method
+    | [@value 7] Property
+    | [@value 8] Field
+    | [@value 9] Constructor
+    | [@value 10] Enum
+    | [@value 11] Interface
+    | [@value 12] Function
+    | [@value 13] Variable
+    | [@value 14] Constant
+    | [@value 15] String
+    | [@value 16] Number
+    | [@value 17] Boolean
+    | [@value 18] Array
+    | [@value 19] Object
+    | [@value 20] Key
+    | [@value 21] Null
+    | [@value 22] EnumMember
+    | [@value 23] Struct
+    | [@value 24] Event
+    | [@value 25] Operator
+    | [@value 26] TypeParameter;
+  let symbol_kind_to_yojson = symbol_kind =>
+    symbol_kind_to_enum(symbol_kind) |> [%to_yojson: int];
+  let symbol_kind_of_yojson = json =>
+    Result.bind(json |> [%of_yojson: int], value => {
+      switch (symbol_kind_of_enum(value)) {
+      | Some(symbol_kind) => Ok(symbol_kind)
+      | None => Result.Error("Invalid enum value")
+      }
+    });
+
+  /**
+   * Symbol tags are extra annotations that tweak the rendering of a symbol.
+   */
+  [@deriving (enum, yojson)]
+  type symbol_tag =
+    | /**
+     * Render a symbol as obsolete, usually using a strike-out.
+     */
+      [@value 1] Deprecated;
+  /**
+   * Represents programming constructs like variables, classes, interfaces etc.
+   * that appear in a document. Document symbols can be hierarchical and they
+   * have two ranges: one that encloses its definition and one that points to its
+   * most interesting range, e.g. the range of an identifier.
+   */
+  [@deriving yojson]
+  type document_symbol = {
+    /**
+     * The name of this symbol. Will be displayed in the user interface and
+     * therefore must not be an empty string or a string only consisting of
+     * white spaces.
+     */
+    name: string,
+    /**
+     * More detail for this symbol, e.g the signature of a function.
+     */
+    [@default None]
+    detail: option(string),
+    /** The kind of this symbol. */
+    kind: symbol_kind,
+    /** Tags for this document symbol. */
+    [@default None]
+    tags: option(list(symbol_tag)),
+    /**
+     * The range enclosing this symbol not including leading/trailing whitespace
+     * but everything else like comments. This information is typically used to
+     * determine if the clients cursor is inside the symbol to reveal it  in the
+     * UI.
+     */
+    range: Protocol.range,
+    /**
+     * The range that should be selected and revealed when this symbol is being
+     * picked, e.g. the name of a function. Must be contained by the `range`.
+     */
+    [@key "selectionRange"]
+    selection_range: Protocol.range,
+    /**
+     * Children of this symbol, e.g. properties of a class.
+     */
+    [@default None]
+    children: option(list(document_symbol)),
+  };
+  [@deriving yojson]
+  type t = list(document_symbol);
+};
+
+// Outline building functions
+let rec build_toplevel_outline = (statement: Typedtree.toplevel_stmt) => {
+  switch (statement.ttop_desc) {
+  | TTopForeign(_)
+  | TTopInclude(_)
+  | TTopProvide(_)
+  | TTopException(_)
+  | TTopExpr(_) => None
+  | TTopData(data_decls) =>
+    Some(
+      List.filter_map(
+        (data_decl: Typedtree.data_declaration) => {
+          let kind: option(ResponseResult.symbol_kind) =
+            switch (data_decl.data_kind) {
+            | TDataRecord(_) => Some(Struct)
+            | TDataVariant(_) => Some(Enum)
+            | TDataAbstract => None
+            };
+          switch (kind) {
+          | Some(kind) =>
+            Some(
+              {
+                name: Ident.name(data_decl.data_id),
+                detail: None,
+                kind,
+                tags: None,
+                range: Utils.loc_to_range(data_decl.data_loc),
+                selection_range: Utils.loc_to_range(data_decl.data_loc),
+                children: None,
+              }: ResponseResult.document_symbol,
+            )
+          | None => None
+          };
+        },
+        data_decls,
+      ),
+    )
+  | TTopLet(_, _, binds) =>
+    Some(
+      List.filter_map(
+        (bind: Typedtree.value_binding) => {
+          switch (bind.vb_pat.pat_desc) {
+          | TPatVar(ident, _) =>
+            Some(
+              {
+                name: Ident.name(ident),
+                detail:
+                  Some(
+                    Printtyp.string_of_type_scheme(bind.vb_expr.exp_type),
+                  ),
+                kind:
+                  switch (bind.vb_expr.exp_desc) {
+                  | TExpLambda(_, _) => Function
+                  | _ => Variable
+                  },
+                tags: None,
+                range: Utils.loc_to_range(bind.vb_loc),
+                selection_range: Utils.loc_to_range(bind.vb_loc),
+                children: None,
+              }: ResponseResult.document_symbol,
+            )
+          | _ => None
+          }
+        },
+        binds,
+      ),
+    )
+  | TTopModule(module_decl) =>
+    Some([
+      (
+        {
+          name: Ident.name(module_decl.tmod_id),
+          detail: None,
+          kind: Module,
+          tags: None,
+          range: Utils.loc_to_range(statement.ttop_loc),
+          selection_range: Utils.loc_to_range(statement.ttop_loc),
+          children:
+            Some(
+              List.fold_left(
+                (acc, statement) => {
+                  switch (build_toplevel_outline(statement)) {
+                  | None => acc
+                  | Some(symbol) => List.append(acc, symbol)
+                  }
+                },
+                [],
+                module_decl.tmod_statements,
+              ),
+            ),
+        }: ResponseResult.document_symbol
+      ),
+    ])
+  };
+};
+
+let build_program_outline = (program: Typedtree.typed_program) => {
+  [
+    (
+      {
+        name: program.module_name.txt,
+        detail: None,
+        kind: Module,
+        tags: None,
+        range: Utils.loc_to_range(program.mod_loc),
+        selection_range: Utils.loc_to_range(program.mod_loc),
+        children:
+          Some(
+            List.fold_left(
+              (acc, statement) => {
+                switch (build_toplevel_outline(statement)) {
+                | None => acc
+                | Some(symbol) => List.append(acc, symbol)
+                }
+              },
+              [],
+              program.statements,
+            ),
+          ),
+      }: ResponseResult.document_symbol
+    ),
+  ];
+};
+
+let process =
+    (
+      ~id: Protocol.message_id,
+      ~compiled_code: Hashtbl.t(Protocol.uri, Lsp_types.code),
+      ~documents: Hashtbl.t(Protocol.uri, string),
+      params: RequestParams.t,
+    ) => {
+  switch (Hashtbl.find_opt(compiled_code, params.text_document.uri)) {
+  | None => Protocol.response(~id, `Null)
+  | Some({program}) =>
+    let outline = build_program_outline(program);
+    Protocol.response(~id, ResponseResult.to_yojson(outline));
+  };
+};

--- a/compiler/src/language_server/symbol.rei
+++ b/compiler/src/language_server/symbol.rei
@@ -1,0 +1,22 @@
+open Grain_typed;
+
+// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#documentSymbolParams
+module RequestParams: {
+  [@deriving yojson({strict: false})]
+  type t;
+};
+
+// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#documentSymbol
+module ResponseResult: {
+  [@deriving yojson]
+  type t;
+};
+
+let process:
+  (
+    ~id: Protocol.message_id,
+    ~compiled_code: Hashtbl.t(Protocol.uri, Lsp_types.code),
+    ~documents: Hashtbl.t(Protocol.uri, string),
+    RequestParams.t
+  ) =>
+  unit;

--- a/compiler/src/typed/typedtree.re
+++ b/compiler/src/typed/typedtree.re
@@ -631,6 +631,7 @@ type typed_program = {
   signature: Cmi_format.cmi_infos,
   comments: list(comment),
   prog_loc: Location.t,
+  mod_loc: Location.t,
 };
 
 let iter_pattern_desc = (f, patt) =>

--- a/compiler/src/typed/typedtree.rei
+++ b/compiler/src/typed/typedtree.rei
@@ -591,6 +591,7 @@ type typed_program = {
   signature: Cmi_format.cmi_infos,
   comments: list(comment),
   prog_loc: Location.t,
+  mod_loc: Location.t,
 };
 
 /* Auxiliary functions over the AST */

--- a/compiler/src/typed/typemod.re
+++ b/compiler/src/typed/typemod.re
@@ -1075,6 +1075,7 @@ let type_implementation = (prog: Parsetree.parsed_program) => {
     signature,
     comments: prog.comments,
     prog_loc: prog.prog_loc,
+    mod_loc: prog.prog_core_loc,
   };
 };
 

--- a/compiler/test/runner.re
+++ b/compiler/test/runner.re
@@ -726,7 +726,7 @@ let assert_lsp_responses =
     lsp_expected_response(
       lsp_success_response(
         Yojson.Safe.from_string(
-          {|{"capabilities":{"documentFormattingProvider":true,"textDocumentSync":1,"hoverProvider":true,"definitionProvider":{"linkSupport":true},"typeDefinitionProvider":true,"referencesProvider":false,"documentSymbolProvider":false,"codeActionProvider":true,"codeLensProvider":{"resolveProvider":true},"documentHighlightProvider":false,"documentRangeFormattingProvider":false,"renameProvider":false,"inlayHintProvider":{"resolveProvider":false}}}|},
+          {|{"capabilities":{"documentFormattingProvider":true,"textDocumentSync":1,"hoverProvider":true,"definitionProvider":{"linkSupport":true},"typeDefinitionProvider":true,"referencesProvider":false,"documentSymbolProvider":true,"codeActionProvider":true,"codeLensProvider":{"resolveProvider":true},"documentHighlightProvider":false,"documentRangeFormattingProvider":false,"renameProvider":false,"inlayHintProvider":{"resolveProvider":false}}}|},
         ),
       ),
     );

--- a/compiler/test/suites/grainlsp.re
+++ b/compiler/test/suites/grainlsp.re
@@ -823,4 +823,91 @@ let Some(a) = Some(1)
       ),
     ]),
   );
+
+  assertLspOutput(
+    "document_symbol",
+    "file:///a.gr",
+    {|module Test
+    provide record A { x: Number }
+    abstract type B = Number
+    enum C { A, B }
+    let a = 1
+    let a = () => 1
+    let _ = [1, 2]
+    let z = (x, y) => x + y
+    provide module Sub {
+      provide let sub = 1
+    }
+|},
+    lsp_input(
+      "textDocument/documentSymbol",
+      `Assoc([
+        ("textDocument", `Assoc([("uri", `String("file:///a.gr"))])),
+      ]),
+    ),
+    `List([
+      `Assoc([
+        ("name", `String("Test")),
+        ("kind", `Int(2)),
+        ("range", lsp_range((0, 0), (11, 0))),
+        ("selectionRange", lsp_range((0, 0), (11, 0))),
+        (
+          "children",
+          `List([
+            `Assoc([
+              ("name", `String("A")),
+              ("kind", `Int(23)),
+              ("range", lsp_range((1, 12), (1, 34))),
+              ("selectionRange", lsp_range((1, 12), (1, 34))),
+            ]),
+            `Assoc([
+              ("name", `String("C")),
+              ("kind", `Int(10)),
+              ("range", lsp_range((3, 4), (3, 19))),
+              ("selectionRange", lsp_range((3, 4), (3, 19))),
+            ]),
+            `Assoc([
+              ("name", `String("a")),
+              ("detail", `String("Number")),
+              ("kind", `Int(13)),
+              ("range", lsp_range((4, 8), (4, 13))),
+              ("selectionRange", lsp_range((4, 8), (4, 13))),
+            ]),
+            `Assoc([
+              ("name", `String("a")),
+              ("detail", `String("() => Number")),
+              ("kind", `Int(12)),
+              ("range", lsp_range((5, 8), (5, 19))),
+              ("selectionRange", lsp_range((5, 8), (5, 19))),
+            ]),
+            `Assoc([
+              ("name", `String("z")),
+              ("detail", `String("(x: Number, y: Number) => Number")),
+              ("kind", `Int(12)),
+              ("range", lsp_range((7, 8), (7, 27))),
+              ("selectionRange", lsp_range((7, 8), (7, 27))),
+            ]),
+            `Assoc([
+              ("name", `String("Sub")),
+              ("kind", `Int(2)),
+              ("range", lsp_range((8, 4), (10, 5))),
+              ("selectionRange", lsp_range((8, 4), (10, 5))),
+              (
+                "children",
+                `List([
+                  `Assoc([
+                    ("name", `String("sub")),
+                    ("detail", `String("Number")),
+                    ("kind", `Int(13)),
+                    ("range", lsp_range((9, 18), (9, 25))),
+                    ("selectionRange", lsp_range((9, 18), (9, 25))),
+                  ]),
+                ]),
+              ),
+            ]),
+          ]),
+        ),
+      ]),
+    ]),
+  );
 });


### PR DESCRIPTION
This adds the lsp symbol outline which makes it easier to navigate large files.

<img width="1552" alt="Screenshot 2025-06-14 at 6 20 23 PM" src="https://github.com/user-attachments/assets/2ae10b90-24dc-43eb-af82-affdb31cca11" />
<img width="420" alt="Screenshot 2025-06-14 at 6 23 05 PM" src="https://github.com/user-attachments/assets/1720f2b0-3893-4a8f-8f58-50d177c1969a" />
