### PR TITLE
feat(compiler): Support raising multiple well formedness errors.

### DIFF
--- a/compiler/src/parsing/well_formedness.re
+++ b/compiler/src/parsing/well_formedness.re
@@ -917,6 +917,13 @@ let check_well_formedness = program => {
 
   Parsetree_iter.iter_parsed_program(iter_hooks, program);
 
-  // TODO(#1503): We should be able to raise _all_ errors at once
-  List.iter(e => raise(Error(e)), errs^);
+  switch (errs^) {
+  | [final, ...rest] =>
+    List.iter(
+      e => Location.report_exception(Format.err_formatter, Error(e)),
+      rest,
+    );
+    raise(Error(final));
+  | [] => ()
+  };
 };


### PR DESCRIPTION
This pr allows us to print multiple well-formedness errors at once as can be seen in the screenshot below, the old behaviour was to just print the final error.
<img width="1582" height="945" alt="Screenshot 2026-01-23 at 3 31 21 PM" src="https://github.com/user-attachments/assets/dba9ea77-fe64-4ece-8037-a097d978274e" />


As can also be seen in the screenshot this pr does not handle emitting multiple errors in the lsp, that would require some refactoring in how we handle errors we would need to either keep a list of the errors that have been raised or throw something like `Error([])` and then handle it in the error handler but this isn't exactly trivial from my understanding of the error handler. I figure we should handle that in another pr and open an issue for it now.

Closes #1503,