### PR TITLE
fix(grainfmt): Correct formatting of single arc function callback

### DIFF
--- a/compiler/src/formatting/fmt.re
+++ b/compiler/src/formatting/fmt.re
@@ -2723,11 +2723,7 @@ let print_type = (fmt, {ptyp_desc, ptyp_loc}) => {
       [
         {
           ptyp_arg_label: Unlabeled,
-          ptyp_arg_type:
-            {
-              ptyp_desc:
-                PTyAny | PTyVar(_) | PTyArrow(_, _) | PTyConstr(_, []),
-            },
+          ptyp_arg_type: {ptyp_desc: PTyAny | PTyVar(_) | PTyConstr(_, [])},
         } as param,
       ],
       return,

--- a/compiler/test/grainfmt/function_params.expected.gr
+++ b/compiler/test/grainfmt/function_params.expected.gr
@@ -20,7 +20,7 @@ let lots_of_args = (
   verylonglong2,
   verylonglong3,
   verylonglong4,
-  verylonglong1,
+  verylonglong5,
 ) => {
   print("lots of args")
 }
@@ -41,3 +41,5 @@ let stringTailMatcher = (toMatch, len) =>
 let f: Number => (Number, Number) => Number = a => (b, c) => a + b + c
 
 let namedArg: (?suffix: String) => String = (suffix="") => suffix
+
+type T<a, b, c, d> = ((a => b) => c) => d

--- a/compiler/test/grainfmt/function_params.input.gr
+++ b/compiler/test/grainfmt/function_params.input.gr
@@ -16,7 +16,7 @@ provide let fake_write: (int, int, int, string) => string =
   "ok"
 }
 
-let lots_of_args = (verylonglong1,verylonglong2,verylonglong3,verylonglong4,verylonglong1) => {
+let lots_of_args = (verylonglong1,verylonglong2,verylonglong3,verylonglong4,verylonglong5) => {
   print("lots of args")
 }
 
@@ -36,3 +36,6 @@ let stringTailMatcher =  (toMatch, len) =>
 let f: Number => (Number, Number) => Number = a => (b, c) => a + b + c
 
 let namedArg: (?suffix: String) => String = (suffix="") => suffix
+
+
+type T<a, b, c, d> = ((a => b) => c) => d


### PR DESCRIPTION
I noticed that `type T = (a => b) => c` was being formatted to `type T = a => b => c` the formatter was seeing a single arugment and stripping the parameters however those are two completely different functions in grain as that is actually interpreted as `type T = a => (b => c)`.

In order to fix this we simply don't strip the parenthesis on function types that accept a single function as their argument.

Notes:
* I changed the parameter name in the tests of another function just so the module validates properly.