### PR TITLE
chore(compiler): Cleanup unused `MArityOp` and `MTagOp`

### DIFF
--- a/compiler/src/codegen/compcore.re
+++ b/compiler/src/codegen/compcore.re
@@ -2816,8 +2816,6 @@ and compile_instr = (wasm_mod, env, instr) => {
         value,
       );
     [Expression.Return.make(wasm_mod, value)];
-  | MArityOp(_) => failwith("NYI: (compile_instr): MArityOp")
-  | MTagOp(_) => failwith("NYI: (compile_instr): MTagOp")
   };
 };
 

--- a/compiler/src/codegen/mashtree.re
+++ b/compiler/src/codegen/mashtree.re
@@ -410,23 +410,6 @@ type allocation_type =
     });
 
 [@deriving sexp]
-type tag_op =
-  | MCheckTag
-  | MAssertTag
-  | MAddTag
-  | MRemoveTag;
-
-[@deriving sexp]
-type arity_operand =
-  | MLambdaArity
-  | MTupleArity;
-
-[@deriving sexp]
-type arity_op =
-  | MGetArity
-  | MAssertArity(int32);
-
-[@deriving sexp]
 type tuple_op =
   | MTupleGet(int32)
   | MTupleSet(int32, immediate);
@@ -498,8 +481,6 @@ and instr_desc =
     })
   | MError(grain_error, list(immediate))
   | MAllocate(allocation_type)
-  | MTagOp(tag_op, tag_type, immediate)
-  | MArityOp(arity_operand, arity_op, immediate)
   | MIf(immediate, block, block)
   | MFor(option(block), option(block), block)
   | MContinue


### PR DESCRIPTION
This pr removes the unused `MTagOp` and `MArityOp` nodes from the mashtree.

Closes: #2380

This pr is based on: #2378 