### PR TITLE
chore(admin): Streamline license attributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,4 @@ To reset your compiler build:
 npm run compiler clean
 ```
 
-Copyright ©️ 2017-2025 Philip Blair, Oscar Spencer, & contributors.
+Copyright ©️ 2017-2025 Grain Core Team, & contributors.

--- a/cli/package.json
+++ b/cli/package.json
@@ -27,7 +27,7 @@
     "grain",
     "cli"
   ],
-  "author": "Oscar Spencer",
+  "author": "Grain Core Team <team@grain-lang.org> (https://grain-lang.org)",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/grain-lang/grain/issues"

--- a/compiler/dune-project
+++ b/compiler/dune-project
@@ -7,8 +7,8 @@
 (generate_opam_files false)
 
 (license LGPL-3.0)
-(authors "Philip Blair" "Oscar Spencer")
-(maintainers "philip@grain-lang.org" "oscar@grain-lang.org")
+(authors "Grain Core Team")
+(maintainers "team@grain-lang.org")
 (source (github grain-lang/grain))
 (homepage "https://grain-lang.org")
 (documentation "https://grain-lang.org/docs/")

--- a/stdlib/LICENSE
+++ b/stdlib/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-2025 Oscar Spencer <oscar@grain-lang.org> and Philip Blair <philip@grain-lang.org>
+Copyright (c) 2017-2025 Grain Core Team <team@grain-lang.org>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This streamlines our license attribution.


We will still need to discuss this at the next core team meeting. 