### PR TITLE
fix(compiler)!: Correct constructors incorrectly being brought in scope

### DIFF
--- a/compiler/src/typed/disambiguation.re
+++ b/compiler/src/typed/disambiguation.re
@@ -136,6 +136,7 @@ module NameChoice =
         ~warn=Location.prerr_warning,
         ~check_lk=(_, _) => (),
         ~scope=?,
+        ~scoped=false,
         lid,
         env,
         opath,
@@ -206,25 +207,33 @@ module NameChoice =
           lbl;
         }) {
         | Not_found =>
-          try({
-            let lbl = lookup_from_type(env, tpath, lid);
-            check_lk(tpath, lbl);
-            if (in_env(lbl)) {
-              let s = Printtyp.string_of_path(tpath);
-              warn(
-                lid.loc,
-                Warnings.NameOutOfScope(
-                  s,
-                  [Identifier.last(lid.txt)],
-                  false,
-                ),
-              );
-            };
-            if (!pr) {
-              warn_pr();
-            };
-            lbl;
-          }) {
+          try(
+            {
+              if (scoped) {
+                // When scoped skip looking up directly from the type
+                raise(
+                  Not_found,
+                );
+              };
+              let lbl = lookup_from_type(env, tpath, lid);
+              check_lk(tpath, lbl);
+              if (in_env(lbl)) {
+                let s = Printtyp.string_of_path(tpath);
+                warn(
+                  lid.loc,
+                  Warnings.NameOutOfScope(
+                    s,
+                    [Identifier.last(lid.txt)],
+                    false,
+                  ),
+                );
+              };
+              if (!pr) {
+                warn_pr();
+              };
+              lbl;
+            }
+          ) {
           | Not_found =>
             if (lbls == []) {
               unbound_name_error(env, lid);

--- a/compiler/src/typed/typecore.re
+++ b/compiler/src/typed/typecore.re
@@ -2104,7 +2104,7 @@ and type_construct =
     wrap_disambiguate(
       "This variant expression is expected to have",
       ty_expected_explained,
-      Constructor.disambiguate(lid, env, opath),
+      Constructor.disambiguate(~scoped=true, lid, env, opath),
       constrs,
     );
   let is_record_cstr_def = constr.cstr_inlined != None;

--- a/compiler/src/typed/typepat.re
+++ b/compiler/src/typed/typepat.re
@@ -883,7 +883,7 @@ and type_pat_aux =
       wrap_disambiguate(
         "This variant pattern is expected to have",
         mk_expected(expected_ty),
-        Constructor.disambiguate(lid, env^, opath),
+        Constructor.disambiguate(~scoped=true, lid, env^, opath),
         candidates,
       );
 


### PR DESCRIPTION
This pr corrects a bug where module values were incorrectly being brought into scope.

If we had a function such as `x: (a, a) => void` then in a case like `x(A.VariantA, VariantB)` the typechecker would lookup the second value through the of `a` when disambiguating causing constructors to be brought into scope incorrectly. This also fixes a very simialr issue with pattern matching.

The fix I chose is minimally invasive; we just skip the scope-based lookup when disambiguating in certain places. We still want the scope and type logic to exist for other cases like inference, which is why it's left alone. 


NOTE: I'm not sure if we consider this a breaking fix or not; some invalid code that previously would compile now won't. 

Closes: #1968 