### PR TITLE
fix(stdlib): Correct bugs in regex parsing

### DIFF
--- a/compiler/test/stdlib/regex.test.gr
+++ b/compiler/test/stdlib/regex.test.gr
@@ -192,6 +192,16 @@ assert testRegex("\\By\\B", "yz") == Ok(None)
 assert testRegex("\\By\\b", "xy") == Ok(Some(("y", [>])))
 assert testRegex("\\by\\B", "yz") == Ok(Some(("y", [>])))
 assert testRegex("\\By\\B", "xyz") == Ok(Some(("y", [>])))
+assert testRegex("\\bhello\\b", "`hello`") == Ok(Some(("hello", [>])))
+assert testRegex("\\bhello\\b", "{hello}") == Ok(Some(("hello", [>])))
+assert testRegex("\\bhello\\b", "|hello|") == Ok(Some(("hello", [>])))
+assert testRegex("\\bhello\\b", "}hello{") == Ok(Some(("hello", [>])))
+assert testRegex("\\bhello\\b", "~hello~") == Ok(Some(("hello", [>])))
+assert testRegex("\\Bhello\\B", "`hello`") == Ok(None)
+assert testRegex("\\Bhello\\B", "{hello}") == Ok(None)
+assert testRegex("\\Bhello\\B", "|hello|") == Ok(None)
+assert testRegex("\\Bhello\\B", "}hello{") == Ok(None)
+assert testRegex("\\Bhello\\B", "~hello~") == Ok(None)
 // Alternation
 assert testRegex("ab|cd", "abc") == Ok(Some(("ab", [>])))
 assert testRegex("ab|cd", "abcd") == Ok(Some(("ab", [>])))
@@ -667,6 +677,7 @@ assert testRegex("(?s:a.b)", "a\nb") == Ok(Some(("a\nb", [>])))
 assert testRegex("(?m:a.b)", "a\nb") == Ok(None)
 assert testRegex("\\w+", "--ab_cd0123--") == Ok(Some(("ab_cd0123", [>])))
 assert testRegex("[\\w]+", "--ab_cd0123--") == Ok(Some(("ab_cd0123", [>])))
+assert testRegex("[[:word:]]+", "--ab_CD0123--") == Ok(Some(("ab_CD0123", [>])))
 assert testRegex("\\D+", "1234abc5678") == Ok(Some(("abc", [>])))
 assert testRegex("[\\D]+", "1234abc5678") == Ok(Some(("abc", [>])))
 assert testRegex("[\\da-fA-F]+", "123abc") == Ok(Some(("123abc", [>])))
@@ -711,6 +722,7 @@ assert testRegex("^([ab]*?)(?!(b))c", "abc")
   == Ok(Some(("abc", [> Some("ab"), None])))
 assert testRegex("^([ab]*?)(?<!(a))c", "abc")
   == Ok(Some(("abc", [> Some("ab"), None])))
+assert testRegex("\\b\\{\\b", "a{b") == Ok(Some(("{", [>])))
 
 // Delimited versions
 assert testRegex("(-[0-9]*)+", "a-12--345b")
@@ -754,6 +766,26 @@ assert List.map(
   findAll(unwrapResult(make("x.")), "12x4x6")
 )
   == [((2, 4), [>]), ((4, 6), [>])]
+assert List.map(
+  mr => flattenResult(mr),
+  findAll(unwrapResult(make("..")), "abcd")
+)
+  == [("ab", [>]), ("cd", [>])]
+assert List.map(
+  mr => flattenResult(mr),
+  findAll(unwrapResult(make("a*")), "aab")
+)
+  == [("aa", [>]), ("", [>]), ("", [>])]
+assert List.map(
+  mr => flattenResult(mr),
+  findAllRange(unwrapResult(make("$")), "ab", 2, 2)
+)
+  == [("", [>])]
+assert List.map(
+  mr => flattenResultPositions(mr),
+  findAllRange(unwrapResult(make("$")), "ab", 2, 2)
+)
+  == [((2, 2), [>])]
 
 assert replaceAll(unwrapResult(make("b(ar)")), "foo bar bar", "baza$1")
   == "foo bazaar bazaar"

--- a/stdlib/regex.gr
+++ b/stdlib/regex.gr
@@ -741,9 +741,13 @@ and parsePosixCharClass = (buf: RegExBuf) => {
                 Ok(
                   rangeAdd(
                     rangeAddSpan(
-                      rangeAddSpan([], Char.code('a'), Char.code('f')),
-                      Char.code('A'),
-                      Char.code('F')
+                      rangeAddSpan(
+                        rangeAddSpan([], Char.code('a'), Char.code('z')),
+                        Char.code('A'),
+                        Char.code('Z')
+                      ),
+                      Char.code('0'),
+                      Char.code('9')
                     ),
                     Char.code('_')
                   ),

--- a/stdlib/regex.gr
+++ b/stdlib/regex.gr
@@ -2946,7 +2946,6 @@ let makeReferenceMatcher = eq =>
 
 let referenceMatcher = makeReferenceMatcher(((a, b)) => a == b)
 
-
 let referenceMatcherCaseInsensitive = makeReferenceMatcher(
   ((a, b)) => Char.Ascii.toLowercase(a) == Char.Ascii.toLowercase(b)
 )

--- a/stdlib/regex.gr
+++ b/stdlib/regex.gr
@@ -2582,7 +2582,7 @@ let isWordChar = c => {
       true,
     Ok(c) when Char.code('A') <= Char.code(c) && Char.code(c) <= Char.code('Z') =>
       true,
-    Ok(c) when Char.code('_') <= Char.code(c) => true,
+    Ok(c) when Char.code('_') == Char.code(c) => true,
     _ => false,
   }
 }

--- a/stdlib/regex.gr
+++ b/stdlib/regex.gr
@@ -3598,7 +3598,7 @@ let fastDriveRegexIsMatch = (rx, string, startOffset, endOffset) => {
 }
 
 let rec fastDriveRegexMatchAll = (rx, string, startOffset, endOffset) => {
-  if (startOffset >= endOffset) {
+  if (startOffset > endOffset) {
     []
   } else {
     let state = Array.make(rx.reNumGroups, None)
@@ -3628,7 +3628,7 @@ let rec fastDriveRegexMatchAll = (rx, string, startOffset, endOffset) => {
           ...fastDriveRegexMatchAll(
             rx,
             string,
-            startPos + startOffset + 1,
+            (if (endPos > startPos) endPos else startPos + 1) + startOffset,
             endOffset
           )
         ],

--- a/stdlib/regex.gr
+++ b/stdlib/regex.gr
@@ -2946,16 +2946,9 @@ let makeReferenceMatcher = eq =>
 
 let referenceMatcher = makeReferenceMatcher(((a, b)) => a == b)
 
-let asciiCharToLower = c => {
-  if (Char.code('A') <= Char.code(c) && Char.code(c) <= Char.code('Z')) {
-    Char.fromCode(Char.code(c) + (Char.code('a') - Char.code('A')))
-  } else {
-    c
-  }
-}
 
 let referenceMatcherCaseInsensitive = makeReferenceMatcher(
-  ((a, b)) => asciiCharToLower(a) == asciiCharToLower(b)
+  ((a, b)) => Char.Ascii.toLowercase(a) == Char.Ascii.toLowercase(b)
 )
 
 // Lookahead, Lookbehind, Conditionals, and Cut

--- a/stdlib/regex.gr
+++ b/stdlib/regex.gr
@@ -2947,7 +2947,7 @@ let makeReferenceMatcher = eq =>
 let referenceMatcher = makeReferenceMatcher(((a, b)) => a == b)
 
 let asciiCharToLower = c => {
-  if (Char.code('Z') <= Char.code(c) && Char.code(c) <= Char.code('Z')) {
+  if (Char.code('A') <= Char.code(c) && Char.code(c) <= Char.code('Z')) {
     Char.fromCode(Char.code(c) + (Char.code('a') - Char.code('A')))
   } else {
     c


### PR DESCRIPTION
If wanted can also add tests cases for these

Changes:
- fix(stdlib): Change posix word parsing to parse word instead of hex
- fix(stdlib): Make word validation only match A-Z, a-z, _

Previously due to the <=, any character with a code of >= 95 was treated as part of a word's characters. This broke `\b` and `\B` matching for backticks alongside {, |, }, ~. You can confirm this behavior by doing 
```
Regex.isMatch(Result.unwrap(Regex.make("\\bhello\\b")), "`hello`")
``` 
which will return false when they should be true (you can do 
```
console.log(/\bhello\b/.test("`hello`"))
``` 
in node to see intended behavior).
- fix(stdlib): Correct asciiCharToLower range
- fix(stdlib): correct findAll termination and advance

zero-width matches would cause some incorrect results:
ex.
```
let matches = Regex.findAll(Result.unwrap(Regex.make("a*")), "aab")
List.forEach(m => {
  let { group, _ } = m
  print(group(0))
}, matches)
```
would result in:
```
Some("aa")
Some("a")
Some("")
```
when it should be
```
Some("aa")
Some("")
Some("")
```
js version for validation:
```
console.log("aab".match(/a*/g))
// Result: [ 'aa', '', '' ]
```