### PR TITLE
Fix Typos in Comments and Documentation in parmacth.re

### DIFF
--- a/compiler/src/typed/parmatch.re
+++ b/compiler/src/typed/parmatch.re
@@ -268,7 +268,7 @@ let first_column = simplified_matrix => List.map(fst, simplified_matrix);
 
      The second clause above will NOT (and cannot) be flagged as useless.
 
-     Finally, there are two compatibility fonction
+     Finally, there are two compatibility function
       compat p q      ---> 'syntactic compatibility, used for diagnostics.
       may_compat p q --->   a safe approximation of possible compat,
                             for compilation

--- a/compiler/src/typed/parmatch.re
+++ b/compiler/src/typed/parmatch.re
@@ -1725,7 +1725,7 @@ let extract_columns = (pss, qs) =>
 let rec every_satisfiables = (pss, qs) =>
   switch (qs.active) {
   | [] =>
-    /* qs is now partitionned,  check usefulness */
+    /* qs is now partitioned,  check usefulness */
     switch (qs.ors) {
     | [] =>
       /* no or-patterns */


### PR DESCRIPTION


Description:  
This pull request corrects two minor typos in the `compiler/src/typed/parmatch.re` file:
- The word "fonction" has been corrected to "function" in a comment describing compatibility functions.
- The word "partitionned" has been corrected to "partitioned" in a comment within the `every_satisfiables` function.

