### PR TITLE
feat(compiler): Correct purity analysis of memory primitives

### DIFF
--- a/compiler/src/middle_end/analyze_purity.re
+++ b/compiler/src/middle_end/analyze_purity.re
@@ -40,8 +40,8 @@ module PurityArg: Anf_iterator.IterArgument = {
       switch (desc) {
       | CImmExpr({imm_desc: ImmTrap}) => false
       | CImmExpr(_) => true
-      | CPrim0(HeapStart | HeapTypeMetadata) => true
-      | CPrim0(WasmMemorySize | Unreachable) => false
+      | CPrim0(WasmMemorySize | HeapStart | HeapTypeMetadata) => true
+      | CPrim0(Unreachable) => false
       | CPrim1(
           AllocateTuple | AllocateBytes | AllocateString | AllocateBigInt |
           BuiltinId |
@@ -105,12 +105,11 @@ module PurityArg: Anf_iterator.IterArgument = {
           WasmUnaryI64(_) |
           WasmUnaryF32(_) |
           WasmUnaryF64(_) |
-          WasmMemoryGrow |
           WasmRefArrayLen,
           _,
         ) =>
         true
-      | CPrim1(Assert | Throw, _) => false
+      | CPrim1(Assert | Throw | WasmMemoryGrow, _) => false
       | CPrim2(
           AllocateArray | AllocateWasmArrayAnyRef | NewRational | Is | Eq | And |
           Or |
@@ -132,14 +131,13 @@ module PurityArg: Anf_iterator.IterArgument = {
           WasmStoreI32(_) | WasmStoreI64(_) | WasmStoreF32 | WasmStoreF64 |
           WasmMemoryCopy |
           WasmMemoryFill |
-          WasmMemoryCompare |
           WasmRefArraySet(_) |
           WasmRefArrayCopy(_) |
           WasmRefArrayFill(_),
           _,
         ) =>
         false
-      | CPrimN(AllocateAdt | AllocateRecord, _) => true
+      | CPrimN(WasmMemoryCompare | AllocateAdt | AllocateRecord, _) => true
       | CArraySet(_)
       | CBoxAssign(_)
       | CAssign(_)


### PR DESCRIPTION
This pr corrects the purity analysis of a few of our memory related primitives.

While looking at this I also did an audit for #1170, at the time the issue was opened we were using linear memory which meant that malloc was being called and allocations were impure, this isn't true anymore as we are using wasm gc all allocates can safely be considered pure.

There are some additional changes I plan to make a future pr, for instance:
* `break` & `consider` are impure as they impact control flow of a loop, however this the way we analyze purity of loops doesn't consider this, meaning any loop with a `break` or `continue` is considered impure.
* Function calls are always considered impure however this isn't really the case, we should probably make a look up table of functions and analyze if the function being called is considered pure itself.
  * This gets complicated though as changing a local in a function is impure but when you look at it from the callers perspective its pure similar to the issues with `break` and `continue` on loops.
  
 
Closes: #1170
Work towards: #2029

This pr is based on: #2378