### PR TITLE
chore(lsp): Remove manual line breaks from hover

### DIFF
--- a/compiler/src/language_server/hover.re
+++ b/compiler/src/language_server/hover.re
@@ -50,7 +50,7 @@ let markdown_join = (a, b) => {
   // Horizonal rules between code blocks render a little funky
   // so we manually add linebreaks
   Printf.sprintf(
-    "%s\n---\n<br><br>\n%s",
+    "%s\n---\n\n%s",
     a,
     b,
   );

--- a/compiler/test/suites/grainlsp.re
+++ b/compiler/test/suites/grainlsp.re
@@ -602,7 +602,7 @@ let a = { x: 1 }
           (
             "value",
             `String(
-              "```grain\nrecord T {\n  x: Number,\n}\n```\n\n\n---\n<br><br>\n```grain-type\nT\n```\n\n",
+              "```grain\nrecord T {\n  x: Number,\n}\n```\n\n\n---\n\n```grain-type\nT\n```\n\n",
             ),
           ),
         ]),
@@ -762,7 +762,7 @@ from "./provideAll.gr" include ProvideAll
           (
             "value",
             `String(
-              "```grain\nmodule ProvideAll\n```\n\n\n---\n<br><br>\n```grain\nlet x: Number\nlet y: (x: a) => a\nlet z: String\n```\n\n",
+              "```grain\nmodule ProvideAll\n```\n\n\n---\n\n```grain\nlet x: Number\nlet y: (x: a) => a\nlet z: String\n```\n\n",
             ),
           ),
         ]),


### PR DESCRIPTION
Currently, only VS Code (and maybe other editors I haven't tested with) support using HTML in their markdown for hovering. The `<br><br>` is currently redundant so removing it help other clients look the same

Previously:
| VS Code | Zed | Neovim |
| :---: | :---: | :---: |
| <img width="990" height="541" alt="image" src="https://github.com/user-attachments/assets/a709a4b0-b832-4319-9122-a12a04bbb0fa" /> | <img width="814" height="440" alt="image" src="https://github.com/user-attachments/assets/fc4dfa02-c7ef-46da-9a99-9336e1e77c59" /> | <img width="913" height="362" alt="image" src="https://github.com/user-attachments/assets/c6acbfe4-9e66-44b0-9009-cbd48cab4a19" /> | 

Now:
| VS Code (no change) | Zed | Neovim |
| :---: | :---: | :---: |
| <img width="954" height="528" alt="image" src="https://github.com/user-attachments/assets/901de8bd-51ec-41a6-8e48-7e54149c0f0c" /> | <img width="801" height="420" alt="image" src="https://github.com/user-attachments/assets/555da99b-feee-46fb-99ef-915e4bd08ef9" /> | <img width="886" height="352" alt="image" src="https://github.com/user-attachments/assets/02d953ba-a9a8-4c7e-ba7b-59609ad2686f" /> |