### PR TITLE
feat(lsp): Support displaying multiple errors in the lsp

### DIFF
--- a/compiler/src/compile.re
+++ b/compiler/src/compile.re
@@ -244,7 +244,7 @@ let compile_wasi_polyfill = () => {
 
 let reset_compiler_state = () => {
   Driver.reset();
-  Location.reset_exns();
+  Location.reset_exceptions();
   Ident.setup();
   Ctype.reset_levels();
   Env.clear_persistent_structures();

--- a/compiler/src/language_server/code_file.re
+++ b/compiler/src/language_server/code_file.re
@@ -142,7 +142,7 @@ let compile_source = (uri, source) => {
             }
           }
         },
-        [exn, ...Grain_parsing.Location.reported_exns^],
+        [exn, ...Grain_parsing.Location.reported_exceptions^],
       );
     {
       program: None,

--- a/compiler/src/parsing/location.re
+++ b/compiler/src/parsing/location.re
@@ -594,11 +594,11 @@ let () =
 
 external reraise: exn => 'a = "%reraise";
 
-let reported_exns = ref([]);
-let reset_exns = () => reported_exns := [];
+let reported_exceptions = ref([]);
+let reset_exceptions = () => reported_exceptions := [];
 
 let rec report_exception = (ppf, exn) => {
-  reported_exns := [exn, ...reported_exns^];
+  reported_exceptions := [exn, ...reported_exceptions^];
   let rec loop = (n, exn) =>
     switch (error_of_exn(exn)) {
     | None => reraise(exn)

--- a/compiler/src/parsing/location.rei
+++ b/compiler/src/parsing/location.rei
@@ -137,9 +137,9 @@ let error_of_printer: (t, (formatter, 'a) => unit, 'a) => error;
 
 let error_of_printer_file: ((formatter, 'a) => unit, 'a) => error;
 
-let reported_exns: ref(list(exn));
+let reported_exceptions: ref(list(exn));
 
-let reset_exns: unit => unit;
+let reset_exceptions: unit => unit;
 
 let error_of_exn:
   exn =>


### PR DESCRIPTION
This pr adds support for displaying multiple well formedness errors in the lsp, this is a follow up pr to #2348. The way I implemented this was to keep a list of all reported errors and then we can go through the list when one is raised. I think whenever we complete #2342 we may want to streamline the error tracking api a little to handle this better but this should work as a good solution for now.

Demo Screenshot:
<img width="1582" height="945" alt="Screenshot 2026-02-05 at 2 38 58 PM" src="https://github.com/user-attachments/assets/e425af6b-44bd-44bf-b4ae-309522810333" />

Closes: #2353