### PR TITLE
feat(compiler): Correct lexer error in malformed match

### DIFF
--- a/compiler/src/parsing/wrapped_lexer.re
+++ b/compiler/src/parsing/wrapped_lexer.re
@@ -437,3 +437,30 @@ let token = state => {
     triple;
   };
 };
+
+let print_syntax_error =
+  Printf.(
+    Location.(
+      fun
+      | Lex_fast_forward_failed(acc, None) => {
+          let loc =
+            switch (List.rev(acc)) {
+            | [_, (tkn, loc_start, loc_end), ..._] => {
+                loc_start,
+                loc_end,
+                loc_ghost: false,
+              }
+            | [(tkn, loc_start, loc_end), ..._] => {
+                loc_start,
+                loc_end,
+                loc_ghost: false,
+              }
+            | [] => Location.dummy_loc
+            };
+          Some(errorf(~loc, "Syntax error."));
+        }
+      | _ => None
+    )
+  );
+
+let _ = Location.register_error_of_exn(print_syntax_error);

--- a/compiler/test/suites/parsing.re
+++ b/compiler/test/suites/parsing.re
@@ -563,4 +563,7 @@ describe("parsing", ({test, testSkip}) => {
       prog_core_loc: Location.dummy_loc,
     },
   );
+  // Regression for #2369
+  assertCompileError("lexer_hack_match_1", "(match { })", "Syntax error.");
+  assertCompileError("lexer_hack_match_2", "(match (true)", "Syntax error.");
 });


### PR DESCRIPTION
This pr corrects errors in cases like:
```
(match { })

(match (true)
```

The reason that the errors were previously messed up here is that these are handled by the lexer hack, rather than the lexer directly the opening `(` causes the issue specifically.

The errors are not perfectly placed here, I decided to place them on the match statement as we are not in the parser it's hard to have the right amount of context to figure out where exactly to place the error however I still think this behaviour is far more helpful then it was before as at least we are now getting a wrapped error.

We could try to slightly improve the error location, but I was having a lot of trouble getting it perfect with the way the lexer hack currently works.

Closes: #2369