### PR TITLE
fix(grainfmt): Correct formatting of record assignments

### DIFF
--- a/compiler/test/grainfmt/application2.expected.gr
+++ b/compiler/test/grainfmt/application2.expected.gr
@@ -63,3 +63,11 @@ record Foo {
 }
 let foo = { idx: 1, }
 foo.idx += 2
+foo.idx += 2
+
+record Nested {
+  x: Foo,
+}
+let nested = { x: { idx: 1, }, }
+nested.x.idx += 2
+nested.x.idx += 2

--- a/compiler/test/grainfmt/application2.input.gr
+++ b/compiler/test/grainfmt/application2.input.gr
@@ -48,4 +48,6 @@ let makePrettyPrintJSONWriter = String.forEachCodePoint(c => {
   void
 }, "")
 
-record Foo { mut idx: Number }; let foo = { idx: 1 }; foo.idx += 2
+record Foo { mut idx: Number }; let foo = { idx: 1 }; foo.idx += 2; foo.idx = foo.idx + 2;
+
+record Nested { x: Foo }; let nested = { x: { idx: 1 } }; nested.x.idx += 2; nested.x.idx = nested.x.idx + 2;


### PR DESCRIPTION
I noticed that `at.y.x += 10` was being formatted as `at.y.x = at.y.x + 10` this was because we only checked one level deep on record assignments. While fixing this I also noticed that we compared the identifier directly on patterns such as `at.y += 10` which means that `at.y += 10` gets formatted as `at.y += 10` however `at.y = at.y + 10` doesn't get collapsed due to the locations on the identifier differing.

Closes: #2343