### PR TITLE
fix(compiler): Correct type printing of `type A<a> = a`

### DIFF
--- a/compiler/src/typed/oprint.re
+++ b/compiler/src/typed/oprint.re
@@ -676,7 +676,7 @@ and print_out_sig_item = ppf =>
         | Otyp_manifest(_, original_type) => resolve_kwd(original_type)
         | Otyp_object(_, _) => failwith("NYI: Otyp_object pretty-printer")
         | Otyp_stuff(_) => failwith("NYI: Otyp_stuff pretty-printer")
-        | Otyp_var(_, _) => failwith("NYI: Otyp_var pretty-printer")
+        | Otyp_var(ng, s) => "type"
         | Otyp_poly(_, _) => failwith("NYI: Otyp_poly pretty-printer")
         | Otyp_module(_, _, _) => failwith("NYI: Otyp_module pretty-printer")
         | Otyp_attribute(_, _) =>


### PR DESCRIPTION
Previously if you had the line `type A<a> = a` it would cause the lsp to crash as we didn't handle the case of `= a` in oprint, this corrects the implementation to prevent the crash.

I am slightly wondering if we should even allow this behaviour. I came across this behaviour with low level grain bassically taking advantage of it to create a completely abstract type and am only submitting a fix because nothing prevents a user from doing it currently however I don't really see any real world use case for this syntax. 