### PR TITLE
feat(compiler): Provide a user friendly error on `_start` override

### DIFF
--- a/compiler/grainc/grainc.re
+++ b/compiler/grainc/grainc.re
@@ -93,7 +93,7 @@ let grainc = (single_file_mode, name, outfile) => {
         Option.value(~default=Compile.default_wasm_filename(name), outfile);
       let dependencies = Module_resolution.get_dependencies();
 
-      Link.link(~main_object, ~outfile, dependencies);
+      error_wrapped(() => Link.link(~main_object, ~outfile, dependencies));
     };
   };
 

--- a/compiler/test/runner.re
+++ b/compiler/test/runner.re
@@ -349,14 +349,14 @@ let makeSnapshotFileRunner = (test, ~config_fn=?, name, filename) => {
 };
 
 let makeCompileErrorRunner =
-    (test, ~module_header=module_header, name, prog, msg) => {
+    (test, ~module_header=module_header, ~link=false, name, prog, msg) => {
   test(
     name,
     ({expect}) => {
       let error =
         try(
           {
-            ignore @@ compile(name, module_header ++ prog);
+            ignore @@ compile(~link, name, module_header ++ prog);
             "";
           }
         ) {

--- a/compiler/test/suites/provides.re
+++ b/compiler/test/suites/provides.re
@@ -222,6 +222,15 @@ describe("provides", ({test, testSkip}) => {
     [("_start", Binaryen.Export.external_function)],
   );
 
+  assertCompileError(
+    ~link=true,
+    "provide_start_function_invalid",
+    {|
+      provide let _start = () => void
+    |},
+    "The export `_start` is only allowed when compiling with `--use-start-section`.",
+  );
+
   assertHasWasmExport(
     "issue_918_annotated_func_provide",
     "module Test; provide let foo: () => Number = () => 5",


### PR DESCRIPTION
This pr provides a nice error in cases where a user overrides `_start` without compiling using `--use-start-section`. Previously binaryen would throw an error because we try to export `_start` twice once for the user's export and once for the actual module start, this error however wasn't very informative and didn't explain to the user how to fix the problem.

Note:
* I'm not 100% sure the language I used in this error is the best I tried to avoid mentioning how wasi uses `_start` which is the reason for the problem as I think that raises more questions than answers.
* Despite the error not fully describing why this is a problem, I think it's still a major improvement on what we had before as it tells them where the problematic function is and how to fix it.

Closes: #2273