### PR TITLE
chore(compiler): Cleanup legacy cmi handling

### DIFF
--- a/compiler/src/typed/cmi_format.rei
+++ b/compiler/src/typed/cmi_format.rei
@@ -41,9 +41,6 @@ let config_sum: unit => string;
 
 let build_crc: (~name: string, Types.signature) => Digest.t;
 
-/* write the magic + the cmi information */
-let serialize_cmi: cmi_infos => bytes;
-
 /* read a cmi from a filename, checking the magic */
 let read_cmi: string => cmi_infos;
 

--- a/compiler/src/utils/char_utils.re
+++ b/compiler/src/utils/char_utils.re
@@ -1,3 +1,0 @@
-// Based on BatChar
-let is_uppercase_letter = c => 'A' <= c && c <= 'Z';
-let is_lowercase_letter = c => 'a' <= c && c <= 'z';

--- a/compiler/src/utils/wasm_utils.rei
+++ b/compiler/src/utils/wasm_utils.rei
@@ -30,15 +30,6 @@ type wasm_bin_section = {
   size: int,
 };
 
-[@deriving sexp]
-type abi_version = {
-  major: int,
-  minor: int,
-  patch: int,
-};
-
-let latest_abi: abi_version;
-
 let read_leb128_i32: (unit => int) => int32;
 let read_leb128_i32_input: in_channel => int32;
 
@@ -52,29 +43,3 @@ let read_leb128_u64: (unit => int) => int64;
 let read_leb128_u64_input: in_channel => int64;
 
 let get_wasm_sections: (~reset: bool=?, in_channel) => list(wasm_bin_section);
-
-module type BinarySectionSpec = {
-  type t;
-
-  let name: string;
-  let deserialize: (in_channel, int) => t;
-  let accepts_version: abi_version => bool;
-  let serialize: t => bytes;
-};
-
-module type BinarySectionSig = {
-  type t;
-
-  /** Loads the first instance of this section from the WASM module
-      loaded at the given [in_channel]. */
-  /** Serializes this section at the current position in the given [out_channel]. */
-
-  let load: (~preserve: bool=?, in_channel) => option(t);
-
-  /** Serializes this section at the current position in the given [out_channel]. */
-
-  let serialize: t => bytes;
-};
-
-module BinarySection:
-  (Spec: BinarySectionSpec) => BinarySectionSig with type t = Spec.t;


### PR DESCRIPTION
I noticed that we still had the legacy cmi tooling in `wasm_utils` with the switch to object files this is no longer needed.