### PR TITLE
chore(stdlib): Simplify path types in `path` module

### DIFF
--- a/stdlib/path.gr
+++ b/stdlib/path.gr
@@ -94,35 +94,25 @@ and provide enum AbsoluteRoot {
   Drive(Char),
 }
 
-// Dummy record names put here just to distinguish the two. These could be
-// replaced with opaque types if they get added to the language
 /**
  * Represents a relative path.
  */
-abstract record Relative {
-  _rel: Void,
-}
+abstract type Relative = Void
 
 /**
  * Represents an absolute path.
  */
-abstract record Absolute {
-  _abs: Void,
-}
+abstract type Absolute = Void
 
 /**
  * Represents a path referencing a file.
  */
-abstract record File {
-  _file: Void,
-}
+abstract type File = Void
 
 /**
  * Represents a path referencing a directory.
  */
-abstract record Directory {
-  _directory: Void,
-}
+abstract type Directory = Void
 
 /**
  * Represents a path typed on (`Absolute` or `Relative`) and (`File` or


### PR DESCRIPTION
When the `path` module was originally implemented, we didn't have `abstract` types, as it was before the module system overhaul. This removes the unneeded records and simplifies them to regular abstract types.


I'm not sure if this is considered a `feat` or `chore` given the types are abstract, it's really just cleanup.