### PR TITLE
fix(stdlib): correct the behavior of float pow opperations

### DIFF
--- a/compiler/test/stdlib/float32.test.gr
+++ b/compiler/test/stdlib/float32.test.gr
@@ -80,8 +80,8 @@ assert 0.0f ** 3.0f == 0.0f
 assert 0.0f ** 2.0f == 0.0f
 assert 0.0f ** 1.0f == 0.0f
 assert 0.0f ** 0.5f == 0.0f
-assert Float32.isNaN(0.0f ** 0.0f)
-assert Float32.isNaN(0.0f ** -0.0f)
+assert 0.0f ** 0.0f == 1.0f
+assert 0.0f ** -0.0f == 1.0f
 assert 0.0f ** -0.5f == Infinityf
 assert 0.0f ** -1.0f == Infinityf
 assert 0.0f ** -Infinityf == Infinityf
@@ -89,21 +89,21 @@ assert Float32.isNaN(-0.0f ** NaNf)
 assert -0.0f ** Infinityf == 0.0f
 assert -0.0f ** 3.0f == -0.0f
 assert -0.0f ** 0.5f == 0.0f
-assert Float32.isNaN(-0.0f ** 0.0f)
-assert Float32.isNaN(-0.0f ** -0.0f)
+assert -0.0f ** 0.0f == 1.0f
+assert -0.0f ** -0.0f == 1.0f
 assert -0.0f ** -0.5f == Infinityf
 assert -0.0f ** -1.0f == -Infinityf
 assert -0.0f ** -2.0f == Infinityf
 assert -0.0f ** -3.0f == -Infinityf
 assert -0.0f ** -4.0f == Infinityf
 assert -0.0f ** -Infinityf == Infinityf
-assert Float32.isNaN(NaNf ** 0.0f)
-assert Float32.isNaN(Infinityf ** 0.0f)
-assert Float32.isNaN(-Infinityf ** 0.0f)
-assert Float32.isNaN(1.0f ** 0.0f)
-assert Float32.isNaN(-1.0f ** 0.0f)
-assert Float32.isNaN(-0.5f ** 0.0f)
-assert Float32.isNaN(NaNf ** -0.0f)
+assert NaNf ** 0.0f == 1.0f
+assert Infinityf ** 0.0f == 1.0f
+assert -Infinityf ** 0.0f == 1.0f
+assert 1.0f ** 0.0f == 1.0f
+assert -1.0f ** 0.0f == 1.0f
+assert -0.5f ** 0.0f == 1.0f
+assert NaNf ** -0.0f == 1.0f
 assert 300.0f ** 1.0f == 300.0f
 
 assert 5.0f > 4.0f

--- a/compiler/test/stdlib/float64.test.gr
+++ b/compiler/test/stdlib/float64.test.gr
@@ -92,8 +92,8 @@ assert 0.0d ** 3.0d == 0.0d
 assert 0.0d ** 2.0d == 0.0d
 assert 0.0d ** 1.0d == 0.0d
 assert 0.0d ** 0.5d == 0.0d
-assert Float64.isNaN(0.0d ** 0.0d)
-assert Float64.isNaN(0.0d ** -0.0d)
+assert 0.0d ** 0.0d == 1.0d
+assert 0.0d ** -0.0d == 1.0d
 assert 0.0d ** -0.5d == Infinityd
 assert 0.0d ** -1.0d == Infinityd
 assert 0.0d ** -Infinityd == Infinityd
@@ -101,21 +101,21 @@ assert Float64.isNaN(-0.0d ** NaNd)
 assert -0.0d ** Infinityd == 0.0d
 assert -0.0d ** 3.0d == -0.0d
 assert -0.0d ** 0.5d == 0.0d
-assert Float64.isNaN(-0.0d ** 0.0d)
-assert Float64.isNaN(-0.0d ** -0.0d)
+assert -0.0d ** 0.0d == 1.0d
+assert -0.0d ** -0.0d == 1.0d
 assert -0.0d ** -0.5d == Infinityd
 assert -0.0d ** -1.0d == -Infinityd
 assert -0.0d ** -2.0d == Infinityd
 assert -0.0d ** -3.0d == -Infinityd
 assert -0.0d ** -4.0d == Infinityd
 assert -0.0d ** -Infinityd == Infinityd
-assert Float64.isNaN(NaNd ** 0.0d)
-assert Float64.isNaN(Infinityd ** 0.0d)
-assert Float64.isNaN(-Infinityd ** 0.0d)
-assert Float64.isNaN(1.0d ** 0.0d)
-assert Float64.isNaN(-1.0d ** 0.0d)
-assert Float64.isNaN(-0.5d ** 0.0d)
-assert Float64.isNaN(NaNd ** -0.0d)
+assert NaNd ** 0.0d == 1.0d
+assert Infinityd ** 0.0d == 1.0d
+assert -Infinityd ** 0.0d == 1.0d
+assert 1.0d ** 0.0d == 1.0d
+assert -1.0d ** 0.0d == 1.0d
+assert -0.5d ** 0.0d == 1.0d
+assert NaNd ** -0.0d == 1.0d
 assert 300.0d ** 1.0d == 300.0d
 
 assert 5.0d > 4.0d

--- a/compiler/test/stdlib/number.test.gr
+++ b/compiler/test/stdlib/number.test.gr
@@ -122,8 +122,8 @@ assert 0.0 ** 3.0 == 0.0
 assert 0.0 ** 2.0 == 0.0
 assert 0.0 ** 1.0 == 0.0
 assert 0.0 ** 0.5 == 0.0
-assert Number.isNaN(0.0 ** 0.0)
-assert Number.isNaN(0.0 ** -0.0)
+assert 0.0 ** 0.0 == 1.0
+assert 0.0 ** -0.0 == 1.0
 assert 0.0 ** -0.5 == Infinity
 assert 0.0 ** -1.0 == Infinity
 assert 0.0 ** -2.0 == Infinity
@@ -136,21 +136,21 @@ assert -0.0 ** 3.0 == -0.0
 assert -0.0 ** 2.0 == 0.0
 assert -0.0 ** 1.0 == -0.0
 assert -0.0 ** 0.5 == 0.0
-assert Number.isNaN(-0.0 ** 0.0)
-assert Number.isNaN(-0.0 ** -0.0)
+assert -0.0 ** 0.0 == 1.0
+assert -0.0 ** -0.0 == 1.0
 assert -0.0 ** -0.5 == Infinity
 assert -0.0 ** -1.0 == -Infinity
 assert -0.0 ** -2.0 == Infinity
 assert -0.0 ** -3.0 == -Infinity
 assert -0.0 ** -4.0 == Infinity
 assert -0.0 ** -Infinity == Infinity
-assert Number.isNaN(NaN ** 0.0)
-assert Number.isNaN(Infinity ** 0.0)
-assert Number.isNaN(-Infinity ** 0.0)
-assert Number.isNaN(1.0 ** 0.0)
-assert Number.isNaN(-1.0 ** 0.0)
-assert Number.isNaN(-0.5 ** 0.0)
-assert Number.isNaN(NaN ** -0.0)
+assert NaN ** 0.0 == 1.0
+assert Infinity ** 0.0 == 1.0
+assert -Infinity ** 0.0 == 1.0
+assert 1.0 ** 0.0 == 1.0
+assert -1.0 ** 0.0 == 1.0
+assert -0.5 ** 0.0 == 1.0
+assert NaN ** -0.0 == 1.0
 assert 1 ** 1 == 1
 assert 2 ** 1 == 2
 assert 300 ** 1 == 300
@@ -172,8 +172,8 @@ assert -1 ** 1.0 == -1.0
 assert -2.0 ** 1 == -2.0
 assert -300 ** 1.0 == -300.0
 assert 0.0 ** 1 == 0.0
-assert Number.isNaN(1 ** 0.0)
-assert Number.isNaN(0.0 ** 0)
+assert 1.0 ** 0.0 == 1.0
+assert 0.0 ** 0 == 1.0
 assert 1 ** 5.0 == 1.0
 assert 5.0 ** 5 == 3125.0
 assert -1.0 ** 1 == -1.0

--- a/stdlib/runtime/numbers.gr
+++ b/stdlib/runtime/numbers.gr
@@ -2943,7 +2943,7 @@ provide let powf = (x: WasmF64, y: WasmF64) => {
     } else if (y == 1.0W) {
       return x
     } else if (y == 0.0W) {
-      return NaNW
+      return 1.0W
     }
   }
   // Full calculation


### PR DESCRIPTION
Previously, `Numbers.powf(0.0W, 0.0W)` and various other cases of numbers being put to the power of `0.0` would result in the value `NaN` being produced when instead it should result in `1.0` being produced.
https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8766229 (page 63)