### PR TITLE
feat(compiler): Stub panic with unreachable to prevent bad codegen

### DIFF
--- a/compiler/src/codegen/compcore.re
+++ b/compiler/src/codegen/compcore.re
@@ -143,20 +143,33 @@ let get_metadata_ptr = wasm_mod =>
 let get_grain_imported_name = (mod_, name) => Ident.unique_name(name);
 
 let call_panic_handler = (wasm_mod, env, args) => {
-  let args = [
-    Expression.Global_get.make(
+  switch (env.compilation_mode) {
+  | Runtime =>
+    Expression.Block.make(
       wasm_mod,
-      resolve_global(~env, panic_with_exception_name),
+      gensym_label("runtime_panic_stub"),
+      List.fold_left(
+        (acc, arg) => [Expression.Drop.make(wasm_mod, arg), ...acc],
+        [Expression.Unreachable.make(wasm_mod)],
+        args,
+      ),
+    )
+  | _ =>
+    let args = [
+      Expression.Global_get.make(
+        wasm_mod,
+        resolve_global(~env, panic_with_exception_name),
+        Type.int32,
+      ),
+      ...args,
+    ];
+    Expression.Call.make(
+      wasm_mod,
+      resolve_func(~env, panic_with_exception_name),
+      args,
       Type.int32,
-    ),
-    ...args,
-  ];
-  Expression.Call.make(
-    wasm_mod,
-    resolve_func(~env, panic_with_exception_name),
-    args,
-    Type.int32,
-  );
+    );
+  };
 };
 
 let call_malloc = (wasm_mod, env, args) => {

--- a/compiler/src/codegen/compcore.re
+++ b/compiler/src/codegen/compcore.re
@@ -149,20 +149,24 @@ let get_metadata_ptr = wasm_mod =>
 let get_grain_imported_name = (mod_, name) => Ident.unique_name(name);
 
 let call_panic_handler = (wasm_mod, env, args) => {
-  let args = [
-    Expression.Global_get.make(
+  switch (env.compilation_mode) {
+  | Runtime => Expression.Unreachable.make(wasm_mod)
+  | _ =>
+    let args = [
+      Expression.Global_get.make(
+        wasm_mod,
+        resolve_global(~env, panic_with_exception_name),
+        ref_any(),
+      ),
+      ...args,
+    ];
+    Expression.Call.make(
       wasm_mod,
-      resolve_global(~env, panic_with_exception_name),
+      resolve_func(~env, panic_with_exception_name),
+      args,
       ref_any(),
-    ),
-    ...args,
-  ];
-  Expression.Call.make(
-    wasm_mod,
-    resolve_func(~env, panic_with_exception_name),
-    args,
-    ref_any(),
-  );
+    );
+  };
 };
 
 let call_equal = (wasm_mod, env, args) =>

--- a/compiler/test/suites/runtime.re
+++ b/compiler/test/suites/runtime.re
@@ -5,7 +5,7 @@ describe("runtime", ({test, testSkip}) => {
   let test_or_skip =
     Sys.backend_type == Other("js_of_ocaml") ? testSkip : test;
 
-  let assertRunError = makeErrorRunner(test);
+  let assertRunError = makeErrorRunner(test_or_skip);
   let assertRuntime = makeRuntimeRunner(test_or_skip);
 
   assertRunError(

--- a/compiler/test/suites/runtime.re
+++ b/compiler/test/suites/runtime.re
@@ -5,7 +5,19 @@ describe("runtime", ({test, testSkip}) => {
   let test_or_skip =
     Sys.backend_type == Other("js_of_ocaml") ? testSkip : test;
 
+  let assertRunError = makeErrorRunner(test_or_skip);
   let assertRuntime = makeRuntimeRunner(test_or_skip);
+
+  assertRunError(
+    ~config_fn=() => {Grain_utils.Config.compilation_mode := Runtime},
+    "runtime_mode_panics",
+    {|
+      let arr = [> 1, 2, 3]
+      provide let x = arr[10]
+    |},
+    "RuntimeError: unreachable",
+  );
+
   assertRuntime("numbers.test");
 
   assertRuntime("unsafe/wasmf32.test");

--- a/compiler/test/suites/runtime.re
+++ b/compiler/test/suites/runtime.re
@@ -5,7 +5,19 @@ describe("runtime", ({test, testSkip}) => {
   let test_or_skip =
     Sys.backend_type == Other("js_of_ocaml") ? testSkip : test;
 
+  let assertRunError = makeErrorRunner(test);
   let assertRuntime = makeRuntimeRunner(test_or_skip);
+
+  assertRunError(
+    ~config_fn=() => {Grain_utils.Config.compilation_mode := Runtime},
+    "runtime_mode_panics",
+    {|
+      let arr = [> 1, 2, 3]
+      provide let x = arr[10]
+    |},
+    "RuntimeError: unreachable",
+  );
+
   assertRuntime("numbers.test");
 
   assertRuntime("unsafe/wasmf32.test");


### PR DESCRIPTION
This pr stubs panic with unreachable when we are compiling in `@runtimeMode`.

Because we use `@runtimeMode` itself to compile the panic module, we can't allow a circular dependency, so we don't import panic when compiling in runtime mode.

This had the side effect that if someone tried to use a higher-level expression such as `arr[x]`, we would generate invalid WASM. In order to avoid this, I figure we can just fail with `unreachable` instead of properly panicking. The downside is we don't get a nice error, but I figure that is a perfectly reasonable tradeoff in the context of the runtime. 

Closes: #2379