### PR TITLE
feat(lsp): Add `textDocument/didClose` to lsp

### DIFF
--- a/compiler/src/language_server/code_file.re
+++ b/compiler/src/language_server/code_file.re
@@ -332,3 +332,26 @@ module DidChange = {
     };
   };
 };
+
+module DidClose = {
+  // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#didCloseTextDocumentParams
+  module RequestParams = {
+    [@deriving yojson({strict: false})]
+    type t = {
+      [@key "textDocument"]
+      text_document: Protocol.text_document_identifier,
+    };
+  };
+
+  let process =
+      (
+        ~uri: Protocol.uri,
+        ~compiled_code: Hashtbl.t(Protocol.uri, code),
+        ~documents: Hashtbl.t(Protocol.uri, string),
+        _params: RequestParams.t,
+      ) => {
+    Hashtbl.remove(documents, uri);
+    Hashtbl.remove(compiled_code, uri);
+    clear_diagnostics(~uri, ());
+  };
+};

--- a/compiler/src/language_server/code_file.rei
+++ b/compiler/src/language_server/code_file.rei
@@ -43,3 +43,23 @@ module DidChange: {
     ) =>
     unit;
 };
+
+module DidClose: {
+  // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#didCloseTextDocumentParams
+  module RequestParams: {
+    [@deriving yojson({strict: false})]
+    type t = {
+      // Not abstract so it can pluck the URI
+      text_document: Protocol.text_document_identifier,
+    };
+  };
+
+  let process:
+    (
+      ~uri: Protocol.uri,
+      ~compiled_code: Hashtbl.t(Protocol.uri, Lsp_types.code),
+      ~documents: Hashtbl.t(Protocol.uri, string),
+      RequestParams.t
+    ) =>
+    unit;
+};

--- a/compiler/src/language_server/driver.re
+++ b/compiler/src/language_server/driver.re
@@ -46,6 +46,9 @@ let process = msg => {
   | TextDocumentDidChange(uri, params) when is_initialized^ =>
     Code_file.DidChange.process(~uri, ~compiled_code, ~documents, params);
     Reading;
+  | TextDocumentDidClose(uri, params) when is_initialized^ =>
+    Code_file.DidClose.process(~uri, ~compiled_code, ~documents, params);
+    Reading;
   | Formatting(id, params) when is_initialized^ =>
     Formatting.process(~id, ~compiled_code, ~documents, params);
     Reading;

--- a/compiler/src/language_server/message.re
+++ b/compiler/src/language_server/message.re
@@ -8,6 +8,7 @@ type t =
   | Exit(Exit.RequestParams.t)
   | TextDocumentDidOpen(Protocol.uri, Code_file.DidOpen.RequestParams.t)
   | TextDocumentDidChange(Protocol.uri, Code_file.DidChange.RequestParams.t)
+  | TextDocumentDidClose(Protocol.uri, Code_file.DidClose.RequestParams.t)
   | TextDocumentInlayHint(Protocol.message_id, Inlayhint.RequestParams.t)
   | TextDocumentSymbol(Protocol.message_id, Symbol.RequestParams.t)
   | Formatting(Protocol.message_id, Formatting.RequestParams.t)
@@ -66,6 +67,11 @@ let of_request = (msg: Protocol.request_message): t => {
   | {method: "textDocument/didChange", id, params: Some(params)} =>
     switch (Code_file.DidChange.RequestParams.of_yojson(params)) {
     | Ok(params) => TextDocumentDidChange(params.text_document.uri, params)
+    | Error(msg) => Error(msg)
+    }
+  | {method: "textDocument/didClose", id, params: Some(params)} =>
+    switch (Code_file.DidClose.RequestParams.of_yojson(params)) {
+    | Ok(params) => TextDocumentDidClose(params.text_document.uri, params)
     | Error(msg) => Error(msg)
     }
   | {method: "textDocument/formatting", id: Some(id), params: Some(params)} =>

--- a/compiler/src/language_server/message.rei
+++ b/compiler/src/language_server/message.rei
@@ -6,6 +6,7 @@ type t =
   | Exit(Exit.RequestParams.t)
   | TextDocumentDidOpen(Protocol.uri, Code_file.DidOpen.RequestParams.t)
   | TextDocumentDidChange(Protocol.uri, Code_file.DidChange.RequestParams.t)
+  | TextDocumentDidClose(Protocol.uri, Code_file.DidClose.RequestParams.t)
   | TextDocumentInlayHint(Protocol.message_id, Inlayhint.RequestParams.t)
   | TextDocumentSymbol(Protocol.message_id, Symbol.RequestParams.t)
   | Formatting(Protocol.message_id, Formatting.RequestParams.t)

--- a/compiler/test/runner.re
+++ b/compiler/test/runner.re
@@ -746,7 +746,13 @@ let lsp_setup_teardown_requests =
 };
 
 let assert_lsp_responses =
-    (expect, expected_open_diagnostics, ~expected_output=?, result) => {
+    (
+      expect,
+      expected_open_diagnostics,
+      ~expected_output=?,
+      ~expected_notification=?,
+      result,
+    ) => {
   let expected_init_response =
     lsp_expected_response(
       lsp_success_response(
@@ -765,21 +771,27 @@ let assert_lsp_responses =
   let expected_begin_response =
     expected_init_response ++ expected_open_response;
 
+  let expected_middle_response =
+    switch (expected_output, expected_notification) {
+    | (None, None) => ""
+    | (Some(expected_output), None) =>
+      lsp_expected_response(lsp_success_response(expected_output))
+    | (None, Some(expected_notification)) =>
+      lsp_expected_response(expected_notification)
+    | (Some(_), Some(_)) =>
+      failwith(
+        "assert_lsp_responses: expected_output and expected_notification are mutually exclusive",
+      )
+    };
+
   let expected_shutdown_response =
     lsp_expected_response(lsp_success_response(`Null));
 
-  let expected =
-    switch (expected_output) {
-    | None => expected_begin_response ++ expected_shutdown_response
-    | Some(expected_output) =>
-      let expected_response =
-        lsp_expected_response(lsp_success_response(expected_output));
-      expected_begin_response
-      ++ expected_response
-      ++ expected_shutdown_response;
-    };
-
-  expect.string(result).toEqual(expected);
+  expect.string(result).toEqual(
+    expected_begin_response
+    ++ expected_middle_response
+    ++ expected_shutdown_response,
+  );
 };
 
 let makeLspRunner =
@@ -828,6 +840,44 @@ let makeLspDiagnosticsRunner =
       assert_lsp_responses(expect, expected_diagnostics, result);
 
       expect.int(code).toBe(0);
+    },
+  );
+};
+
+let makeLspDidCloseRunner =
+    (test, name, code_uri, code, expected_open_diagnostics) => {
+  test(
+    name,
+    ({expect}) => {
+      let (setup_request, teardown_request) =
+        lsp_setup_teardown_requests(code_uri, code);
+
+      let close_request =
+        lsp_input(
+          "textDocument/didClose",
+          `Assoc([
+            ("textDocument", `Assoc([("uri", `String(code_uri))])),
+          ]),
+        );
+
+      let (result, exit_code) =
+        lsp(setup_request ++ lsp_request(close_request) ++ teardown_request);
+
+      assert_lsp_responses(
+        expect,
+        expected_open_diagnostics,
+        ~expected_notification=
+          lsp_notification(
+            "textDocument/publishDiagnostics",
+            `Assoc([
+              ("uri", `String(code_uri)),
+              ("diagnostics", `List([])),
+            ]),
+          ),
+        result,
+      );
+
+      expect.int(exit_code).toBe(0);
     },
   );
 };

--- a/compiler/test/suites/grainlsp.re
+++ b/compiler/test/suites/grainlsp.re
@@ -92,6 +92,7 @@ describe("grainlsp", ({test, testSkip}) => {
 
   let assertLspOutput = makeLspRunner(test_or_skip);
   let assertLspDiagnostics = makeLspDiagnosticsRunner(test_or_skip);
+  let assertLspDidClose = makeLspDidCloseRunner(test_or_skip);
 
   assertLspOutput(
     "goto_definition1",
@@ -832,6 +833,34 @@ let b = 2 and c = 3
 
   assertLspDiagnostics(
     "compile_error1",
+    "file:///a.gr",
+    {|module A
+let a = 123
+let b = "a" + a
+|},
+    `Assoc([
+      ("uri", `String("file:///a.gr")),
+      (
+        "diagnostics",
+        `List([
+          `Assoc([
+            ("range", lsp_range((2, 8), (2, 11))),
+            ("severity", `Int(1)),
+            (
+              "message",
+              `String(
+                "This expression has type String but an expression was expected of type\n         Number",
+              ),
+            ),
+            ("relatedInformation", `List([])),
+          ]),
+        ]),
+      ),
+    ]),
+  );
+
+  assertLspDidClose(
+    "did_close_clears_diagnostics",
     "file:///a.gr",
     {|module A
 let a = 123


### PR DESCRIPTION
Added `textDocument/didClose` functionality to the LSP. ~While not a huge problem on small codebases, if you are working on a large codebase with a lot of files, it can cause the LSP to eat up a lot more memory by still keeping the typedTree and sourceTree~

Edit: the ocaml runtime seems to not free the heap to the OS immediately so even if its removed memory will stay the same. Can be fixed with `Gc.compact()` (see: https://ocaml.org/manual/5.5/api/Gc.html#VALcompact) but its (probably) not worth it