### PR TITLE
feat(lsp): Disable code lenses on `records` & `enums`

### DIFF
--- a/compiler/src/language_server/lenses.re
+++ b/compiler/src/language_server/lenses.re
@@ -30,16 +30,27 @@ let get_signature_from_statement = (stmt: Typedtree.toplevel_stmt) =>
   | TTopData([]) => None
   | TTopData(data_declarations) =>
     let decls =
-      List.map(
+      List.filter_map(
         (decl: Typedtree.data_declaration) =>
-          Printtyp.string_of_type_declaration(
-            ~ident=decl.data_id,
-            decl.data_type,
-          ),
+          switch (decl.data_kind) {
+          | TDataVariant(_)
+          | TDataRecord(_) => None
+          | _ =>
+            Some(
+              Printtyp.string_of_type_declaration(
+                ~ident=decl.data_id,
+                decl.data_type,
+              ),
+            )
+          },
         data_declarations,
       );
 
-    Some(String.concat(", ", decls));
+    if (!List.is_empty(decls)) {
+      Some(String.concat(", ", decls));
+    } else {
+      None;
+    };
   | TTopLet(rec_flag, mut_flag, []) => None
   | TTopLet(rec_flag, mut_flag, value_bindings) =>
     let bindings =

--- a/compiler/test/suites/grainlsp.re
+++ b/compiler/test/suites/grainlsp.re
@@ -788,16 +788,6 @@ let b = 2 and c = 3
     ),
     `List([
       `Assoc([
-        ("range", lsp_range((1, 1), (1, 1))),
-        (
-          "command",
-          `Assoc([
-            ("title", `String("record T {\n  x: Number,\n}")),
-            ("command", `String("")),
-          ]),
-        ),
-      ]),
-      `Assoc([
         ("range", lsp_range((2, 1), (2, 1))),
         (
           "command",


### PR DESCRIPTION
This pr disables code lenses on record and enum elements. While this might at first glance seem like a regression the reasoing behind it is that the content of the record or enum is right there anyways so the codelens isn't really providing any additional context like it is for `let` statements.

In vscode the additional codelens wasn't really a problem because new lines are not emitted and the output is truncated however in other editors like zed you end up with a massive block of text like is shown below.

<img width="3164" height="1882" alt="image" src="https://github.com/user-attachments/assets/8cc4dfa8-be48-4cd2-9447-8ceb510a59df" />
