### PR TITLE
chore: Pin ci to `macos-14`

### DIFF
--- a/.github/workflows/build-js.yml
+++ b/.github/workflows/build-js.yml
@@ -13,7 +13,7 @@ on:
         default: "ubuntu-latest"
         options:
           - ubuntu-latest
-          - macos-latest
+          - macos-14 # TODO(2321): Use macos-latest, after binaryen.ml upgrade
           - windows-latest
       ref:
         description: Git reference to checkout

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -13,7 +13,7 @@ on:
         default: "ubuntu-latest"
         options:
           - ubuntu-latest
-          - macos-latest
+          - macos-14 # TODO(2321): Use macos-latest, after binaryen.ml upgrade
           - windows-latest
       ref:
         description: Git reference to checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-14, windows-latest] # TODO(2321): Use macos-latest, after binaryen.ml upgrade
     uses: ./.github/workflows/build.yml
     with:
       os: ${{ matrix.os }}


### PR DESCRIPTION
Attempting to pin our current ci to `macos-14` so we can merge changes, until we fix #2321 