### PR TITLE
fix(lsp): Make exit a notification instead of a request

### DIFF
--- a/compiler/src/language_server/driver.re
+++ b/compiler/src/language_server/driver.re
@@ -38,8 +38,8 @@ let process = msg => {
     Shutdown.process(~id, ~compiled_code, ~documents, params);
     is_shutting_down := true;
     Reading;
-  | Exit(id, _) when is_shutting_down^ => Break
-  | Exit(id, _) => Exit(1)
+  | Exit(_) when is_shutting_down^ => Break
+  | Exit(_) => Exit(1)
   | TextDocumentDidOpen(uri, params) when is_initialized^ =>
     Code_file.DidOpen.process(~uri, ~compiled_code, ~documents, params);
     Reading;

--- a/compiler/src/language_server/exit.re
+++ b/compiler/src/language_server/exit.re
@@ -5,19 +5,3 @@ module RequestParams = {
   [@deriving yojson]
   type t = unit;
 };
-
-// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#exit
-module ResponseResult = {
-  [@deriving yojson]
-  type t = unit;
-};
-
-let process =
-    (
-      ~id: Protocol.message_id,
-      ~compiled_code: Hashtbl.t(Protocol.uri, Lsp_types.code),
-      ~documents: Hashtbl.t(Protocol.uri, string),
-      params: RequestParams.t,
-    ) => {
-  Protocol.response(~id, ResponseResult.to_yojson());
-};

--- a/compiler/src/language_server/exit.rei
+++ b/compiler/src/language_server/exit.rei
@@ -5,18 +5,3 @@ module RequestParams: {
   [@deriving yojson]
   type t;
 };
-
-// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#exit
-module ResponseResult: {
-  [@deriving yojson]
-  type t;
-};
-
-let process:
-  (
-    ~id: Protocol.message_id,
-    ~compiled_code: Hashtbl.t(Protocol.uri, Lsp_types.code),
-    ~documents: Hashtbl.t(Protocol.uri, string),
-    RequestParams.t
-  ) =>
-  unit;

--- a/compiler/src/language_server/message.re
+++ b/compiler/src/language_server/message.re
@@ -5,7 +5,7 @@ type t =
   | TextDocumentHover(Protocol.message_id, Hover.RequestParams.t)
   | TextDocumentCodeLens(Protocol.message_id, Lenses.RequestParams.t)
   | Shutdown(Protocol.message_id, Shutdown.RequestParams.t)
-  | Exit(Protocol.message_id, Exit.RequestParams.t)
+  | Exit(Exit.RequestParams.t)
   | TextDocumentDidOpen(Protocol.uri, Code_file.DidOpen.RequestParams.t)
   | TextDocumentDidChange(Protocol.uri, Code_file.DidChange.RequestParams.t)
   | TextDocumentInlayHint(Protocol.message_id, Inlayhint.RequestParams.t)
@@ -53,9 +53,9 @@ let of_request = (msg: Protocol.request_message): t => {
     | Ok(params) => Shutdown(id, params)
     | Error(msg) => Error(msg)
     }
-  | {method: "exit", id: Some(id), params: None} =>
+  | {method: "exit", id: None, params: None} =>
     switch (Exit.RequestParams.of_yojson(`Null)) {
-    | Ok(params) => Exit(id, params)
+    | Ok(params) => Exit(params)
     | Error(msg) => Error(msg)
     }
   | {method: "textDocument/didOpen", id, params: Some(params)} =>

--- a/compiler/src/language_server/message.rei
+++ b/compiler/src/language_server/message.rei
@@ -3,7 +3,7 @@ type t =
   | TextDocumentHover(Protocol.message_id, Hover.RequestParams.t)
   | TextDocumentCodeLens(Protocol.message_id, Lenses.RequestParams.t)
   | Shutdown(Protocol.message_id, Shutdown.RequestParams.t)
-  | Exit(Protocol.message_id, Exit.RequestParams.t)
+  | Exit(Exit.RequestParams.t)
   | TextDocumentDidOpen(Protocol.uri, Code_file.DidOpen.RequestParams.t)
   | TextDocumentDidChange(Protocol.uri, Code_file.DidChange.RequestParams.t)
   | TextDocumentInlayHint(Protocol.message_id, Inlayhint.RequestParams.t)

--- a/compiler/test/runner.re
+++ b/compiler/test/runner.re
@@ -727,12 +727,12 @@ let lsp_setup_teardown_requests = (code_uri, code) => {
   let shutdown_request =
     Yojson.Safe.from_string({|{"jsonrpc":"2.0","id":1,"method":"shutdown"}|});
 
-  let exit_request =
-    Yojson.Safe.from_string({|{"jsonrpc":"2.0","id":1,"method":"exit"}|});
+  let exit_notification =
+    Yojson.Safe.from_string({|{"jsonrpc":"2.0","method":"exit"}|});
 
   (
     lsp_request(init_request) ++ lsp_request(open_request),
-    lsp_request(shutdown_request) ++ lsp_request(exit_request),
+    lsp_request(shutdown_request) ++ lsp_request(exit_notification),
   );
 };
 
@@ -756,16 +756,18 @@ let assert_lsp_responses =
   let expected_begin_response =
     expected_init_response ++ expected_open_response;
 
-  let expected_exit_response =
+  let expected_shutdown_response =
     lsp_expected_response(lsp_success_response(`Null));
 
   let expected =
     switch (expected_output) {
-    | None => expected_begin_response ++ expected_exit_response
+    | None => expected_begin_response ++ expected_shutdown_response
     | Some(expected_output) =>
       let expected_response =
         lsp_expected_response(lsp_success_response(expected_output));
-      expected_begin_response ++ expected_response ++ expected_exit_response;
+      expected_begin_response
+      ++ expected_response
+      ++ expected_shutdown_response;
     };
 
   expect.string(result).toEqual(expected);


### PR DESCRIPTION
currently, LSP exit is handled as a request instead of a notification and expects a response and has an ID. just changes it to align with spec: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#exit