### PR TITLE
feat(compiler): Test typemetadata size

### DIFF
--- a/compiler/test/suites/basic_functionality.re
+++ b/compiler/test/suites/basic_functionality.re
@@ -13,14 +13,19 @@ describe("basic functionality", ({test, testSkip}) => {
   let assertParse = makeParseRunner(test);
   let assertRun = makeRunner(test_or_skip);
   let assertRunError = makeErrorRunner(test_or_skip);
-  let assertTypeMetaDataSize = (name, prog, expectedSize) => {
+  let assertTypeMetaDataSize =
+      (~elide_type_info=false, name, prog, expectedSize) => {
     test(
       name,
       ({expect}) => {
         ignore(
           compile(
             ~link=true,
-            ~config_fn=() => {Grain_utils.Config.compilation_mode := Runtime},
+            ~config_fn=
+              () => {
+                Grain_utils.Config.compilation_mode := Runtime;
+                Grain_utils.Config.elide_type_info := elide_type_info;
+              },
             name,
             prog,
           ),
@@ -34,10 +39,15 @@ describe("basic functionality", ({test, testSkip}) => {
           bytes;
         };
         let asm = Binaryen.Module.read(bytes);
-        let type_metadata =
-          Binaryen.Memory.get_segment_data(asm, "type_metadata");
-        let type_metadata_size = Bytes.length(type_metadata);
-        expect.int(type_metadata_size).toBe(expectedSize);
+        // TODO(#2358): Binaryen Validate the given memory segment exists
+        if (Binaryen.Memory.get_num_segments(asm) > 0) {
+          let type_metadata =
+            Binaryen.Memory.get_segment_data(asm, "type_metadata");
+          let type_metadata_size = Bytes.length(type_metadata);
+          expect.int(type_metadata_size).toBe(expectedSize);
+        } else {
+          expect.int(-1).toBe(expectedSize);
+        };
       },
     );
   };
@@ -422,6 +432,57 @@ describe("basic functionality", ({test, testSkip}) => {
       module Main
     |},
     32,
+  );
+
+  assertTypeMetaDataSize(
+    ~elide_type_info=true,
+    "type_metadata_base_size_no_type_info",
+    {|
+      @runtimeMode
+      module Main
+    |},
+    -1,
+  );
+
+  assertTypeMetaDataSize(
+    "type_metadata_size",
+    {|
+      @runtimeMode
+      module Main
+
+      record Test {
+        field1: Bool,
+        field2: Bool
+      }
+
+      enum T {
+        One,
+        Two,
+        Three
+      }
+    |},
+    168,
+  );
+
+  assertTypeMetaDataSize(
+    ~elide_type_info=true,
+    "type_metadata_size_no_type_info",
+    {|
+      @runtimeMode
+      module Main
+
+      record Test {
+        field1: Bool,
+        field2: Bool
+      }
+
+      enum T {
+        One,
+        Two,
+        Three
+      }
+    |},
+    -1,
   );
 
   assertFilesize(


### PR DESCRIPTION
This pr tests the base typemetadata size in runtimeMode avoiding changes from modifications to the runtime or pervasives.

Note:
* I'm pretty sure this is a feat because we are adding a test though it may be a chore.

Closes: #1834 