### PR TITLE
chore(compiler): Remove unused filename and other general cleanup

### DIFF
--- a/compiler/src/typed/env.re
+++ b/compiler/src/typed/env.re
@@ -2259,7 +2259,7 @@ let imports = () => {
 
 /* Build a module signature */
 let build_signature_with_imports =
-    (~deprecated=?, sg, modname, filename, imports, type_metadata) => {
+    (~deprecated=?, sg, modname, imports, type_metadata) => {
   Btype.cleanup_abbrev();
   let sg =
     Subst.with_reset_state(() =>
@@ -2304,12 +2304,11 @@ let add_cmi_to_persistent_structures = (filename, cmi) => {
   save_pers_struct(ps);
 };
 
-let build_signature = (~deprecated=?, sg, modname, filename, type_metadata) =>
+let build_signature = (~deprecated=?, sg, modname, type_metadata) =>
   build_signature_with_imports(
     ~deprecated?,
     sg,
     modname,
-    filename,
     imports(),
     type_metadata,
   );

--- a/compiler/src/typed/env.rei
+++ b/compiler/src/typed/env.rei
@@ -175,20 +175,13 @@ let use_full_signature_of_initially_included_module: (Path.t, t) => t;
 
 /* Arguments: module name, file name. Results: signature. */
 let build_signature:
-  (
-    ~deprecated: string=?,
-    signature,
-    string,
-    string,
-    Cmi_format.cmi_type_metadata
-  ) =>
+  (~deprecated: string=?, signature, string, Cmi_format.cmi_type_metadata) =>
   Cmi_format.cmi_infos;
 /* Arguments: signature, module name, file name. */
 let build_signature_with_imports:
   (
     ~deprecated: string=?,
     signature,
-    string,
     string,
     list((string, Digest.t)),
     Cmi_format.cmi_type_metadata

--- a/compiler/src/typed/typecore.re
+++ b/compiler/src/typed/typecore.re
@@ -2236,16 +2236,6 @@ and type_statement_expr = (~explanation=?, ~in_function=?, env, sexp) => {
     with_explanation(explanation, () => unify_exp(env, exp, expected_ty));
     exp;
   } else {
-    switch (ty.desc) {
-    /*| Tarrow _ -> [not really applicable with our syntax]
-      Location.prerr_warning loc Warnings.Partial_application*/
-    | TTyConstr(p, _, _) when Path.same(p, Builtin_types.path_void) => ()
-    /*| Tvar _ ->
-      add_delayed_check (fun () -> check_application_result env true exp)*/
-    | _ => ()
-    /* This isn't quite relevant to Grain mechanics
-       Location.prerr_warning loc Grain_utils.Warnings.StatementType */
-    };
     unify_var(env, tv, ty);
     exp;
   };
@@ -2514,15 +2504,13 @@ and type_let =
   let exp_env =
     if (is_recursive) {
       new_env;
-    } else if (!is_recursive) {
+    } else {
       /* add ghost bindings to help detecting missing "rec" keywords */
       switch (spat_sexp_list) {
       | [{pvb_loc, _}, ..._] =>
         maybe_add_pattern_variables_ghost(pvb_loc, env, pv)
       | _ => assert(false)
       };
-    } else {
-      env;
     };
   let current_slot = ref(None);
   /*let rec_needed = ref false in*/

--- a/compiler/src/typed/typemod.re
+++ b/compiler/src/typed/typemod.re
@@ -1100,7 +1100,6 @@ let type_implementation = (prog: Parsetree.parsed_program) => {
   let initenv = initial_env();
   let (statements, sg, finalenv) = type_module(initenv, prog.statements);
   let simple_sg = simplify_signature(sg);
-  let filename = sourcefile; // TODO(#1396): Don't use filepath as filename
 
   check_nongen_schemes(finalenv, simple_sg);
   let normalized_sig = normalize_signature(finalenv, simple_sg);
@@ -1112,7 +1111,7 @@ let type_implementation = (prog: Parsetree.parsed_program) => {
       ctm_offsets_tbl: [],
     };
   let signature =
-    Env.build_signature(normalized_sig, module_name, filename, type_metadata);
+    Env.build_signature(normalized_sig, module_name, type_metadata);
   {
     module_name: prog.module_name,
     statements,


### PR DESCRIPTION
Some more cleanup of legacy code throughout the codebase.

The changes in `typecore.re` removes a short ciruit and a match that was doing nothing as both paths returned unit and have no side effects. 

Closes: #1396

I'm pretty sure we started using the module name over the filename with either the object file rewrite or module system rewrite this pr just removes the argument that wasn't being consumed anywhere.