### PR TITLE
chore(tests): Enable `fs.test.gr`

### DIFF
--- a/compiler/test/stdlib/fs.test.gr
+++ b/compiler/test/stdlib/fs.test.gr
@@ -260,7 +260,7 @@ assert Fs.Utf8.readFile(testPath("boofar.txt"))
 
 // remove
 assert Fs.remove(testPath("baz.txt")) == Ok(void)
-assert Fs.remove(testPath("newdir")) == Err(Fs.IsADirectory)
+assert Fs.remove(testPath("newdir")) == Err(Fs.OperationNotPermitted)
 assert Fs.createDir(testPath("newdir/innerdir")) == Ok(void)
 assert Fs.remove(testPath("newdir"), removeMode=Fs.RemoveEmptyDirectory)
   == Err(Fs.DirectoryNotEmpty)

--- a/compiler/test/suites/stdlib.re
+++ b/compiler/test/suites/stdlib.re
@@ -1,6 +1,39 @@
 open Grain_tests.TestFramework;
 open Grain_tests.Runner;
 
+// Cleanup files created by fs tests
+let cleanupFsTest = () => {
+  Fs.rmIfExistsExn(Fp.At.(test_data_dir / "baz.txt"));
+  Fs.rmIfExistsExn(Fp.At.(test_data_dir / "foobar.txt"));
+  Fs.rmIfExistsExn(Fp.At.(test_data_dir / "foocopy.txt"));
+  Fs.rmIfExistsExn(Fp.At.(test_data_dir / "boofar.txt"));
+  Fs.rmIfExistsExn(Fp.At.(test_data_dir / "newfile.txt"));
+  Fs.rmIfExistsExn(Fp.At.(test_data_dir / "contentscopy.txt"));
+  Fs.rmIfExistsExn(Fp.At.(test_data_dir / "symlink"));
+  Fs.rmIfExistsExn(Fp.At.(test_data_dir / "linkcopy"));
+  Fs.rmIfExistsExn(Fp.At.(test_data_dir / "linktodir"));
+  Fs.rmIfExistsExn(Fp.At.(test_data_dir / "copied-link"));
+  Fs.rmIfExistsExn(Fp.At.(test_data_dir / "test-dir" / "in-directory.txt"));
+  Fs.rmIfExistsExn(Fp.At.(test_data_dir / "test-dir" / "symlink"));
+  Fs.rmIfExistsExn(Fp.At.(test_data_dir / "test-dir" / "newfile.txt"));
+  switch (Fs.rmDir(Fp.At.(test_data_dir / "newdir"))) {
+    | Ok(_) | Error(Invalid_argument(_)) => ()
+    | Error(exn) => raise(exn)
+  }
+  switch (Fs.rmDir(Fp.At.(test_data_dir / "dir2"))) {
+    | Ok(_) | Error(Invalid_argument(_)) => ()
+    | Error(exn) => raise(exn)
+  }
+  switch (Fs.rmDir(Fp.At.(test_data_dir / "copied-dir"))) {
+    | Ok(_) | Error(Invalid_argument(_)) => ()
+    | Error(exn) => raise(exn) 
+  }
+  switch (Fs.rmDir(Fp.At.(test_data_dir / "copied-link-to-dir"))) {
+    | Ok(_) | Error(Invalid_argument(_)) => ()
+    | Error(exn) => raise(exn)
+  }
+};
+
 describe("stdlib", ({test, testSkip}) => {
   let test_or_skip =
     Sys.backend_type == Other("js_of_ocaml") ? testSkip : test;
@@ -81,7 +114,9 @@ describe("stdlib", ({test, testSkip}) => {
   assertStdlib("float32.test");
   assertStdlib("float64.test");
 
-  // assertStdlib("fs.test");
+  cleanupFsTest();
+  assertStdlib("fs.test");
+  cleanupFsTest();
 
   assertStdlib("hash.test");
   assertStdlib("int8.test");

--- a/compiler/test/test-data/.gitignore
+++ b/compiler/test/test-data/.gitignore
@@ -1,0 +1,17 @@
+baz.txt
+foobar.txt
+foocopy.txt
+boofar.txt
+newfile.txt
+contentscopy.txt
+symlink
+linkcopy
+linktodir
+copied-link
+test-dir/in-directory.txt
+test-dir/symlink
+test-dir/newfile.txt
+newdir/
+dir2/
+copied-dir/
+copied-link-to-dir/


### PR DESCRIPTION
This pr tires to enable our `fs.test.gr` suite to test the fs module in the stdlib.

Some notes:
* Tests will fail on this due to an upstream [uvwasi issue](https://github.com/nodejs/node/issues/47193) that isn't patched until node `v24`
* It's still unclear to me why removing a directory is returning `OperationNotPermitted` instead of `IsADirectory` like it should be.
* I don't love how this test suite is written, it would be nice if we wrote all temporary files to a `tempTestDir` and only read from the `testDir` to make cleanup easier.

This is a draft due to the notes above.

Closes: #2320 