### PR TITLE
feat(lsp): Add submodule information to module hover

### DIFF
--- a/compiler/src/diagnostics/modules.re
+++ b/compiler/src/diagnostics/modules.re
@@ -6,7 +6,8 @@ type export_kind =
   | Record
   | Enum
   | Abstract
-  | Exception;
+  | Exception
+  | Module;
 
 type export = {
   name: string,
@@ -33,31 +34,38 @@ let rec get_provides = (md: Types.module_declaration) =>
               kind: Value,
               signature: Printtyp.string_of_value_description(~ident, vd),
             })
-          | TSigType(ident, {type_kind: TDataRecord(_), _} as td, recstatus) =>
+          | TSigType(ident, {type_kind: TDataRecord(_), _} as td, _) =>
             Some({
               name: ident.name,
               kind: Record,
               signature: Printtyp.string_of_type_declaration(~ident, td),
             })
-          | TSigType(ident, {type_kind: TDataVariant(_), _} as td, recstatus) =>
+          | TSigType(ident, {type_kind: TDataVariant(_), _} as td, _) =>
             Some({
               name: ident.name,
               kind: Enum,
               signature: Printtyp.string_of_type_declaration(~ident, td),
             })
-          | TSigType(ident, {type_kind: TDataAbstract, _} as td, recstatus) =>
+          | TSigType(ident, {type_kind: TDataAbstract, _} as td, _) =>
             Some({
               name: ident.name,
               kind: Abstract,
               signature: Printtyp.string_of_type_declaration(~ident, td),
             })
-          | TSigType(ident, {type_kind: TDataOpen, _} as td, recstatus) =>
+          | TSigType(ident, {type_kind: TDataOpen, _} as td, _) =>
             Some({
               name: ident.name,
               kind: Exception, // Currently we only use TDataOpen for exceptions
               signature: Printtyp.string_of_type_declaration(~ident, td),
             })
-          | _ => None
+          | TSigModule(ident, {md_type}, _) =>
+            Some({
+              name: ident.name,
+              kind: Module,
+              signature: ident.name,
+            })
+          | TSigModType(_, _)
+          | TSigTypeExt(_, _, _) => None
           }
         },
         sigs,

--- a/compiler/src/language_server/hover.re
+++ b/compiler/src/language_server/hover.re
@@ -99,6 +99,7 @@ let module_lens = (decl: Types.module_declaration) => {
         | Enum
         | Abstract
         | Exception => v.signature
+        | Module => Format.sprintf("module %s", v.signature)
         },
       vals,
     );

--- a/compiler/test/suites/grainlsp.re
+++ b/compiler/test/suites/grainlsp.re
@@ -632,6 +632,40 @@ module B {
   );
 
   assertLspOutput(
+    "hover_submodule",
+    "file:///a.gr",
+    {|module A
+module B {
+  provide let a = 1
+  provide let b = 2
+  let c = 3
+  provide module C {
+    provide let d = 4
+  }
+}
+|},
+    lsp_input(
+      "textDocument/hover",
+      lsp_text_document_position("file:///a.gr", 1, 0),
+    ),
+    `Assoc([
+      (
+        "contents",
+        `Assoc([
+          ("kind", `String("markdown")),
+          (
+            "value",
+            `String(
+              "```grain\nlet a: Number\nlet b: Number\nmodule C\n```\n\n",
+            ),
+          ),
+        ]),
+      ),
+      ("range", lsp_range((1, 0), (8, 1))),
+    ]),
+  );
+
+  assertLspOutput(
     "hover_include",
     make_test_utils_uri("a.gr"),
     {|module A


### PR DESCRIPTION
<img width="509" height="299" alt="Screenshot 2025-09-08 at 3 00 15 PM" src="https://github.com/user-attachments/assets/7ceb02b3-654a-43a0-a932-e3157fe3068e" />

Small pr adding the provided submodules to module hover.

I was wondering separately if we should change the way sourcetree works slightly so in cases like `Stream.G|et.char` with `|` being the cursor it returns the hover for `Stream.Get` rather than the hover for the value.